### PR TITLE
Remove unnecessary 'type' attributes

### DIFF
--- a/src/main/java/uk/gov/legislation/api/responses/ld/Legislature.java
+++ b/src/main/java/uk/gov/legislation/api/responses/ld/Legislature.java
@@ -9,7 +9,4 @@ public class Legislature {
     @JsonProperty
     public URI uri;
 
-    @JsonProperty
-    public String type = "Legislature";
-
 }

--- a/src/main/java/uk/gov/legislation/api/responses/ld/Monarch.java
+++ b/src/main/java/uk/gov/legislation/api/responses/ld/Monarch.java
@@ -10,9 +10,6 @@ public class Monarch {
     public URI uri;
 
     @JsonProperty
-    public String type;
-
-    @JsonProperty
     public String label;
 
     @JsonProperty
@@ -21,6 +18,4 @@ public class Monarch {
     @JsonProperty
     public Integer number;
 
-    public Monarch() {
-    }
 }

--- a/src/main/java/uk/gov/legislation/api/responses/ld/RegnalYear.java
+++ b/src/main/java/uk/gov/legislation/api/responses/ld/RegnalYear.java
@@ -26,5 +26,3 @@ public class RegnalYear {
     public LocalDate endDate;
 
 }
-
-

--- a/src/main/java/uk/gov/legislation/api/responses/ld/Reign.java
+++ b/src/main/java/uk/gov/legislation/api/responses/ld/Reign.java
@@ -23,12 +23,6 @@ public class Reign {
     @JsonProperty
     public LocalDate endDate;
 
-//    @JsonProperty
-//    public Integer startYear;
-//
-//    @JsonProperty
-//    public Integer endYear;
-
     @JsonProperty
     public Integer startRegnalYear;
 

--- a/src/main/java/uk/gov/legislation/converters/ld/LegislatureConverter.java
+++ b/src/main/java/uk/gov/legislation/converters/ld/LegislatureConverter.java
@@ -8,7 +8,6 @@ public class LegislatureConverter {
     public static Legislature convert(LegislatureLD ld) {
         Legislature legislature = new Legislature();
         legislature.uri = ld.id;
-        legislature.type = ld.type.substring(46);
         return legislature;
     }
 

--- a/src/main/java/uk/gov/legislation/converters/ld/MonarchConverter.java
+++ b/src/main/java/uk/gov/legislation/converters/ld/MonarchConverter.java
@@ -8,7 +8,6 @@ public class MonarchConverter {
     public static Monarch convert(MonarchLD ld) {
         Monarch monarch = new Monarch();
         monarch.uri = ld.id;
-        monarch.type = ld.type;
         monarch.label = ld.label;
         monarch.name = ld.regnalName;
         monarch.number = ld.regnalNumber;

--- a/src/main/java/uk/gov/legislation/converters/ld/ReignConverter.java
+++ b/src/main/java/uk/gov/legislation/converters/ld/ReignConverter.java
@@ -15,8 +15,6 @@ public class ReignConverter {
         reign.monarchs = ld.monarch.stream().map(LDConverter::extractLastComponentOfUri).toList();
         reign.startDate = extractDateAtEndOfUri(ld.startDate);
         reign.endDate = extractDateAtEndOfUri(ld.endDate);
-//        reign.startYear = extractIntegerAtEndOfUri(ld.startCalendarYear);
-//        reign.endYear = extractIntegerAtEndOfUri(ld.endCalendarYear);
         reign.startRegnalYear = extractIntegerAtEndOfUri(ld.startRegnalYear);
         reign.endRegnalYear = extractIntegerAtEndOfUri(ld.endRegnalYear);
         return reign;

--- a/src/main/java/uk/gov/legislation/endpoints/ld/session/SessionApi.java
+++ b/src/main/java/uk/gov/legislation/endpoints/ld/session/SessionApi.java
@@ -32,7 +32,7 @@ public interface SessionApi {
     @Operation(summary = "information about a parliamentary session")
     ResponseEntity<?> getSessionByLegislatureReign(
         NativeWebRequest request,
-        @Parameter(description = "Legislature", example = "UnitedKingdomParliament ")
+        @Parameter(description = "Legislature", example = "UnitedKingdomParliament")
         @PathVariable String legislature,
         @Parameter(description = "Reign", example = "Eliz2")
         @PathVariable String reign,


### PR DESCRIPTION
Removes the 'type' attribute from Linked Data responses when it will always have the same value for a given endpoint