### PR TITLE
Filter subjects for single letter subject queries

### DIFF
--- a/src/main/java/uk/gov/legislation/converters/DocumentsFeedConverter.java
+++ b/src/main/java/uk/gov/legislation/converters/DocumentsFeedConverter.java
@@ -19,6 +19,11 @@ public class DocumentsFeedConverter {
         page.meta = convertMeta(atom);
         page.meta.query = query;
         page.documents = convertDocuments(atom.entries);
+        if (query != null && query.subject != null && query.subject.length() == 1) {
+            page.meta.subjects = page.meta.subjects.stream()
+                .filter(s -> s.regionMatches(true, 0, query.subject, 0, 1))
+                .toList();
+        }
         return page;
     }
 


### PR DESCRIPTION
When I user searches for secondary documents having any subject that begins with a given letter, the middle-tier will now filter the list of subjects in the metadata to include only those beginning with that letter.