### PR TITLE
Align type parameter name in response

### DIFF
--- a/src/main/java/uk/gov/legislation/endpoints/search/SearchParameters.java
+++ b/src/main/java/uk/gov/legislation/endpoints/search/SearchParameters.java
@@ -1,6 +1,7 @@
 package uk.gov.legislation.endpoints.search;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.legislation.data.marklogic.search.Parameters;
 
 import java.time.LocalDate;
@@ -8,6 +9,7 @@ import java.util.List;
 
 public class SearchParameters {
 
+    @JsonProperty("type")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public List<String> types;
 


### PR DESCRIPTION
@Aasif-Gulbarga You were right the first time; I shouldn't have changed it.

In the search response metadata, the type parameter should be "type" (singular) to match the request parameter name.