### PR TITLE
Remove duplicate formats from search results

### DIFF
--- a/src/main/java/uk/gov/legislation/api/responses/PageOfDocuments.java
+++ b/src/main/java/uk/gov/legislation/api/responses/PageOfDocuments.java
@@ -7,6 +7,7 @@ import uk.gov.legislation.endpoints.search.SearchParameters;
 import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.List;
+import java.util.SortedSet;
 
 public class PageOfDocuments {
 
@@ -136,7 +137,7 @@ public class PageOfDocuments {
         public String version;
 
         @Schema(allowableValues = { "xml", "pdf" }, example = "[\"xml\", \"pdf\"]")
-        public List<String> formats;
+        public SortedSet<String> formats;
 
     }
 

--- a/src/main/java/uk/gov/legislation/converters/DocumentsFeedConverter.java
+++ b/src/main/java/uk/gov/legislation/converters/DocumentsFeedConverter.java
@@ -139,13 +139,13 @@ public class DocumentsFeedConverter {
             .orElse(null);
     }
 
-    private static List<String> getFormats(List<SearchResults.Link> links) {
+    private static SortedSet<String> getFormats(List<SearchResults.Link> links) {
         return links.stream()
             .filter(l -> "alternate".equals(l.rel))
             .map(l -> l.type)
             .filter(t -> "application/xml".equals(t) || "application/pdf".equals(t))
             .map(t -> t.substring(12))
-            .toList();
+            .collect(Collectors.toCollection(TreeSet::new));
     }
 
 }

--- a/src/test/resources/ukpga.json
+++ b/src/test/resources/ukpga.json
@@ -691,7 +691,7 @@
     "published" : "2024-09-10T16:19:53.337093Z",
     "updated" : "2024-10-16T14:02:23Z",
     "version" : "2024-10-15",
-    "formats" : [ "xml", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   }, {
     "id" : "ukpga/2024/23",
     "longType" : "UnitedKingdomPublicGeneralAct",
@@ -705,7 +705,7 @@
     "published" : "2024-07-31T14:30:44.788658Z",
     "updated" : "2024-09-03T12:40:39Z",
     "version" : "2024-07-30",
-    "formats" : [ "xml", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   }, {
     "id" : "ukpga/2024/22",
     "longType" : "UnitedKingdomPublicGeneralAct",
@@ -719,7 +719,7 @@
     "published" : "2024-06-03T16:19:47.87452Z",
     "updated" : "2024-11-04T11:32:30Z",
     "version" : "2024-10-31",
-    "formats" : [ "xml", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   }, {
     "id" : "ukpga/2024/21",
     "longType" : "UnitedKingdomPublicGeneralAct",
@@ -733,7 +733,7 @@
     "published" : "2024-06-03T16:14:35.844788Z",
     "updated" : "2024-11-06T17:56:52Z",
     "version" : "2024-11-01",
-    "formats" : [ "xml", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   }, {
     "id" : "ukpga/2024/20",
     "longType" : "UnitedKingdomPublicGeneralAct",
@@ -747,7 +747,7 @@
     "published" : "2024-05-30T17:09:27.563445Z",
     "updated" : "2024-07-26T09:07:48Z",
     "version" : "2024-07-24",
-    "formats" : [ "xml", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   }, {
     "id" : "ukpga/2024/19",
     "longType" : "UnitedKingdomPublicGeneralAct",
@@ -761,7 +761,7 @@
     "published" : "2024-06-03T16:09:51.364037Z",
     "updated" : "2024-06-12T09:18:09Z",
     "version" : "2024-05-24",
-    "formats" : [ "xml", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   }, {
     "id" : "ukpga/2024/18",
     "longType" : "UnitedKingdomPublicGeneralAct",
@@ -775,7 +775,7 @@
     "published" : "2024-06-03T15:59:22.034634Z",
     "updated" : "2024-08-21T11:35:14Z",
     "version" : "2024-07-24",
-    "formats" : [ "xml", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   }, {
     "id" : "ukpga/2024/17",
     "longType" : "UnitedKingdomPublicGeneralAct",
@@ -789,7 +789,7 @@
     "published" : "2024-05-30T17:04:14.058656Z",
     "updated" : "2024-06-11T13:35:49Z",
     "version" : "2024-05-24",
-    "formats" : [ "xml", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   }, {
     "id" : "ukpga/2024/16",
     "longType" : "UnitedKingdomPublicGeneralAct",
@@ -803,7 +803,7 @@
     "published" : "2024-05-30T16:59:08.55125Z",
     "updated" : "2024-08-27T09:49:27Z",
     "version" : "2024-08-24",
-    "formats" : [ "xml", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   }, {
     "id" : "ukpga/2024/15",
     "longType" : "UnitedKingdomPublicGeneralAct",
@@ -817,7 +817,7 @@
     "published" : "2024-06-04T12:30:36.002796Z",
     "updated" : "2024-10-23T15:05:15Z",
     "version" : "2024-10-17",
-    "formats" : [ "xml", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   }, {
     "id" : "ukpga/2024/14",
     "longType" : "UnitedKingdomPublicGeneralAct",
@@ -831,7 +831,7 @@
     "published" : "2024-05-30T09:36:46.582486Z",
     "updated" : "2024-07-30T13:54:55Z",
     "version" : "2024-05-24",
-    "formats" : [ "xml", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   }, {
     "id" : "ukpga/2024/13",
     "longType" : "UnitedKingdomPublicGeneralAct",
@@ -845,7 +845,7 @@
     "published" : "2024-07-16T00:00:00Z",
     "updated" : "2024-07-26T08:18:31Z",
     "version" : "2024-07-24",
-    "formats" : [ "xml", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   }, {
     "id" : "ukpga/2024/12",
     "longType" : "UnitedKingdomPublicGeneralAct",
@@ -859,7 +859,7 @@
     "published" : "2024-05-31T16:53:15.313973Z",
     "updated" : "2024-06-05T12:27:30Z",
     "version" : "2024-05-24",
-    "formats" : [ "xml", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   }, {
     "id" : "ukpga/2024/11",
     "longType" : "UnitedKingdomPublicGeneralAct",
@@ -873,7 +873,7 @@
     "published" : "2024-05-21T14:39:04.984569Z",
     "updated" : "2024-08-04T19:51:35Z",
     "version" : "2024-07-22",
-    "formats" : [ "xml", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   }, {
     "id" : "ukpga/2024/10",
     "longType" : "UnitedKingdomPublicGeneralAct",
@@ -887,7 +887,7 @@
     "published" : "2024-05-22T19:07:30.494629Z",
     "updated" : "2024-07-30T12:46:24Z",
     "version" : "2024-05-20",
-    "formats" : [ "xml", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   }, {
     "id" : "ukpga/2024/9",
     "longType" : "UnitedKingdomPublicGeneralAct",
@@ -901,7 +901,7 @@
     "published" : "2024-04-29T16:21:15.273338Z",
     "updated" : "2024-10-16T11:36:48Z",
     "version" : "2024-10-14",
-    "formats" : [ "xml", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   }, {
     "id" : "ukpga/2024/8",
     "longType" : "UnitedKingdomPublicGeneralAct",
@@ -915,7 +915,7 @@
     "published" : "2024-04-25T15:33:51.163974Z",
     "updated" : "2024-06-26T19:03:20Z",
     "version" : "2024-04-25",
-    "formats" : [ "xml", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   }, {
     "id" : "ukpga/2024/7",
     "longType" : "UnitedKingdomPublicGeneralAct",
@@ -929,7 +929,7 @@
     "published" : "2024-04-25T15:28:46.413124Z",
     "updated" : "2024-07-17T18:04:19Z",
     "version" : "2024-06-25",
-    "formats" : [ "xml", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   }, {
     "id" : "ukpga/2024/6",
     "longType" : "UnitedKingdomPublicGeneralAct",
@@ -943,7 +943,7 @@
     "published" : "2024-03-25T16:44:38.250586Z",
     "updated" : "2024-05-29T11:02:47Z",
     "version" : "2024-03-20",
-    "formats" : [ "xml", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   }, {
     "id" : "ukpga/2024/5",
     "longType" : "UnitedKingdomPublicGeneralAct",
@@ -957,6 +957,6 @@
     "published" : "2024-03-20T16:06:33.129257Z",
     "updated" : "2024-07-29T13:04:25Z",
     "version" : "2024-04-06",
-    "formats" : [ "xml", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   } ]
 }

--- a/src/test/resources/uksi.json
+++ b/src/test/resources/uksi.json
@@ -366,7 +366,7 @@
     "published" : "2024-11-07T16:20:25.454689Z",
     "updated" : "2024-11-07T16:40:51Z",
     "version" : "made",
-    "formats" : [ "xml", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   }, {
     "id" : "wsi/2024/1129",
     "longType" : "WelshStatutoryInstrument",
@@ -384,7 +384,7 @@
     "published" : "2024-11-08T03:04:28.236314Z",
     "updated" : "2024-11-08T03:09:23Z",
     "version" : "made",
-    "formats" : [ "pdf", "pdf" ]
+    "formats" : [ "pdf" ]
   }, {
     "id" : "wsi/2024/1126",
     "longType" : "WelshStatutoryInstrument",
@@ -403,7 +403,7 @@
     "published" : "2024-11-07T13:23:34.489155Z",
     "updated" : "2024-11-07T15:09:37Z",
     "version" : "made",
-    "formats" : [ "xml", "xml", "pdf", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   }, {
     "id" : "uksi/2024/1122",
     "longType" : "UnitedKingdomStatutoryInstrument",
@@ -418,7 +418,7 @@
     "published" : "2024-11-07T10:41:52.870972Z",
     "updated" : "2024-11-07T10:57:07Z",
     "version" : "made",
-    "formats" : [ "xml", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   }, {
     "id" : "wsi/2024/1121",
     "longType" : "WelshStatutoryInstrument",
@@ -455,7 +455,7 @@
     "published" : "2024-11-07T09:51:06.927897Z",
     "updated" : "2024-11-07T10:01:11Z",
     "version" : "made",
-    "formats" : [ "xml", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   }, {
     "id" : "wsi/2024/1119",
     "longType" : "WelshStatutoryInstrument",
@@ -474,7 +474,7 @@
     "published" : "2024-11-08T13:11:55.912895Z",
     "updated" : "2024-11-08T13:12:04Z",
     "version" : "made",
-    "formats" : [ "xml", "xml", "pdf", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   }, {
     "id" : "uksi/2024/1118",
     "longType" : "UnitedKingdomStatutoryInstrument",
@@ -489,7 +489,7 @@
     "published" : "2024-11-07T09:15:38.233155Z",
     "updated" : "2024-11-07T09:25:49Z",
     "version" : "made",
-    "formats" : [ "xml", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   }, {
     "id" : "uksi/2024/1116",
     "longType" : "UnitedKingdomStatutoryInstrument",
@@ -504,7 +504,7 @@
     "published" : "2024-11-07T13:38:41.595156Z",
     "updated" : "2024-11-07T13:43:52Z",
     "version" : "made",
-    "formats" : [ "xml", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   }, {
     "id" : "uksi/2024/1115",
     "longType" : "UnitedKingdomStatutoryInstrument",
@@ -519,7 +519,7 @@
     "published" : "2024-11-07T12:12:47.474738Z",
     "updated" : "2024-11-07T12:17:44Z",
     "version" : "made",
-    "formats" : [ "xml", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   }, {
     "id" : "uksi/2024/1114",
     "longType" : "UnitedKingdomStatutoryInstrument",
@@ -534,7 +534,7 @@
     "published" : "2024-11-07T13:38:50.801294Z",
     "updated" : "2024-11-07T13:44:01Z",
     "version" : "made",
-    "formats" : [ "xml", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   }, {
     "id" : "uksi/2024/1113",
     "longType" : "UnitedKingdomStatutoryInstrument",
@@ -549,7 +549,7 @@
     "published" : "2024-11-07T13:23:24.95671Z",
     "updated" : "2024-11-07T13:28:32Z",
     "version" : "made",
-    "formats" : [ "xml", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   }, {
     "id" : "uksi/2024/1112",
     "longType" : "UnitedKingdomStatutoryInstrument",
@@ -564,7 +564,7 @@
     "published" : "2024-11-07T12:17:53.250955Z",
     "updated" : "2024-11-07T12:22:51Z",
     "version" : "made",
-    "formats" : [ "xml", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   }, {
     "id" : "uksi/2024/1111",
     "longType" : "UnitedKingdomStatutoryInstrument",
@@ -579,7 +579,7 @@
     "published" : "2024-11-07T12:07:39.061044Z",
     "updated" : "2024-11-07T12:13:06Z",
     "version" : "made",
-    "formats" : [ "xml", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   }, {
     "id" : "uksi/2024/1110",
     "longType" : "UnitedKingdomStatutoryInstrument",
@@ -594,7 +594,7 @@
     "published" : "2024-11-06T15:57:41.564173Z",
     "updated" : "2024-11-06T16:02:39Z",
     "version" : "made",
-    "formats" : [ "xml", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   }, {
     "id" : "wsi/2024/1109",
     "longType" : "WelshStatutoryInstrument",
@@ -613,7 +613,7 @@
     "published" : "2024-11-08T13:11:45.373078Z",
     "updated" : "2024-11-08T13:11:46Z",
     "version" : "made",
-    "formats" : [ "xml", "xml", "pdf", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   }, {
     "id" : "uksi/2024/1108",
     "longType" : "UnitedKingdomStatutoryInstrument",
@@ -631,7 +631,7 @@
     "published" : "2024-11-06T10:54:39.588789Z",
     "updated" : "2024-11-06T11:25:05Z",
     "version" : "made",
-    "formats" : [ "xml", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   }, {
     "id" : "uksi/2024/1106",
     "longType" : "UnitedKingdomStatutoryInstrument",
@@ -646,6 +646,6 @@
     "published" : "2024-11-05T16:32:40.605665Z",
     "updated" : "2024-11-10T00:10:00Z",
     "version" : "made",
-    "formats" : [ "xml", "pdf" ]
+    "formats" : [ "pdf", "xml" ]
   } ]
 }


### PR DESCRIPTION
Sometimes format values were appearing more than once in the "formats" array, e.g., `"formats" : [ "xml", "xml", "pdf", "pdf" ]`

This fix uses SortedSet<String> instead of List<String> for document formats to automatically eliminate duplicates and ensure consistent alphabetical ordering.