### PR TITLE
add support for older interpretations

### DIFF
--- a/src/main/java/uk/gov/legislation/api/responses/ld/Interpretation.java
+++ b/src/main/java/uk/gov/legislation/api/responses/ld/Interpretation.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.net.URI;
+import java.util.List;
 
 public class Interpretation {
 
@@ -14,22 +15,25 @@ public class Interpretation {
     public String language;
 
     @JsonProperty
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    public String longTitle;
-
-    @JsonProperty
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String shortTitle;
 
     @JsonProperty
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    public String orderTitle;
+    public String longTitle;
 
     @JsonProperty
     public boolean original;
 
     @JsonProperty
     public boolean current;
+
+    @JsonProperty
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public URI parent;
+
+    @JsonProperty
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<URI> children;
 
     @JsonProperty
     @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/java/uk/gov/legislation/api/responses/ld/Item.java
+++ b/src/main/java/uk/gov/legislation/api/responses/ld/Item.java
@@ -22,7 +22,8 @@ public class Item {
     public String session;
 
     @JsonProperty
-    public int number;
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    public Integer number;
 
     @JsonProperty
     public String title;
@@ -54,6 +55,14 @@ public class Item {
 
     @JsonProperty
     public List<String> originalLanguages;
+
+    @JsonProperty
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public URI parent;
+
+    @JsonProperty
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public List<URI> children;
 
     @JsonProperty
     @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/src/main/java/uk/gov/legislation/converters/ld/InterpretationConverter.java
+++ b/src/main/java/uk/gov/legislation/converters/ld/InterpretationConverter.java
@@ -10,11 +10,20 @@ public class InterpretationConverter {
         Interpretation interpretation = new Interpretation();
         interpretation.uri = ld.id;
         interpretation.language = ld.languageOfTextIsoCode.value;
-        interpretation.longTitle = (ld.longTitle == null) ? null : ld.longTitle.value;
         interpretation.shortTitle = (ld.shortTitle == null) ? null : ld.shortTitle.value;
-        interpretation.orderTitle = (ld.orderTitle == null) ? null : ld.orderTitle.value;
+        if (interpretation.shortTitle == null && ld.orderTitle != null)
+            interpretation.shortTitle = ld.orderTitle.value;
+        if (interpretation.shortTitle == null && ld.statuteTitle != null)
+            interpretation.shortTitle = ld.statuteTitle.value;
+        if (interpretation.shortTitle == null && ld.europeanUnionTitle != null)
+            interpretation.shortTitle = ld.europeanUnionTitle.value;
+        interpretation.longTitle = (ld.longTitle == null) ? null : ld.longTitle.value;
+        if (interpretation.longTitle == null && ld.subjectDescription != null)
+            interpretation.longTitle = ld.subjectDescription.value;
         interpretation.original = ld.type.stream().anyMatch(t -> t.equals(Resources.Leg.OriginalInterpretation));
         interpretation.current = ld.type.stream().anyMatch(t -> t.equals(Resources.Leg.CurrentInterpretation));
+        interpretation.parent = ld.within;
+        interpretation.children = ld.contains;
         return interpretation;
     }
 

--- a/src/main/java/uk/gov/legislation/converters/ld/ItemConverter.java
+++ b/src/main/java/uk/gov/legislation/converters/ld/ItemConverter.java
@@ -29,6 +29,8 @@ public class ItemConverter {
         item.welshCommentaryCitation = ValueAndLanguage.get(ld.commentaryCitation, "cy");
         item.originalLanguages = ld.originalLanguageOfTextIsoCode.stream()
             .map(value -> value.value).toList();
+        item.parent = ld.within;
+        item.children = ld.contains;
         item.interpretations = ld.interpretation;
         return item;
     }

--- a/src/main/java/uk/gov/legislation/data/virtuoso/jsonld/InterpretationLD.java
+++ b/src/main/java/uk/gov/legislation/data/virtuoso/jsonld/InterpretationLD.java
@@ -39,6 +39,27 @@ public class InterpretationLD {
     @JsonProperty
     public ValueAndLanguage orderTitle;
 
+    @JsonProperty
+    public ValueAndLanguage statuteTitle;
+
+    @JsonProperty
+    public ValueAndLanguage statuteTitleAbbreviated;
+
+    @JsonProperty
+    public ValueAndLanguage alternativeStatuteTitle;
+
+    @JsonProperty
+    public ValueAndLanguage europeanUnionTitle;
+
+    @JsonProperty
+    public ValueAndLanguage subjectDescription;
+
+    @JsonProperty
+    public URI within;
+
+    @JsonProperty
+    public List<URI> contains;
+
     public static InterpretationLD convert(ObjectNode node) {
         return Graph.mapper.convertValue(node, InterpretationLD.class);
     }

--- a/src/main/java/uk/gov/legislation/data/virtuoso/jsonld/ItemLD.java
+++ b/src/main/java/uk/gov/legislation/data/virtuoso/jsonld/ItemLD.java
@@ -30,7 +30,7 @@ public class ItemLD {
     public URI session;
 
     @JsonProperty
-    public int number;
+    public Integer number;
 
     @JsonProperty
     public List<ValueAndLanguage> title;
@@ -63,6 +63,12 @@ public class ItemLD {
     public void setCommentaryCitation(JsonNode node) {
         this.commentaryCitation = oneOrMany(node, ValueAndLanguage.class);
     }
+
+    @JsonProperty
+    public URI within;
+
+    @JsonProperty
+    public List<URI> contains;
 
     @JsonProperty
     public List<String> interpretation;

--- a/src/main/java/uk/gov/legislation/data/virtuoso/queries/InterpretationQuery.java
+++ b/src/main/java/uk/gov/legislation/data/virtuoso/queries/InterpretationQuery.java
@@ -22,9 +22,21 @@ public class InterpretationQuery {
 
     public InterpretationQuery(Virtuoso virtuoso) { this.virtuoso = virtuoso; }
 
-    String makeSparqlQuery(String type, String year, int number, String version, boolean welsh) {
-        String workUri = "http://www.legislation.gov.uk/id/%s/%s/%d".formatted(type, year, number);
-        String exprUri = "http://www.legislation.gov.uk/%s/%s/%d".formatted(type, year, number);
+    /**
+     * @param type    the first component of the URI, cannot be null
+     * @param middle  the following components of the URI, can contain slashes, cannot be null
+     * @param number  can be null
+     * @param version can be null
+     * @param welsh   whether to append /welsh
+     * @return the SPARQL query string
+     */
+    String makeSparqlQuery(String type, String middle, String number, String version, boolean welsh) {
+        String workUri = "http://www.legislation.gov.uk/id/%s/%s".formatted(type, middle);
+        String exprUri = "http://www.legislation.gov.uk/%s/%s".formatted(type, middle);
+        if (number != null) {
+            workUri += "/" + number;
+            exprUri += "/" + number;
+        }
         if (version != null)
             exprUri += "/" + version;
         if (welsh)
@@ -35,13 +47,13 @@ public class InterpretationQuery {
             """.formatted(workUri, exprUri);
     }
 
-    public String get(String type, String year, int number, String version, boolean welsh, String format) throws IOException, InterruptedException {
-        String query = makeSparqlQuery(type, year, number, version, welsh);
+    public String get(String type, String middle, String number, String version, boolean welsh, String format) throws IOException, InterruptedException {
+        String query = makeSparqlQuery(type, middle, number, version, welsh);
         return virtuoso.query(query, format);
     }
 
-    public Optional<Interpretation> get(String type, String year, int number, String version, boolean welsh) throws IOException, InterruptedException {
-        String json = get(type, year, number, version, welsh, "application/ld+json");
+    public Optional<Interpretation> get(String type, String middle, String number, String version, boolean welsh) throws IOException, InterruptedException {
+        String json = get(type, middle, number, version, welsh, "application/ld+json");
         ArrayNode graph = Graph.extract(json);
         if (graph == null)
             return Optional.empty();


### PR DESCRIPTION
This adds support for interpretations of older documents, with the following URI patterns:
- /{type}/{year:\\d{4}}/{date}/{number}
- /{type}/{reign}/{session}/{statute}/{number}
- /aep/{reign}/{statute}/{number}
- /aep/{statute}/{number}  // for tempincert URIs with number
- /aep/{statute}  // for tempincert URIs without number

Also, it adds support for EU treaties:
- /eut/{treaty}