### PR TITLE
Handle case of missing PartialRefs element

### DIFF
--- a/src/main/resources/transforms/clml2docx/xslt/amendments.xsl
+++ b/src/main/resources/transforms/clml2docx/xslt/amendments.xsl
@@ -278,7 +278,7 @@
 		<w:r>
 			<w:t xml:space="preserve"> </w:t>
 		</w:r>
-		<xsl:variable name="lead-in" as="element()" select="$amendment/*[@id = $partial-refs]" />
+		<xsl:variable name="lead-in" as="element()?" select="$amendment/*[@id = $partial-refs]" />
 		<xsl:apply-templates select="$lead-in" mode="lead-in">
 			<xsl:with-param name="within-extract" as="xs:boolean" select="true()" tunnel="yes" />
 			<xsl:with-param name="extract-is-amendment" as="xs:boolean" select="true()" tunnel="yes" />


### PR DESCRIPTION
This one character fix handles the case in which no element exists with an id that matches the PartialRefs attribute of a BlockAmendment.

At the moment, ukpga/2023/54 contains two BlockAmendments like this, although I suspect that may get fixed.