### PR TITLE
Performance enhancements

### DIFF
--- a/src/main/java/uk/gov/legislation/data/marklogic/Error.java
+++ b/src/main/java/uk/gov/legislation/data/marklogic/Error.java
@@ -1,6 +1,7 @@
 package uk.gov.legislation.data.marklogic;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
@@ -13,9 +14,11 @@ import java.util.List;
 public class Error {
 
     public static Error parse(String xml) throws JsonProcessingException {
-        XmlMapper mapper = new XmlMapper();
-        return mapper.readValue(xml, Error.class);
+        return MAPPER.readValue(xml, Error.class);
     }
+
+    private static final XmlMapper MAPPER = (XmlMapper) new XmlMapper()
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     @JacksonXmlProperty(localName = "status-code")
     public int statusCode;

--- a/src/main/java/uk/gov/legislation/transform/Clml2Akn.java
+++ b/src/main/java/uk/gov/legislation/transform/Clml2Akn.java
@@ -5,9 +5,9 @@ import org.springframework.stereotype.Service;
 
 import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.io.StringReader;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.Properties;
@@ -56,8 +56,10 @@ public class Clml2Akn {
     }
 
     public XdmNode transform(String clml) throws SaxonApiException {
-        ByteArrayInputStream stream = new ByteArrayInputStream(clml.getBytes());
-        return transform(stream);
+        Source source = new StreamSource(new StringReader(clml));
+        XdmDestination destination = new XdmDestination();
+        transform(source, destination);
+        return destination.getXdmNode();
     }
 
     static final Properties Properties = new Properties();

--- a/src/main/java/uk/gov/legislation/transform/Helper.java
+++ b/src/main/java/uk/gov/legislation/transform/Helper.java
@@ -9,8 +9,8 @@ import net.sf.saxon.serialize.Emitter;
 
 import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.StringReader;
 import java.util.Properties;
 
 public class Helper {
@@ -61,8 +61,7 @@ public class Helper {
     }
 
     public static XdmNode parse(String xml) throws SaxonApiException {
-        ByteArrayInputStream stream = new ByteArrayInputStream(xml.getBytes());
-        Source source = new StreamSource(stream);
+        Source source = new StreamSource(new StringReader(xml));
         DocumentBuilder builder = processor.newDocumentBuilder();
         return builder.build(source);
     }

--- a/src/main/java/uk/gov/legislation/transform/simple/Contents.java
+++ b/src/main/java/uk/gov/legislation/transform/simple/Contents.java
@@ -1,12 +1,9 @@
 package uk.gov.legislation.transform.simple;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import java.util.List;
 
@@ -14,10 +11,7 @@ import java.util.List;
 public class Contents {
 
     public static uk.gov.legislation.transform.simple.Contents parse(String xml) throws JsonProcessingException {
-        XmlMapper mapper = (XmlMapper) new XmlMapper()
-            .registerModules(new JavaTimeModule())
-            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        return mapper.readValue(xml, uk.gov.legislation.transform.simple.Contents.class);
+        return SimpleXmlMapper.INSTANCE.readValue(xml, uk.gov.legislation.transform.simple.Contents.class);
     }
 
     public Metadata meta;

--- a/src/main/java/uk/gov/legislation/transform/simple/SimpleXmlMapper.java
+++ b/src/main/java/uk/gov/legislation/transform/simple/SimpleXmlMapper.java
@@ -1,0 +1,23 @@
+package uk.gov.legislation.transform.simple;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+/**
+ * Central place to build the XML-aware Jackson mapper used across the
+ * simplification pipeline. The mapper is immutable and thread-safe, so we
+ * expose a single shared instance to avoid repeated configuration work in hot
+ * paths.
+ */
+public final class SimpleXmlMapper {
+
+    private SimpleXmlMapper() {
+        // no instances
+    }
+
+    public static final XmlMapper INSTANCE = (XmlMapper) new XmlMapper()
+        .registerModules(new JavaTimeModule())
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+}

--- a/src/main/java/uk/gov/legislation/transform/simple/Simplify.java
+++ b/src/main/java/uk/gov/legislation/transform/simple/Simplify.java
@@ -7,8 +7,8 @@ import uk.gov.legislation.transform.Helper;
 
 import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.StringReader;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
@@ -56,9 +56,8 @@ public class Simplify {
     }
 
     public String transform(String clml, Parameters params) throws SaxonApiException {
-        ByteArrayInputStream input = new ByteArrayInputStream(clml.getBytes());
+        Source source = new StreamSource(new StringReader(clml));
         ByteArrayOutputStream output = new ByteArrayOutputStream();
-        Source source = new StreamSource(input);
         Serializer destination = executable.getProcessor().newSerializer(output);
         transform(source, destination, params);
         return output.toString(StandardCharsets.UTF_8);

--- a/src/main/java/uk/gov/legislation/transform/simple/Simplify.java
+++ b/src/main/java/uk/gov/legislation/transform/simple/Simplify.java
@@ -19,6 +19,9 @@ public class Simplify {
 
     private static final String STYLESHEET = "/transforms/simplify/legislation.xsl";
 
+    private static final QName IS_FRAGMENT_PARAM = new QName("is-fragment");
+    private static final QName INCLUDE_CONTENTS_PARAM = new QName("include-contents");
+
     private final XsltExecutable executable;
 
     public Simplify() {
@@ -39,9 +42,9 @@ public class Simplify {
 
     private void transform(Source clml, Destination destination, Parameters params) throws SaxonApiException {
         Xslt30Transformer transformer = executable.load30();
-        Map<QName, XdmValue> params2 = new LinkedHashMap<>();
-        params2.put(new QName("is-fragment"), new XdmAtomicValue(params.isFragment()));
-        params2.put(new QName("include-contents"), new XdmAtomicValue(params.includeContents()));
+        Map<QName, XdmValue> params2 = new LinkedHashMap<>(2);
+        params2.put(IS_FRAGMENT_PARAM, new XdmAtomicValue(params.isFragment()));
+        params2.put(INCLUDE_CONTENTS_PARAM, new XdmAtomicValue(params.includeContents()));
         transformer.setStylesheetParameters(params2);
         transformer.transform(clml, destination);
     }

--- a/src/main/java/uk/gov/legislation/transform/simple/effects/EffectsSimplifier.java
+++ b/src/main/java/uk/gov/legislation/transform/simple/effects/EffectsSimplifier.java
@@ -1,12 +1,10 @@
 package uk.gov.legislation.transform.simple.effects;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import net.sf.saxon.s9api.*;
 import org.springframework.stereotype.Service;
 import uk.gov.legislation.transform.Helper;
+import uk.gov.legislation.transform.simple.SimpleXmlMapper;
 
 import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
@@ -47,13 +45,9 @@ public class EffectsSimplifier {
         return simple.toString();
     }
 
-    private static final XmlMapper Mapper = (XmlMapper) new XmlMapper()
-        .registerModules(new JavaTimeModule())
-        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-
     public Page parse(String atom) throws SaxonApiException, JsonProcessingException {
         String simple = simpify(atom);
-        return Mapper.readValue(simple, Page.class);
+        return SimpleXmlMapper.INSTANCE.readValue(simple, Page.class);
     }
 
 }


### PR DESCRIPTION
Cuts steady-state allocation overhead in the XML simplification pipeline:
- centralise the Jackson XmlMapper used for simplified metadata/effects parsing so it’s built once and shared everywhere
- feed Saxon helpers with StringReaders instead of ByteArrayInputStream(clml.getBytes(...)), removing redundant byte[] copies and charset lookups
- precompute stylesheet parameter QNames (and tidy the imports) to avoid recreating them on every transform call