### PR TITLE
Exclude commons-logging to resolve logging conflict

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,12 @@
 			<groupId>io.awspring.cloud</groupId>
 			<artifactId>spring-cloud-aws-starter-parameter-store</artifactId>
 			<version>3.4.0</version>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
The `spring-cloud-aws-starter-parameter-store` dependency transitively pulls in the legacy `commons-logging` library via the AWS SDK.

This conflicts with Spring Boot's logging architecture, which provides its own bridge (`spring-jcl`) to route all commons-logging calls to SLF4J. The presence of both libraries on the classpath causes a warning and can lead to unpredictable logging behavior.

This commit explicitly excludes the `commons-logging` artifact. This ensures that only Spring Boot's logging bridge is used, unifying all application logs and resolving the runtime warning.