### PR TITLE
Disable Parameter Store in development

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,3 +1,5 @@
 logging.level.org.springframework.web=DEBUG
 logging.level.org.springframework.web.filter.CommonsRequestLoggingFilter=DEBUG
 logging.level.uk.gov.legislation=DEBUG
+
+spring.cloud.aws.parameterstore.enabled=false


### PR DESCRIPTION
Adds a line to the dev profile, disabling the AWS Parameter Store