### PR TITLE
Add CI/CD Pipeline and Parameter Store Integration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Create Elastic Beanstalk application version
       run: |
         aws elasticbeanstalk create-application-version \
-          --application-name LGU2-API \
+          --application-name LGU2-Middle-Tier \
           --version-label ${{ steps.deployment-info.outputs.version-label }} \
           --source-bundle S3Bucket=lgu2-code,S3Key=api/${{ steps.deployment-info.outputs.jar-name }} \
           --description "Deployed from GitHub Actions - commit ${{ github.sha }}"
@@ -60,23 +60,23 @@ jobs:
     - name: Deploy to Elastic Beanstalk
       run: |
         aws elasticbeanstalk update-environment \
-          --application-name LGU2-API \
-          --environment-name LGU2-API \
+          --application-name LGU2-Middle-Tier \
+          --environment-name LGU2-Middle-Tier \
           --version-label ${{ steps.deployment-info.outputs.version-label }}
     
     - name: Wait for deployment to complete
       run: |
         echo "Waiting for deployment to complete..."
         aws elasticbeanstalk wait environment-updated \
-          --application-name LGU2-API \
-          --environment-name LGU2-API
+          --application-name LGU2-Middle-Tier \
+          --environment-name LGU2-Middle-Tier
         echo "Deployment completed successfully!"
     
     - name: Get environment URL
       run: |
         CNAME=$(aws elasticbeanstalk describe-environments \
-          --application-name LGU2-API \
-          --environment-names LGU2-API \
+          --application-name LGU2-Middle-Tier \
+          --environment-names LGU2-Middle-Tier \
           --query 'Environments[0].CNAME' \
           --output text)
         echo "🚀 Application deployed to: http://${CNAME}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to AWS Elastic Beanstalk
 
 on:
   push:
-    branches: [ ci-cd ]  # Testing on ci-cd branch first
+    branches: [ main ]
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
         aws-region: ${{ secrets.AWS_REGION }}
     
     - name: Build with Maven
-      run: ./mvnw clean package -DskipTests
+      run: mvn clean package -DskipTests
     
     - name: Generate deployment info
       id: deployment-info

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,82 @@
+name: Deploy to AWS Elastic Beanstalk
+
+on:
+  push:
+    branches: [ ci-cd ]  # Testing on ci-cd branch first
+
+jobs:
+  deploy:
+    name: Build and Deploy
+    runs-on: ubuntu-latest
+    
+    permissions:
+      id-token: write   # Required for AWS OIDC
+      contents: read    # Required to checkout code
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'corretto'
+    
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+        role-session-name: GitHubActions-Deploy
+        aws-region: ${{ secrets.AWS_REGION }}
+    
+    - name: Build with Maven
+      run: ./mvnw clean package -DskipTests
+    
+    - name: Generate deployment info
+      id: deployment-info
+      run: |
+        TIMESTAMP=$(date +%Y%m%d%H%M%S)
+        COMMIT_SHA=$(git rev-parse --short HEAD)
+        VERSION_LABEL="api-${TIMESTAMP}-${COMMIT_SHA}"
+        JAR_NAME="api-${TIMESTAMP}.jar"
+        echo "version-label=${VERSION_LABEL}" >> $GITHUB_OUTPUT
+        echo "jar-name=${JAR_NAME}" >> $GITHUB_OUTPUT
+        echo "timestamp=${TIMESTAMP}" >> $GITHUB_OUTPUT
+    
+    - name: Upload JAR to S3
+      run: |
+        cp target/*.jar ${{ steps.deployment-info.outputs.jar-name }}
+        aws s3 cp ${{ steps.deployment-info.outputs.jar-name }} s3://lgu2-code/api/
+    
+    - name: Create Elastic Beanstalk application version
+      run: |
+        aws elasticbeanstalk create-application-version \
+          --application-name LGU2-API \
+          --version-label ${{ steps.deployment-info.outputs.version-label }} \
+          --source-bundle S3Bucket=lgu2-code,S3Key=api/${{ steps.deployment-info.outputs.jar-name }} \
+          --description "Deployed from GitHub Actions - commit ${{ github.sha }}"
+    
+    - name: Deploy to Elastic Beanstalk
+      run: |
+        aws elasticbeanstalk update-environment \
+          --application-name LGU2-API \
+          --environment-name LGU2-API \
+          --version-label ${{ steps.deployment-info.outputs.version-label }}
+    
+    - name: Wait for deployment to complete
+      run: |
+        echo "Waiting for deployment to complete..."
+        aws elasticbeanstalk wait environment-updated \
+          --application-name LGU2-API \
+          --environment-name LGU2-API
+        echo "Deployment completed successfully!"
+    
+    - name: Get environment URL
+      run: |
+        CNAME=$(aws elasticbeanstalk describe-environments \
+          --application-name LGU2-API \
+          --environment-names LGU2-API \
+          --query 'Environments[0].CNAME' \
+          --output text)
+        echo "🚀 Application deployed to: http://${CNAME}"

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,11 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>io.awspring.cloud</groupId>
+			<artifactId>spring-cloud-aws-starter-parameter-store</artifactId>
+			<version>3.4.0</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -6,3 +6,6 @@ MARKLOGIC_PASSWORD=password
 VIRTUOSO_HOST=localhost
 VIRTUOSO_PORT=0
 DEFRALEX_PORT=0
+
+# Disable AWS Parameter Store auto-configuration during tests
+spring.cloud.aws.parameterstore.enabled=false


### PR DESCRIPTION
This PR adds GitHub Actions CI/CD for automated deployment to AWS Elastic Beanstalk and integrates AWS Parameter Store for secure secrets management.

## Key Changes

- Add Spring Cloud AWS Parameter Store dependency - Required for loading application secrets from AWS Parameter Store instead of embedding them in the repository
- Add GitHub Actions CI/CD workflow - Automated build and deployment on merge to main

## Why Parameter Store?

The new spring-cloud-aws-starter-parameter-store dependency allows the application to load database credentials and other secrets from AWS Parameter Store at runtime. This eliminates the need to store sensitive configuration in the repository or pass secrets through environment variables.

## Technical Details

### CI/CD Pipeline:
- Maven build → S3 upload → EB deployment
- Triggers automatically on main branch merges
- Uses temporary token authentication (no stored credentials)

### Parameter Store Integration:
- Production secrets loaded from AWS Parameter Store
- Local development still uses application-secrets.properties
- Backward compatible configuration

## Test Plan

- CI/CD pipeline tested with successful deployments
- Parameter Store integration verified working
- Application responding correctly after deployment