### PR TITLE
improve error responses

### DIFF
--- a/src/main/java/uk/gov/legislation/data/marklogic/Legislation.java
+++ b/src/main/java/uk/gov/legislation/data/marklogic/Legislation.java
@@ -100,7 +100,7 @@ public class Legislation {
             return xml;
         }
         if (error.statusCode >= 400)
-            throw new NoDocumentException(error.toString());
+            throw new NoDocumentException(error);
         if (!error.header.name.equals("Location"))
             throw new IOException(xml);
         throw new RedirectException(error.header.value);

--- a/src/main/java/uk/gov/legislation/data/marklogic/NoDocumentException.java
+++ b/src/main/java/uk/gov/legislation/data/marklogic/NoDocumentException.java
@@ -1,8 +1,13 @@
 package uk.gov.legislation.data.marklogic;
 
 public class NoDocumentException extends RuntimeException {
+
     public NoDocumentException(String message) {
         super(message);
+    }
+
+    NoDocumentException(Error error) {
+        this(error.message);
     }
 
 }

--- a/src/main/java/uk/gov/legislation/exceptions/ErrorResponse.java
+++ b/src/main/java/uk/gov/legislation/exceptions/ErrorResponse.java
@@ -2,7 +2,7 @@ package uk.gov.legislation.exceptions;
 
 import lombok.Getter;
 
-import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
 @Getter
@@ -15,7 +15,7 @@ public class ErrorResponse {
     public ErrorResponse(String status, String message) {
         this.status = status;
         this.message = message;
-        this.timestamp = LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME);
+        this.timestamp = ZonedDateTime.now().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
     }
 
 }

--- a/src/main/java/uk/gov/legislation/exceptions/ErrorResponse.java
+++ b/src/main/java/uk/gov/legislation/exceptions/ErrorResponse.java
@@ -1,6 +1,7 @@
 package uk.gov.legislation.exceptions;
 
 import lombok.Getter;
+import org.springframework.http.HttpStatusCode;
 
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -8,14 +9,20 @@ import java.time.format.DateTimeFormatter;
 @Getter
 public class ErrorResponse {
 
-    private final String status;
+    private final int status;
+    private final String error;
     private final String message;
     private final String timestamp;
 
-    public ErrorResponse(String status, String message) {
+    public ErrorResponse(int status, String error, String message) {
         this.status = status;
+        this.error = error;
         this.message = message;
         this.timestamp = ZonedDateTime.now().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+    }
+
+    ErrorResponse(HttpStatusCode status, String error, String message) {
+        this(status.value(), error, message);
     }
 
 }

--- a/src/main/java/uk/gov/legislation/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/legislation/exceptions/GlobalExceptionHandler.java
@@ -14,8 +14,9 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(NoDocumentException.class)
     public ResponseEntity <ErrorResponse> handleNoDocumentException(NoDocumentException ex) {
         ErrorResponse errorResponse = new ErrorResponse(
-                "Not Found",
-                "Document not found: " + ex.getMessage()
+                HttpStatus.NOT_FOUND,
+                "Document Not Found",
+                ex.getMessage()
         );
         return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
     }
@@ -23,8 +24,9 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(TransformationException.class)
     public ResponseEntity<ErrorResponse> handleAknTransformationException(TransformationException ex) {
         ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.INTERNAL_SERVER_ERROR,
                 "Transformation Error",
-                "Transformation failed: " + ex.getMessage()
+                ex.getMessage()
         );
         return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
     }
@@ -32,8 +34,9 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(XSLTCompilationException.class)
     public ResponseEntity<ErrorResponse> handleXSLTCompilationException(XSLTCompilationException ex) {
         ErrorResponse errorResponse = new ErrorResponse(
-                "Error compiling XSLT",
-                "XSLTCompilationException failed: " + ex.getMessage()
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                "XSLT Compilation Error",
+                ex.getMessage()
         );
         return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
     }
@@ -41,17 +44,20 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(InvalidURISyntaxException.class)
     public ResponseEntity<ErrorResponse> handleInvalidURISyntaxException(InvalidURISyntaxException ex) {
         ErrorResponse errorResponse = new ErrorResponse(
-                "InvalidURISyntax_Error",
-                "InvalidURISyntax: " + ex.getMessage()
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                "Invalid URI Syntax Error",
+                ex.getMessage()
         );
         return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
+    // thrown when MarkLogic returns an error response
     @ExceptionHandler(MarkLogicRequestException.class)
     public ResponseEntity<ErrorResponse> handleMarkLogicRequestException(MarkLogicRequestException ex) {
         ErrorResponse errorResponse = new ErrorResponse(
-                "MarkLogic Request Error",
-                "MarkLogic Error: " + ex.getMessage()
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                "MarkLogic Error",
+                ex.getMessage()
         );
         return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
     }
@@ -59,8 +65,9 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(IOException.class)
     public ResponseEntity<ErrorResponse> handleIOException(IOException ex) {
         ErrorResponse errorResponse = new ErrorResponse(
-                "IOException_Error",
-                "An IO error occurred: " + ex.getMessage()
+                HttpStatus.SERVICE_UNAVAILABLE,
+                "IO Error",
+                ex.getMessage()
         );
         return new ResponseEntity<>(errorResponse, HttpStatus.SERVICE_UNAVAILABLE);
     }
@@ -69,17 +76,20 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleInterruptedException(InterruptedException ex) {
         Thread.currentThread().interrupt();
         ErrorResponse errorResponse = new ErrorResponse(
-                "InterruptedException_Error",
-                "The request was interrupted: " + ex.getMessage()
+                HttpStatus.SERVICE_UNAVAILABLE,
+                "Network Interruption Error",
+                ex.getMessage()
         );
         return new ResponseEntity<>(errorResponse, HttpStatus.SERVICE_UNAVAILABLE);
     }
 
+    // a wrapper around an IOException or an InterruptedException thrown during a request to MarkLogic
     @ExceptionHandler(DocumentFetchException.class)
     public ResponseEntity<Object> handleDocumentFetchException(DocumentFetchException ex) {
         ErrorResponse errorResponse = new ErrorResponse(
-                "Document fetch failed",
-                "Document fetch failed: " + ex.getMessage()
+                HttpStatus.SERVICE_UNAVAILABLE,
+                "Document Fetch Error",
+                ex.getMessage()
         );
         return new ResponseEntity<>(errorResponse, HttpStatus.SERVICE_UNAVAILABLE);
     }


### PR DESCRIPTION
I've made a few small changes here: I've added a time zone to the timestamp, and I use the _message_ field of the MarkLogic error responses. And finally, I've added the status code to the response.