### PR TITLE
improved doc extent for some tables of contents

### DIFF
--- a/src/main/java/uk/gov/legislation/converters/TableOfContentsConverter.java
+++ b/src/main/java/uk/gov/legislation/converters/TableOfContentsConverter.java
@@ -10,21 +10,26 @@ import java.util.List;
 public class TableOfContentsConverter {
 
     public static TableOfContents convert(Contents simple) {
-        EnumSet<Extent> docExtent = ExtentConverter.convert(simple.meta.extent);
         TableOfContents toc = new TableOfContents();
         toc.meta = DocumentMetadataConverter.convert(simple.meta);
+        // to compensate for missing data
+        if (toc.meta.extent.isEmpty() && simple.contents != null)
+            toc.meta.extent = simple.contents.body.stream()
+                .map(item -> item.extent)
+                .map(ExtentConverter::convert)
+                .collect(() -> EnumSet.noneOf(Extent.class), EnumSet::addAll, EnumSet::addAll);
         if (simple.contents == null)
             return toc;
         toc.contents = new TableOfContents.Contents();
         toc.contents.title = simple.contents.title;
         if (simple.meta.hasParts.introduction != null) {
             toc.contents.introduction = new TableOfContents.Introduction();
-            toc.contents.introduction.extent = docExtent;
+            toc.contents.introduction.extent = toc.meta.extent;
         }
         toc.contents.body = convertItems(simple.contents.body);
         if (simple.meta.hasParts.signature != null) {
             toc.contents.signature = new TableOfContents.Signature();
-            toc.contents.signature.extent = docExtent;
+            toc.contents.signature.extent = toc.meta.extent;
         }
         toc.contents.appendices = convertItems(simple.contents.appendices);
         toc.contents.attachmentsBeforeSchedules = convertItems(simple.contents.attachmentsBeforeSchedules);
@@ -32,11 +37,11 @@ public class TableOfContentsConverter {
         toc.contents.attachments = convertItems(simple.contents.attachments);
         if (simple.meta.hasParts.note != null) {
             toc.contents.explanatoryNote = new TableOfContents.ExplanatoryNote();
-            toc.contents.explanatoryNote.extent = docExtent;
+            toc.contents.explanatoryNote.extent = toc.meta.extent;
         }
         if (simple.meta.hasParts.earlierOrders != null) {
             toc.contents.earlierOrders = new TableOfContents.EarlierOrders();
-            toc.contents.earlierOrders.extent = docExtent;
+            toc.contents.earlierOrders.extent = toc.meta.extent;
         }
         return toc;
     }

--- a/src/test/resources/ukpga_2023_29_2024-11-01/ukpga-2023-29-2024-11-01-contents.json
+++ b/src/test/resources/ukpga_2023_29_2024-11-01/ukpga-2023-29-2024-11-01-contents.json
@@ -11,7 +11,7 @@
     "version" : "2024-11-01",
     "status" : "revised",
     "title" : "Financial Services and Markets Act 2023",
-    "extent" : [ ],
+    "extent" : [ "E", "W", "S", "NI" ],
     "lang" : "en",
     "publisher" : "Statute Law Database",
     "modified" : "2024-11-04",
@@ -2384,7 +2384,7 @@
       "number" : null,
       "title" : "Introductory Text",
       "ref" : "introduction",
-      "extent" : [ ]
+      "extent" : [ "E", "W", "S", "NI" ]
     },
     "body" : [ {
       "name" : "part",


### PR DESCRIPTION
When the document-level extent is missing from a table of contents, it'll be inferred from the body