### PR TITLE
Fix up-to-date tests

### DIFF
--- a/src/main/java/uk/gov/legislation/util/UpToDate.java
+++ b/src/main/java/uk/gov/legislation/util/UpToDate.java
@@ -10,7 +10,10 @@ public class UpToDate {
 
     public static void setUpToDate(DocumentMetadata meta) {
         LocalDate today = LocalDate.now();
-        meta.unappliedEffects.forEach(e -> markEffect(e, today));
+        setUpToDate(meta, today);
+    }
+    public static void setUpToDate(DocumentMetadata meta, LocalDate cutoff) {
+        meta.unappliedEffects.forEach(e -> markEffect(e, cutoff));
         meta.upToDate = meta.unappliedEffects.stream().noneMatch(effect -> effect.outstanding);
     }
 
@@ -18,7 +21,7 @@ public class UpToDate {
         LocalDate today = LocalDate.now();
         setUpToDate(meta, today);
     }
-    private static void setUpToDate(FragmentMetadata meta, LocalDate cutoff) {
+    public static void setUpToDate(FragmentMetadata meta, LocalDate cutoff) {
         meta.upToDate = UpToDate.mark(meta.unappliedEffects, cutoff);
     }
 

--- a/src/test/java/uk/gov/legislation/api/test/TocTest.java
+++ b/src/test/java/uk/gov/legislation/api/test/TocTest.java
@@ -10,7 +10,9 @@ import uk.gov.legislation.converters.TableOfContentsConverter;
 import uk.gov.legislation.endpoints.Application;
 import uk.gov.legislation.transform.simple.Contents;
 import uk.gov.legislation.transform.simple.Simplify;
+import uk.gov.legislation.util.UpToDate;
 
+import java.time.LocalDate;
 import java.util.stream.Stream;
 
 import static uk.gov.legislation.api.test.TransformTest.read;
@@ -35,6 +37,8 @@ class TocTest {
         String clml = read(id, "-contents.xml");
         Contents simple = simplifier.contents(clml);
         TableOfContents toc = TableOfContentsConverter.convert(simple);
+        LocalDate cutoff = LocalDate.of(2025, 3, 30);
+        UpToDate.setUpToDate(toc.meta, cutoff);
         String actual = UnappliedEffectsTest.mapper.writeValueAsString(toc);
         String expected = read(id, "-contents.json");
         Assertions.assertEquals(expected, actual);

--- a/src/test/java/uk/gov/legislation/api/test/TransformTest.java
+++ b/src/test/java/uk/gov/legislation/api/test/TransformTest.java
@@ -14,9 +14,11 @@ import uk.gov.legislation.endpoints.Application;
 import uk.gov.legislation.endpoints.document.service.DocumentService;
 import uk.gov.legislation.endpoints.fragment.service.TransformationService;
 import uk.gov.legislation.util.Links;
+import uk.gov.legislation.util.UpToDate;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -106,12 +108,15 @@ class TransformTest {
             .registerModules(new JavaTimeModule())
             .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
             .enable(SerializationFeature.INDENT_OUTPUT);
+        LocalDate cutoff = LocalDate.of(2025, 3, 30);
         String actual;
         if (isFragment(id)) {
             Fragment fragment = fragmentService.transformToJsonResponse(clml);
+            UpToDate.setUpToDate(fragment.meta, cutoff);
             actual = mapper.writeValueAsString(fragment);
         } else {
             Document document = documentService.transformToJsonResponse(clml);
+            UpToDate.setUpToDate(document.meta, cutoff);
             actual = mapper.writeValueAsString(document);
         }
         String expected = read(id, ".json");


### PR DESCRIPTION
Some of the tests began failing after a certain date passed, because the up-to-date status of the document changed. This fix makes those tests date-independent.