### PR TITLE
Fix fragment version calculation and add caching

### DIFF
--- a/src/main/java/uk/gov/legislation/transform/simple/Metadata.java
+++ b/src/main/java/uk/gov/legislation/transform/simple/Metadata.java
@@ -118,37 +118,38 @@ public class Metadata {
 
     private List<String> _versions;
 
-    private static final String REPEALED = " repealed";
-
-    public SortedSet<String> versions() {
-        TreeSet<String> set = new TreeSet<>(Versions.COMPARATOR);
-        set.addAll(_versions);
-        if (set.contains("current")) {
-            set.remove("current");
-            if (this.valid != null)
-                set.add(this.valid.toString());  // TODO check
-        }
-        if ("final".equals(status)) {
-            String first = FirstVersion.getFirstVersion(longType);
-            set.add(first);
-        }
-        if (!set.isEmpty()) {
-            String last = set.last();
-            if (last.endsWith(REPEALED)) {
-                set.pollLast();
-                String base = last.substring(0, last.length() - REPEALED.length());
-                set.add(base);
-            }
-        }
-        return set;
-    }
-
     @JacksonXmlElementWrapper(localName = "hasVersions")
     @JacksonXmlProperty(localName = "hasVersion")
     @JsonSetter
     public void setVersions(List<String> value) { _versions = value; }
 
+    private TreeSet<String> _versions2;
 
+    private static final String REPEALED = " repealed";
+
+    public SortedSet<String> versions() {
+        if (_versions2 != null)
+            return _versions2;
+        _versions2 = new TreeSet<>(Versions.COMPARATOR);
+        _versions2.addAll(_versions);
+        if (_versions2.remove("current")) {
+            if (this.valid != null)
+                _versions2.add(this.valid.toString());  // TODO check
+        }
+        if ("final".equals(status)) {
+            String first = FirstVersion.getFirstVersion(longType);
+            _versions2.add(first);
+        }
+        if (!_versions2.isEmpty()) {
+            String last = _versions2.last();
+            if (last.endsWith(REPEALED)) {
+                _versions2.pollLast();
+                String base = last.substring(0, last.length() - REPEALED.length());
+                _versions2.add(base);
+            }
+        }
+        return _versions2;
+    }
 
     @JacksonXmlProperty
     public HasParts hasParts;

--- a/src/main/java/uk/gov/legislation/transform/simple/Metadata.java
+++ b/src/main/java/uk/gov/legislation/transform/simple/Metadata.java
@@ -85,6 +85,23 @@ public class Metadata {
         }
     }
 
+    /**
+     * Determines the appropriate version identifier for this legislation document or fragment.
+     *
+     * <p>The version logic follows these rules:
+     * <ol>
+     * <li>If no dct:valid date exists, this is an original (unrevised) version.
+     *     Returns the type-specific original version name (enacted, made, created, or adopted).</li>
+     * <li>If dct:valid date exists, this is a revised document that should have dated versions.
+     *     If no dated versions are found (defensive fallback), returns the dct:valid date.</li>
+     * <li>For document fragments: if dct:valid date is after the last actual revision date
+     *     (due to other document parts being amended more recently), returns the fragment's
+     *     last actual revision date instead of the overall document valid date.</li>
+     * <li>Otherwise, returns the dct:valid date as the current version.</li>
+     * </ol>
+     *
+     * @return the version identifier string (either a type-specific name or an ISO date)
+     */
     public String version() {
         if (valid == null)
             return FirstVersion.getFirstVersion(longType);

--- a/src/test/resources/ukpga_2000_8_schedule_6_paragraph_4A/meta.json
+++ b/src/test/resources/ukpga_2000_8_schedule_6_paragraph_4A/meta.json
@@ -7,7 +7,7 @@
   "isbn" : "010540800X",
   "date" : "2000-06-14",
   "cite" : "2000 c. 8",
-  "version" : "2024-11-01",
+  "version" : "2020-12-31",
   "status" : "revised",
   "title" : "Financial Services and Markets Act 2000",
   "extent" : [ "E", "W", "S", "NI" ],
@@ -212,8 +212,10 @@
       "inForce" : [ {
         "date" : "2024-12-31",
         "applied" : false,
-        "description" : "wholly in force"
-      } ]
+        "description" : "wholly in force",
+        "outstanding" : true
+      } ],
+      "outstanding" : true
     }, {
       "applied" : false,
       "required" : true,
@@ -271,8 +273,10 @@
       "inForce" : [ {
         "date" : "2024-12-31",
         "applied" : false,
-        "description" : "wholly in force"
-      } ]
+        "description" : "wholly in force",
+        "outstanding" : true
+      } ],
+      "outstanding" : true
     }, {
       "applied" : false,
       "required" : true,
@@ -330,8 +334,10 @@
       "inForce" : [ {
         "date" : "2024-12-31",
         "applied" : false,
-        "description" : "wholly in force"
-      } ]
+        "description" : "wholly in force",
+        "outstanding" : true
+      } ],
+      "outstanding" : true
     } ],
     "ancestor" : [ {
       "applied" : false,
@@ -384,8 +390,10 @@
         "date" : null,
         "applied" : false,
         "prospective" : true,
-        "description" : "with effect in accordance with"
-      } ]
+        "description" : "with effect in accordance with",
+        "outstanding" : false
+      } ],
+      "outstanding" : false
     }, {
       "applied" : false,
       "required" : true,
@@ -437,8 +445,10 @@
         "date" : null,
         "applied" : false,
         "prospective" : true,
-        "description" : "with effect in accordance with"
-      } ]
+        "description" : "with effect in accordance with",
+        "outstanding" : false
+      } ],
+      "outstanding" : false
     }, {
       "applied" : false,
       "required" : true,
@@ -496,8 +506,10 @@
       "inForce" : [ {
         "date" : "2024-12-31",
         "applied" : false,
-        "description" : "wholly in force"
-      } ]
+        "description" : "wholly in force",
+        "outstanding" : true
+      } ],
+      "outstanding" : true
     }, {
       "applied" : false,
       "required" : true,
@@ -555,8 +567,10 @@
       "inForce" : [ {
         "date" : "2024-12-31",
         "applied" : false,
-        "description" : "wholly in force"
-      } ]
+        "description" : "wholly in force",
+        "outstanding" : true
+      } ],
+      "outstanding" : true
     }, {
       "applied" : false,
       "required" : true,
@@ -614,8 +628,10 @@
       "inForce" : [ {
         "date" : "2024-12-31",
         "applied" : false,
-        "description" : "wholly in force"
-      } ]
+        "description" : "wholly in force",
+        "outstanding" : true
+      } ],
+      "outstanding" : true
     }, {
       "applied" : false,
       "required" : true,
@@ -673,9 +689,11 @@
       "inForce" : [ {
         "date" : "2024-12-31",
         "applied" : false,
-        "description" : "wholly in force"
-      } ]
+        "description" : "wholly in force",
+        "outstanding" : true
+      } ],
+      "outstanding" : true
     } ]
   },
-  "upToDate" : null
+  "upToDate" : false
 }

--- a/src/test/resources/ukpga_2000_8_section_91/ukpga-2000-8-section-91.json
+++ b/src/test/resources/ukpga_2000_8_section_91/ukpga-2000-8-section-91.json
@@ -8,7 +8,7 @@
     "isbn" : "010540800X",
     "date" : "2000-06-14",
     "cite" : "2000 c. 8",
-    "version" : "2024-11-22",
+    "version" : "2024-01-30",
     "status" : "revised",
     "title" : "Financial Services and Markets Act 2000",
     "extent" : [ "E", "W", "S", "NI" ],


### PR DESCRIPTION
## Fixes version calculation issues for fragments and adds performance optimization

  ### Changes
  - **Fragment version logic**: Ensure fragments return their actual last revision date when the
  document's overall `dct:valid` date is more recent
  - **Repealed version handling**: Strip " repealed" suffix from version strings
  - **Performance**: Cache version calculations to avoid recalculating on each call
  - **Documentation**: Add JavaDoc explaining the version calculation logic

  ### Testing
  Updated test fixtures to reflect corrected version calculations.
