### PR TITLE
Custom headers for redirect info

### DIFF
--- a/src/main/java/uk/gov/legislation/data/marklogic/Legislation.java
+++ b/src/main/java/uk/gov/legislation/data/marklogic/Legislation.java
@@ -1,13 +1,16 @@
 package uk.gov.legislation.data.marklogic;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import uk.gov.legislation.exceptions.DocumentFetchException;
+import uk.gov.legislation.exceptions.MarkLogicRequestException;
 import uk.gov.legislation.util.Links;
+
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
-import java.util.function.Function;
 
 @Service
 public class Legislation {
@@ -20,79 +23,78 @@ public class Legislation {
         this.db = db;
     }
 
-    public String getDocument(String type, String year, int number, Optional<String> version) {
-        return handleRequest(
-                buildQuery(type, year, number, version, Optional.empty(), Optional.empty()),
-                comp -> getDocument(comp.type(), comp.year(), comp.number(), comp.version())
-        );
+    public Response getDocument(String type, String year, int number, Optional<String> version) {
+        Parameters params = new Parameters(type, year, number).version(version);
+        return getAndFollowRedirect(params);
     }
 
     /** Get table of contents
      */
 
-    public String getTableOfContents(String type, String year, int number, Optional<String> version) {
-        return handleRequest(
-                buildQuery(type, year, number, version, Optional.of("contents"), Optional.empty()),
-                comp -> getTableOfContents(comp.type(), comp.year(), comp.number(), comp.version())
-        );
+    private static final Optional<String> CONTENTS_VIEW = Optional.of("contents");
+
+    public Response getTableOfContents(String type, String year, int number, Optional<String> version) {
+        Parameters params = new Parameters(type, year, number).version(version).view(CONTENTS_VIEW);
+        return getAndFollowRedirect(params);
     }
 
     /** Get document section
      */
-    public String getDocumentSection(String type, String year, int number, String section, Optional<String> version) {
-        return handleRequest(
-                buildQuery(type, year, number, version, Optional.empty(), Optional.of(section)),
-                comp -> {
-                    if (comp.fragment().isEmpty()) {
-                        throw new IllegalStateException("Invalid redirect without fragment.");
-                    }
-                    return getDocumentSection(comp.type(), comp.year(), comp.number(), comp.fragment().get(), comp.version());
-                }
-        );
+    public Response getDocumentSection(String type, String year, int number, String section, Optional<String> version) {
+        Parameters params = new Parameters(type, year, number).version(version).section(Optional.of(section));
+        return getAndFollowRedirect(params);
     }
 
-    /** Helper method for handling requests
-     */
+    /* helper methods */
 
-    private String handleRequest(String query, Function<Links.Components, String> redirectHandler) {
+    public record Redirect(String type, String year, int number, Optional<String> version) {
+
+        static Redirect make(Parameters params) {
+            return new Redirect(params.type(), params.year(), params.number(), params.version());
+        }
+
+        static Optional<Redirect> make(boolean afterRedirect, Parameters params) {
+            if (afterRedirect)
+                return Optional.of(make(params));
+            return Optional.empty();
+        }
+
+    }
+
+    public record Response(String clml, Optional<Redirect> redirect) { }
+
+    private Response getAndFollowRedirect(Parameters params) {
+        return getAndFollowRedirect(params, false);
+    }
+    private Response getAndFollowRedirect(Parameters params, boolean afterRedirect) {
         try {
-            return get(query);
+            String clml = get(params);
+            Optional<Redirect> redirect = Redirect.make(afterRedirect, params);
+            return new Response(clml, redirect);
+        } catch (RedirectException e) {
+            Links.Components comp = Links.parse(e.getLocation());
+            if (comp == null)
+                throw new IllegalStateException("Invalid redirect location: " + e.getLocation(), e);
+            params = new Parameters(comp.type(), comp.year(), comp.number())
+                .version(comp.version())
+                .view(params.view)
+                .section(params.section); // FixMe I believe this should be comp.fragment() ?
+            return getAndFollowRedirect(params, true);
+        }
+    }
+
+    private final Logger logger = LoggerFactory.getLogger(Legislation.class);
+
+    private String get(Parameters params) throws NoDocumentException, RedirectException {
+        String xml;
+        try {
+            xml = db.get(ENDPOINT, params.buildQuery());
         } catch (IOException e) {
             throw new DocumentFetchException("Failed to fetch document due to I/O", e);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new DocumentFetchException("Failed to fetch document due to interruption", e);
-        } catch (RedirectException redirect) {
-            Links.Components components = Links.parse(redirect.getLocation());
-            if (components == null) {
-                throw new IllegalStateException("Invalid redirect location: " + redirect.getLocation(), redirect);
-            }
-            return redirectHandler.apply(components);
         }
-    }
-
-    /** Build the query string for requests
-    */
-
-     private String buildQuery(String type, String year, int number, Optional<String> version, Optional<String> view, Optional<String> section) {
-        StringBuilder query = new StringBuilder();
-        query.append("?type=").append(encode(type))
-                .append("&year=").append(encode(year))
-                .append("&number=").append(number);
-
-        version.ifPresent(v -> query.append("&version=").append(encode(v)));
-        view.ifPresent(v -> query.append("&view=").append(encode(v)));
-        section.ifPresent(s -> query.append("&section=").append(encode(s)));
-
-        return query.toString();
-    }
-
-    /** Fetch document and handle redirection
-     * @param query the query string compoent of the MarkLogic request URL
-     */
-    private String get(String query)
-            throws IOException, InterruptedException, NoDocumentException, RedirectException {
-        String xml = db.get(ENDPOINT, query);
         Error error;
         try {
             error = Error.parse(xml);
@@ -102,16 +104,78 @@ public class Legislation {
         if (error.statusCode >= 400)
             throw new NoDocumentException(error);
         if (!error.header.name.equals("Location"))
-            throw new IOException(xml);
+            throw new MarkLogicRequestException("Error parsing MarkLogic error response");
+        logger.debug("MarkLogic redirecting to {}", error.header.value);
         throw new RedirectException(error.header.value);
     }
 
-    /** URL encoding
-     * @param value a query parameter
-     * @return the URL-encoded parameter
-     */
-    private String encode(String value) {
-        return URLEncoder.encode(value, StandardCharsets.US_ASCII);
+    /* parameters */
+
+    static class Parameters {
+
+        private final String type;
+
+        private final String year;
+
+        private final int number;
+
+        private Optional<String> version;
+
+        private Optional<String> view;
+
+        private Optional<String> section;
+
+        Parameters(String type, String year, int number) {
+            if (type == null)
+                throw new IllegalArgumentException();
+            if (year == null)
+                throw new IllegalArgumentException();
+            this.type = type;
+            this.year = year;
+            this.number = number;
+            this.version = Optional.empty();
+            this.view = Optional.empty();
+            this.section = Optional.empty();
+        }
+
+        String type() { return type; }
+
+        String year() { return year; }
+
+        int number() { return number; }
+
+        Optional<String> version() { return version; }
+
+        Parameters version(Optional<String> version) {
+            this.version = version;
+            return this;
+        }
+
+        Parameters view(Optional<String> view) {
+            this.view = view;
+            return this;
+        }
+
+        Parameters section(Optional<String> section) {
+            this.section = section;
+            return this;
+        }
+
+        String buildQuery() {
+            StringBuilder query = new StringBuilder();
+            query.append("?type=").append(encode(type))
+                .append("&year=").append(encode(year))
+                .append("&number=").append(number);
+            version.ifPresent(v -> query.append("&version=").append(encode(v)));
+            view.ifPresent(v -> query.append("&view=").append(encode(v)));
+            section.ifPresent(s -> query.append("&section=").append(encode(s)));
+            return query.toString();
+        }
+
+        static String encode(String value) {
+            return URLEncoder.encode(value, StandardCharsets.US_ASCII);
+        }
+
     }
 
 }

--- a/src/main/java/uk/gov/legislation/endpoints/CustomHeaders.java
+++ b/src/main/java/uk/gov/legislation/endpoints/CustomHeaders.java
@@ -1,0 +1,22 @@
+package uk.gov.legislation.endpoints;
+
+import org.springframework.http.HttpHeaders;
+import uk.gov.legislation.data.marklogic.Legislation;
+
+public class CustomHeaders {
+
+    static final String TYPE_HEADER = "X-Document-Type";
+    static final String YEAR_HEADER = "X-Document-Year";
+    static final String NUMBER_HEADER = "X-Document-Number";
+    static final String VERSION_HEADER = "X-Document-Version";
+
+    public static HttpHeaders makeHeaders(Legislation.Redirect redirect) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(TYPE_HEADER, redirect.type());
+        headers.set(YEAR_HEADER, redirect.year());
+        headers.set(NUMBER_HEADER, Integer.toString(redirect.number()));
+        headers.set(VERSION_HEADER, redirect.version().orElse("current"));
+        return headers;
+    }
+
+}

--- a/src/main/java/uk/gov/legislation/endpoints/contents/controller/ContentsApiController.java
+++ b/src/main/java/uk/gov/legislation/endpoints/contents/controller/ContentsApiController.java
@@ -1,15 +1,13 @@
 package uk.gov.legislation.endpoints.contents.controller;
 
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
-import uk.gov.legislation.data.marklogic.NoDocumentException;
 import uk.gov.legislation.endpoints.document.TableOfContents;
 import uk.gov.legislation.endpoints.contents.api.ContentsApi;
 import uk.gov.legislation.endpoints.contents.service.ContentsService;
 
-import uk.gov.legislation.util.Constants;
 import java.util.Optional;
+import java.util.function.Function;
 
 
 /**
@@ -52,12 +50,7 @@ public class ContentsApiController implements ContentsApi {
         return getDocumentContentsClml(type, regnalYear, number, version);
     }
     private ResponseEntity<String> getDocumentContentsClml(String type, String year, int number, Optional<String> version) {
-        return
-                Optional.ofNullable(contentsService.fetchContentsXml(type, year, number, version))
-                        .map(xmlContent -> ResponseEntity.ok().contentType(MediaType.APPLICATION_XML).body(xmlContent))
-                        .orElseThrow(() ->
-                                new NoDocumentException(String.format(Constants.DOCUMENT_NOT_FOUND.getError(), type, year, number))
-                        );
+        return contentsService.fetchAndTransform(type, year, number, version, Function.identity());
     }
 
     /**
@@ -74,13 +67,7 @@ public class ContentsApiController implements ContentsApi {
         return getDocumentContentsAkn(type, regnalYear, number, version);
     }
     private ResponseEntity<String> getDocumentContentsAkn(String type, String year, int number, Optional<String> version) {
-        return
-                Optional.ofNullable(contentsService.fetchContentsXml(type, year, number, version))
-                        .map(contentsService::transformToAkn)
-                        .map(aknXml -> ResponseEntity.ok().contentType(MediaType.valueOf("application/akn+xml")).body(aknXml))
-                        .orElseThrow(() ->
-                                new NoDocumentException(String.format(Constants.DOCUMENT_NOT_FOUND.getError(), type, year, number))
-                        );
+        return contentsService.fetchAndTransform(type, year, number, version, contentsService::transformToAkn);
     }
 
     /**
@@ -97,13 +84,7 @@ public class ContentsApiController implements ContentsApi {
         return getDocumentContentsJson(type, regnalYear, number, version);
     }
     private ResponseEntity<TableOfContents> getDocumentContentsJson(String type, String year, int number, Optional<String> version) {
-        return
-                Optional.ofNullable(contentsService.fetchContentsXml(type, year, number, version))
-                        .map(contentsService::simplifyToTableOfContents)
-                        .map(jsonContent -> ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(jsonContent))
-                        .orElseThrow(() ->
-                                new NoDocumentException(String.format(Constants.DOCUMENT_NOT_FOUND.getError(), type, year, number))
-                        );
+        return contentsService.fetchAndTransform(type, year, number, version, contentsService::simplifyToTableOfContents);
     }
 
 }

--- a/src/main/java/uk/gov/legislation/endpoints/document/controller/DocumentApiController.java
+++ b/src/main/java/uk/gov/legislation/endpoints/document/controller/DocumentApiController.java
@@ -29,26 +29,24 @@ public class DocumentApiController implements DocumentApi {
      */
     @Override
     public ResponseEntity<String> getDocumentClml(String type, int year, int number, Optional<String> version) {
-        return documentService.handleTransformation(
+        return documentService.fetchAndTransform(
                 clml -> clml,
                 type,
                 Integer.toString(year),
                 number,
-                version,
-                Constants.DOCUMENT_NOT_FOUND.getError()
+                version
         );
     }
 
     @Override
     public ResponseEntity<String> getDocumentClml(String type, String monarch, String years, int number, Optional<String> version) {
         String regnalYear = String.join("/", monarch, years);
-        return documentService.handleTransformation(
+        return documentService.fetchAndTransform(
                 clml -> clml,
                 type,
                 regnalYear,
                 number,
-                version,
-                Constants.DOCUMENT_NOT_FOUND.getError()
+                version
         );
     }
 
@@ -64,7 +62,7 @@ public class DocumentApiController implements DocumentApi {
     }
 
     private ResponseEntity<String> getDocumentAkn(String type, String year, int number, Optional<String> version) {
-        return documentService.handleTransformation(
+        return documentService.fetchAndTransform(
                 clml -> {
                     try {
                         return documentService.transformToAkn(clml);
@@ -75,8 +73,7 @@ public class DocumentApiController implements DocumentApi {
                 type,
                 year,
                 number,
-                version,
-                Constants.DOCUMENT_NOT_FOUND.getError()
+                version
         );
     }
 
@@ -92,10 +89,10 @@ public class DocumentApiController implements DocumentApi {
     }
 
     private ResponseEntity<String> getDocumentHtml(String type, String year, int number, Optional<String> version) {
-        return documentService.handleTransformation(
+        return documentService.fetchAndTransform(
                 clml -> {
                     try {
-                        return documentService.transformToHtml(clml, true);
+                        return documentService.transformToHtml(clml);
                     } catch (SaxonApiException e) {
                         throw new TransformationException(Constants.TRANSFORMATION_FAIL_HTML.getError(), e);
                     }
@@ -103,8 +100,7 @@ public class DocumentApiController implements DocumentApi {
                 type,
                 year,
                 number,
-                version,
-                Constants.DOCUMENT_NOT_FOUND.getError()
+                version
         );
     }
 
@@ -120,7 +116,7 @@ public class DocumentApiController implements DocumentApi {
     }
 
     private ResponseEntity<Response> getDocumentJson(String type, String year, int number, Optional<String> version) {
-        return documentService.handleTransformation(
+        return documentService.fetchAndTransform(
                 clml -> {
                     try {
                         return documentService.transformToJsonResponse(clml);
@@ -131,8 +127,7 @@ public class DocumentApiController implements DocumentApi {
                 type,
                 year,
                 number,
-                version,
-                Constants.DOCUMENT_NOT_FOUND.getError()
+                version
         );
     }
 }

--- a/src/main/java/uk/gov/legislation/endpoints/fragment/service/TransformationService.java
+++ b/src/main/java/uk/gov/legislation/endpoints/fragment/service/TransformationService.java
@@ -1,8 +1,6 @@
 package uk.gov.legislation.endpoints.fragment.service;
 
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import net.sf.saxon.s9api.SaxonApiException;
 import net.sf.saxon.s9api.XdmNode;
 import org.springframework.stereotype.Service;
@@ -51,13 +49,4 @@ public class TransformationService {
         }
     }
 
-    public Object parse(String xml) {
-        try {
-            XmlMapper mapper = new XmlMapper();
-            return mapper.readValue(xml, Object.class);
-        } catch (JsonProcessingException e) {
-            throw new TransformationException("Error parsing XML to object", e);
-        }
-    }
 }
-

--- a/src/main/java/uk/gov/legislation/endpoints/pdf/service/PdfService.java
+++ b/src/main/java/uk/gov/legislation/endpoints/pdf/service/PdfService.java
@@ -26,7 +26,7 @@ public class PdfService {
      * Fetches the URL of a PDF or its thumbnail based on the input parameters.
      */
     public Optional<String> fetchPdfUrl(String type, String yearOrRegnal, int number, String version) throws IOException, SaxonApiException {
-        String clml = legislationService.getTableOfContents(type,yearOrRegnal, number, Optional.ofNullable(version));
+        String clml = legislationService.getTableOfContents(type,yearOrRegnal, number, Optional.ofNullable(version)).clml();
         return simplifier.contents(clml).meta().pdfFormatUri();
     }
 

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,2 +1,3 @@
 logging.level.org.springframework.web=DEBUG
 logging.level.org.springframework.web.filter.CommonsRequestLoggingFilter=DEBUG
+logging.level.uk.gov.legislation=DEBUG


### PR DESCRIPTION
This change adds four new custom HTTP headers to the responses from the` /document`, `/contents` and `/fragment` endpoints, when MarkLogic has responded with a redirect.

Now the Legislation class, instead of returning a String containing CLML, returns a Response object that holds both the CLML and a new, optional Redirect object. If present, the Redirect object contains information about the `type`, `year`, `number` and `version` of the document that was ultimately retrieved from MarkLogic.

When the Redirect object is present, the services will add custom headers to the HTTP responses. The custom headers are called
- X-Document-Type
- X-Document-Year
- X-Document-Number
- X-Document-Version