### PR TITLE
Add API key authentication for internal endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,10 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>io.awspring.cloud</groupId>
 			<artifactId>spring-cloud-aws-starter-parameter-store</artifactId>
 			<version>3.4.0</version>

--- a/src/main/java/uk/gov/legislation/Application.java
+++ b/src/main/java/uk/gov/legislation/Application.java
@@ -1,7 +1,10 @@
 package uk.gov.legislation;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
@@ -19,6 +22,12 @@ import java.util.Locale;
 @SpringBootApplication(scanBasePackages = "uk.gov.legislation")
 @Configuration
 @OpenAPIDefinition(info = @Info(title = "api.legislation.gov.uk", version = "0.0.2", description = "the API for www.legislation.gov.uk"))
+@SecurityScheme(
+    name = "apiKey",
+    type = SecuritySchemeType.APIKEY,
+    in = SecuritySchemeIn.HEADER,
+    paramName = "X-API-Key"
+)
 public class Application implements WebMvcConfigurer {
 
 	public static void main(String[] args) {

--- a/src/main/java/uk/gov/legislation/endpoints/contact/ContactController.java
+++ b/src/main/java/uk/gov/legislation/endpoints/contact/ContactController.java
@@ -1,0 +1,26 @@
+package uk.gov.legislation.endpoints.contact;
+
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@Tag(name = "Internal", description = "Endpoints requiring API key authentication")
+@RequestMapping(path = "/contact")
+@SecurityRequirement(name = "apiKey")
+public class ContactController {
+
+    @PostMapping(value = "/tso", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Void> sendEmailToTso(@Valid @RequestBody ContactRequest request) {
+        throw new ResponseStatusException(HttpStatus.NOT_IMPLEMENTED);
+    }
+
+}

--- a/src/main/java/uk/gov/legislation/endpoints/contact/ContactRequest.java
+++ b/src/main/java/uk/gov/legislation/endpoints/contact/ContactRequest.java
@@ -1,0 +1,22 @@
+package uk.gov.legislation.endpoints.contact;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record ContactRequest(
+
+    @NotBlank(message = "Full name is required")
+    String fullName,
+
+    @NotBlank(message = "Email address is required")
+    @Email(message = "Email address must be valid")
+    String email,
+
+    String telephone,
+
+    @NotBlank(message = "Address is required")
+    String address,
+
+    String additionalDetails
+
+) {}

--- a/src/main/java/uk/gov/legislation/exceptions/ValidationErrorResponse.java
+++ b/src/main/java/uk/gov/legislation/exceptions/ValidationErrorResponse.java
@@ -1,0 +1,14 @@
+package uk.gov.legislation.exceptions;
+
+import java.util.Map;
+
+public class ValidationErrorResponse extends ErrorResponse {
+
+    public final Map<String, String> errors;
+
+    ValidationErrorResponse(int status, String error, String message, Map<String, String> errors) {
+        super(status, error, message);
+        this.errors = errors;
+    }
+
+}

--- a/src/main/java/uk/gov/legislation/security/ApiKeyAuthenticationFilter.java
+++ b/src/main/java/uk/gov/legislation/security/ApiKeyAuthenticationFilter.java
@@ -1,0 +1,70 @@
+package uk.gov.legislation.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Collections;
+
+/**
+ * Validates API key authentication for protected endpoints.
+ * Uses constant-time comparison to prevent timing attacks.
+ */
+@Component
+public class ApiKeyAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final Logger logger = LoggerFactory.getLogger(ApiKeyAuthenticationFilter.class);
+    private static final String API_KEY_HEADER = "X-API-Key";
+
+    private final byte[] validApiKey;
+
+    public ApiKeyAuthenticationFilter(@Value("${api.key.secret:}") String validApiKey) {
+        if (StringUtils.hasText(validApiKey)) {
+            this.validApiKey = validApiKey.getBytes(StandardCharsets.UTF_8);
+        } else {
+            logger.warn("API key secret is not configured. Protected endpoints will return 401. Set 'api.key.secret' property to enable authentication.");
+            this.validApiKey = new byte[0];
+        }
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                   HttpServletResponse response,
+                                   FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String providedKey = request.getHeader(API_KEY_HEADER);
+
+        if (StringUtils.hasText(providedKey) && isValidKey(providedKey)) {
+            // Valid API key - set authentication
+            UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken("api-client", null,
+                    Collections.singletonList(new SimpleGrantedAuthority("ROLE_API_CLIENT")));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private boolean isValidKey(String providedKey) {
+        if (this.validApiKey.length == 0) {
+            return false; // Not configured
+        }
+        byte[] providedBytes = providedKey.getBytes(StandardCharsets.UTF_8);
+        return MessageDigest.isEqual(this.validApiKey, providedBytes);
+    }
+
+}

--- a/src/main/java/uk/gov/legislation/security/SecurityConfiguration.java
+++ b/src/main/java/uk/gov/legislation/security/SecurityConfiguration.java
@@ -1,0 +1,44 @@
+package uk.gov.legislation.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfiguration {
+
+    private final ApiKeyAuthenticationFilter filter;
+
+    public SecurityConfiguration(ApiKeyAuthenticationFilter filter) {
+        this.filter = filter;
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(AbstractHttpConfigurer::disable)
+            .formLogin(AbstractHttpConfigurer::disable)
+            .httpBasic(AbstractHttpConfigurer::disable)
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers(HttpMethod.OPTIONS, "/contact/**").permitAll()
+                .requestMatchers("/contact/**").authenticated()
+                .anyRequest().permitAll()
+            )
+            .exceptionHandling(exception -> exception
+                .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
+            )
+            .addFilterBefore(filter, UsernamePasswordAuthenticationFilter.class)
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+        return http.build();
+    }
+
+}

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -7,5 +7,7 @@ VIRTUOSO_HOST=localhost
 VIRTUOSO_PORT=0
 DEFRALEX_PORT=0
 
+api.key.secret=test-api-key-12345
+
 # Disable AWS Parameter Store auto-configuration during tests
 spring.cloud.aws.parameterstore.enabled=false

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -6,7 +6,7 @@
     <meta name="description" content="" />
     <title>specification</title>
     <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.20.1/swagger-ui.css" />
-    <style> .scheme-container { display: none } </style>
+    <style> .scheme-container { padding-top: 0 !important } .schemes-server-container > div { display: none } </style>
 </head>
 <body>
 <div id="swagger-ui"></div>

--- a/src/test/java/uk/gov/legislation/api/test/WelshContentsTest.java
+++ b/src/test/java/uk/gov/legislation/api/test/WelshContentsTest.java
@@ -2,6 +2,7 @@ package uk.gov.legislation.api.test;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
@@ -25,6 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(ContentsController.class)
 @Import({ Transforms.class, Clml2Akn.class, Akn2Html.class, Simplify.class, Clml2Docx.class})
+@AutoConfigureMockMvc(addFilters = false)
 class WelshContentsTest {
 
     @Autowired

--- a/src/test/java/uk/gov/legislation/api/test/WelshDocumentTest.java
+++ b/src/test/java/uk/gov/legislation/api/test/WelshDocumentTest.java
@@ -2,6 +2,7 @@ package uk.gov.legislation.api.test;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
@@ -25,6 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(DocumentController.class)
 @Import({ Transforms.class, Clml2Akn.class, Akn2Html.class, Simplify.class, Clml2Docx.class})
+@AutoConfigureMockMvc(addFilters = false)
 class WelshDocumentTest {
 
     @Autowired

--- a/src/test/java/uk/gov/legislation/api/test/WelshFragmentTest.java
+++ b/src/test/java/uk/gov/legislation/api/test/WelshFragmentTest.java
@@ -2,6 +2,7 @@ package uk.gov.legislation.api.test;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
@@ -25,6 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(FragmentController.class)
 @Import({ Transforms.class, Clml2Akn.class, Akn2Html.class, Simplify.class, Clml2Docx.class})
+@AutoConfigureMockMvc(addFilters = false)
 class WelshFragmentTest {
 
     @Autowired

--- a/src/test/java/uk/gov/legislation/endpoints/contact/ContactRequestValidationTest.java
+++ b/src/test/java/uk/gov/legislation/endpoints/contact/ContactRequestValidationTest.java
@@ -1,0 +1,85 @@
+package uk.gov.legislation.endpoints.contact;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Tests that validation annotations on the ContactRequest record work correctly.
+ * Verifies that Spring Boot's Bean Validation properly handles record components.
+ */
+@WebMvcTest(ContactController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ContactRequestValidationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void rejectsRequestWhenFullNameMissing() throws Exception {
+        mockMvc.perform(post("/contact/tso")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"email\":\"test@example.com\",\"address\":\"123 Main St\"}"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.error").value("Validation Failed"))
+            .andExpect(jsonPath("$.message").value("Request validation failed for 1 field(s)"))
+            .andExpect(jsonPath("$.timestamp").exists())
+            .andExpect(jsonPath("$.errors.fullName").value("Full name is required"));
+    }
+
+    @Test
+    void rejectsRequestWhenEmailMissing() throws Exception {
+        mockMvc.perform(post("/contact/tso")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"fullName\":\"Test User\",\"address\":\"123 Main St\"}"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.error").value("Validation Failed"))
+            .andExpect(jsonPath("$.message").value("Request validation failed for 1 field(s)"))
+            .andExpect(jsonPath("$.timestamp").exists())
+            .andExpect(jsonPath("$.errors.email").value("Email address is required"));
+    }
+
+    @Test
+    void rejectsRequestWhenEmailInvalid() throws Exception {
+        mockMvc.perform(post("/contact/tso")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"fullName\":\"Test\",\"email\":\"not-an-email\",\"address\":\"123 Main St\"}"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.error").value("Validation Failed"))
+            .andExpect(jsonPath("$.message").value("Request validation failed for 1 field(s)"))
+            .andExpect(jsonPath("$.timestamp").exists())
+            .andExpect(jsonPath("$.errors.email").value("Email address must be valid"));
+    }
+
+    @Test
+    void rejectsRequestWhenAddressMissing() throws Exception {
+        mockMvc.perform(post("/contact/tso")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"fullName\":\"Test\",\"email\":\"test@example.com\"}"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.error").value("Validation Failed"))
+            .andExpect(jsonPath("$.message").value("Request validation failed for 1 field(s)"))
+            .andExpect(jsonPath("$.timestamp").exists())
+            .andExpect(jsonPath("$.errors.address").value("Address is required"));
+    }
+
+    @Test
+    void acceptsValidRequest() throws Exception {
+        mockMvc.perform(post("/contact/tso")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"fullName\":\"Test User\",\"email\":\"test@example.com\",\"address\":\"123 Main St\"}"))
+            .andExpect(status().isNotImplemented()); // Controller returns 501
+    }
+
+}

--- a/src/test/java/uk/gov/legislation/endpoints/fragment/FragmentControllerTest.java
+++ b/src/test/java/uk/gov/legislation/endpoints/fragment/FragmentControllerTest.java
@@ -22,7 +22,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(FragmentController.class)
-@AutoConfigureMockMvc
+@AutoConfigureMockMvc(addFilters = false)
 class FragmentControllerTest {
 
     @Autowired

--- a/src/test/java/uk/gov/legislation/security/ApiKeyAuthenticationFilterTest.java
+++ b/src/test/java/uk/gov/legislation/security/ApiKeyAuthenticationFilterTest.java
@@ -1,0 +1,106 @@
+package uk.gov.legislation.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for ApiKeyAuthenticationFilter.
+ * Tests that the filter correctly sets authentication in the SecurityContext
+ * when a valid API key is provided.
+ */
+class ApiKeyAuthenticationFilterTest {
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void setsAuthenticationWhenValidKeyProvided() throws ServletException, IOException {
+        ApiKeyAuthenticationFilter filter = new ApiKeyAuthenticationFilter("test-secret-key");
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/contact/tso");
+        request.addHeader("X-API-Key", "test-secret-key");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilterInternal(request, response, chain);
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(auth).isNotNull();
+        assertThat(auth.getName()).isEqualTo("api-client");
+        assertThat(auth.getAuthorities()).hasSize(1);
+        assertThat(auth.getAuthorities().iterator().next().getAuthority()).isEqualTo("ROLE_API_CLIENT");
+        verify(chain).doFilter(request, response);
+    }
+
+    @Test
+    void doesNotSetAuthenticationWhenKeyMissing() throws ServletException, IOException {
+        ApiKeyAuthenticationFilter filter = new ApiKeyAuthenticationFilter("test-secret-key");
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/contact/tso");
+        // No X-API-Key header
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilterInternal(request, response, chain);
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(auth).isNull();
+        verify(chain).doFilter(request, response);
+    }
+
+    @Test
+    void doesNotSetAuthenticationWhenKeyIncorrect() throws ServletException, IOException {
+        ApiKeyAuthenticationFilter filter = new ApiKeyAuthenticationFilter("test-secret-key");
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/contact/tso");
+        request.addHeader("X-API-Key", "wrong-key");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilterInternal(request, response, chain);
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(auth).isNull();
+        verify(chain).doFilter(request, response);
+    }
+
+    @Test
+    void doesNotSetAuthenticationWhenKeyNotConfigured() throws ServletException, IOException {
+        ApiKeyAuthenticationFilter filter = new ApiKeyAuthenticationFilter(""); // Empty config
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/contact/tso");
+        request.addHeader("X-API-Key", "some-key");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilterInternal(request, response, chain);
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(auth).isNull();
+        verify(chain).doFilter(request, response);
+    }
+
+    @Test
+    void alwaysInvokesFilterChainRegardlessOfKey() throws ServletException, IOException {
+        ApiKeyAuthenticationFilter filter = new ApiKeyAuthenticationFilter("test-secret-key");
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/documents/ukpga");
+        // No API key for public endpoint
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilterInternal(request, response, chain);
+
+        // Filter is passive - always continues the chain
+        verify(chain).doFilter(request, response);
+    }
+}

--- a/src/test/java/uk/gov/legislation/security/SecurityConfigIntegrationTest.java
+++ b/src/test/java/uk/gov/legislation/security/SecurityConfigIntegrationTest.java
@@ -1,0 +1,66 @@
+package uk.gov.legislation.security;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration tests for Spring Security configuration.
+ * Tests the full authentication/authorization chain including filter and SecurityConfig.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+class SecurityConfigIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void protectedEndpointReturns401WithoutApiKey() throws Exception {
+        mockMvc.perform(post("/contact/tso")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"fullName\":\"Test\",\"email\":\"test@example.com\",\"address\":\"123 Main St\"}"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void protectedEndpointReturns401WithInvalidApiKey() throws Exception {
+        mockMvc.perform(post("/contact/tso")
+                .header("X-API-Key", "wrong-key")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"fullName\":\"Test\",\"email\":\"test@example.com\",\"address\":\"123 Main St\"}"))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void protectedEndpointAllowsRequestWithValidApiKey() throws Exception {
+        // Note: This uses the api.key.secret from application-test.properties
+        mockMvc.perform(post("/contact/tso")
+                .header("X-API-Key", "test-api-key-12345")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"fullName\":\"Test\",\"email\":\"test@example.com\",\"address\":\"123 Main St\"}"))
+            .andExpect(status().isNotImplemented()); // Controller throws NOT_IMPLEMENTED
+    }
+
+    @Test
+    void publicEndpointAllowsRequestWithoutApiKey() throws Exception {
+        // Public endpoints should work without API key
+        mockMvc.perform(get("/types"))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    void publicEndpointAllowsRequestWithApiKey() throws Exception {
+        // Public endpoints should also work WITH API key (filter is passive)
+        mockMvc.perform(get("/types")
+                .header("X-API-Key", "test-api-key-12345"))
+            .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
Implement stateless API key authentication using Spring Security to protect server-to-server endpoints (initially /contact/tso for TSO email sending). All other endpoints remain public and unauthenticated.

Authentication uses X-API-Key header with constant-time comparison to prevent timing attacks. Graceful degradation: if API key not configured, filter logs warning and protected endpoints return 401 (fail closed), while public API remains operational. CORS pre-flight requests explicitly permitted to support potential browser clients.

  Key Components:
  - ApiKeyAuthenticationFilter: Validates API key and sets authentication context
  - SecurityConfiguration: Defines authorization rules (OPTIONS + /contact/** protected)
  - ContactController: Protected endpoint with request validation
  - ContactRequest: Java record DTO with Bean Validation annotations
  - ValidationErrorResponse: Extends ErrorResponse for consistent error format
  - GlobalExceptionHandler: Handles validation errors with field-level details

  Testing:
  - Unit tests for filter logic (5 tests)
  - Integration tests for security configuration (5 tests)
  - Validation tests for request DTO (5 tests)
  - Updated 4 existing @WebMvcTest classes to disable security filters
  - All 248 tests passing

  Configuration:
  - Production: AWS Parameter Store /lgu2/api/API_KEY_SECRET
  - Test: application-test.properties with test key
  - Django: Receives secret via environment variable

  Design rationale:
  - Graceful degradation chosen over fail-fast because API is 99% public
  - Missing auth config doesn't break document serving (TNA's core mission)
  - Protected endpoint correctly returns 401 without key (fail closed security)
  - Warning log makes missing config visible during development/testing