### PR TITLE
Stabilize metadata versions and surface canonical fragment links

### DIFF
--- a/docs/notes/2025-10-16-metadata-versioning-problem.md
+++ b/docs/notes/2025-10-16-metadata-versioning-problem.md
@@ -1,0 +1,48 @@
+# Metadata Version Logic – Problem Statement
+
+This note explains how MarkLogic’s `legislation.xq` pipeline emits version
+metadata (via Atom `hasVersion` links and fragment attributes) and how the
+`uk.gov.legislation.transform.simple.Metadata` class interprets it. Future
+changes to either the XQuery or the Java logic should revisit these assumptions.
+
+## Context
+- Source metadata comes from Atom feeds that describe legislation XML snapshots. Each snapshot may include multiple `<atom:link rel="http://purl.org/dc/terms/hasVersion">` entries whose `@title` values we ingest verbatim.
+- The feeds are inconsistent: early versions often list only `"current"` alongside the snapshot being fetched, while revised documents may include a full history of ISO-dated revisions mixed with human labels such as `"enacted"` or `"made"`.
+- Downstream consumers need two derived views:
+  1. `version()` – a single label representing the version that the current XML payload describes.
+  2. `versions()` – an ordered set of all meaningful version labels (initial label, dated revisions, “prospective” etc.) suitable for UI widgets.
+
+## Observed Challenges
+- **Ambiguous “current” links.** `"current"` may point to an actual dated revision or stand in for “prospective” when no dated revisions exist yet. The feed does not tell us which meaning applies.
+- **Sparse initial releases.** First-publication XML sometimes lacks any dated entries beyond `"current"`, so we must infer the existence of a prospective version without explicit evidence.
+- **Mixed labels and dates.** The feed can contain both natural-language labels and ISO dates. Ordering and deduplication must be stable so clients see predictable sequences.
+- **Fragment snapshots lagging behind parent documents.** For sections or sub-sections, the `dct:valid` date can be newer than any explicit version label because other parts of the document have been amended. We need to detect that anomaly and surface the latest actual change instead of the theoretical document-level valid date.
+- **Prospective detection.** Only the first descendant node within `<descendants>` carries the status flag relevant to the current snippet. We have to treat that as authoritative while ignoring the rest.
+
+## Desired Behaviour
+1. **Single version label (`version()`).**
+   - Return the document-type-specific first label (`enacted`, `made`, …) when the snapshot is the initial publication (`dct:valid` missing).
+   - Return `"prospective"` when the active node is marked `Status="Prospective"` and no dated history exists.
+   - Otherwise return the best-known ISO date: prefer the latest dated entry in `versions()` unless it is younger than the fragment’s own `dct:valid`, in which case fall back to the fragment’s `dct:valid`.
+2. **Complete ordered set (`versions()`).**
+   - Start from the raw titles, remove `"current"`, normalise `"… repealed"` suffixes, and sort by the existing comparator (initial labels → dates → `"prospective"`).
+   - Inject the first-version label for `status="final"` payloads so clients always see it.
+   - For revised material, add the authoritative `dct:valid` date back in (unless we already resolved to `"prospective"`), ensuring the active snapshot appears exactly once.
+   - Append `"prospective"` when `version()` resolves to that label, guaranteeing consistency between the scalar and the collection.
+
+## What the MarkLogic XQuery Actually Emits
+- The authoritative feed is built in `src/legislation/queries/legislation.xq` (plus a condensed variant in `large-data.xq`). The `<atom:link rel="…hasVersion">` entries come from the block starting near line 1120.
+- `utils:find-valid-dates-lang` always yields the first-version label for “final” material by calling `utils:enacted` in `utils.xq`. The XQuery deliberately suppresses that label when the request already targets `/enacted`, `/made`, etc. (`not($version = $utils:inforceStrings)`), so the feed for the first version does **not** repeat its own label.
+- `"current"` is appended only when `$version` is a dated revision *and* there are any dated values in the index. If there are no dated entries but a prospective snapshot exists, the same slot is filled with `"prospective"` instead.
+- Fragment-level dates (`@ValidDates`, `search:get-alt-dates`) flow into `$altDates`. The loop that writes `<hasVersion>` links iterates over those values, normalises `"current"` to the empty string in the URI, and appends `" repealed"` when the date falls beyond the last active `RestrictEndDate`.
+- Welsh items clone the entire link set per language when the alternate fragment is available (see lines 1230–1274). The large-document export path mirrors the same logic at `large-data.xq:398-406`.
+- The feed treats in-force versus revised material as two distinct universes. A document can have only the first version (no revised collection) or only revisions (no final collection), and the XQuery adjusts the link set accordingly.
+
+## Updated Questions / Follow-ups
+- Given the explicit suppression of first-version labels in the `/enacted` responses, we should keep reinjecting that label in `versions()` for `status="final"` payloads. No further feed samples are needed to prove the gap.
+- Still worth considering whether we should record how `"prospective"` was inferred (explicit vs. fallback) for analytics/debugging.
+- If descendant status becomes unreliable, revisiting the transformation to capture it earlier might simplify the Java-side heuristics.
+
+This note captures both the downstream requirements and the upstream feed behaviour so future changes can revisit the assumptions with concrete data.
+
+run `codex resume 0199ee4b-2729-7ab1-bace-c0b02b96db07`

--- a/src/main/java/uk/gov/legislation/api/responses/LabelledLink.java
+++ b/src/main/java/uk/gov/legislation/api/responses/LabelledLink.java
@@ -14,7 +14,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
  */
 public class LabelledLink {
 
-    @Schema(example = "ukpga/2000/8/section/91", description = "Target fragment path (short form)")
+    @Schema(example = "section/91", description = "Target fragment path relative to the document root")
     public String href;
 
     @Schema(

--- a/src/main/java/uk/gov/legislation/api/responses/Level.java
+++ b/src/main/java/uk/gov/legislation/api/responses/Level.java
@@ -10,10 +10,10 @@ public class Level {
     @Schema(example = "P1")
     public String element;
 
-    @Schema(example = "section-91")
+    @Schema(example = "crossheading-final-provisions")
     public String id;
 
-    @Schema(example = "ukpga/2000/8/section/91")
+    @Schema(example = "crossheading/final-provisions")
     public String href;
 
     @Schema(example = "91")

--- a/src/main/java/uk/gov/legislation/api/responses/Level.java
+++ b/src/main/java/uk/gov/legislation/api/responses/Level.java
@@ -1,6 +1,9 @@
 package uk.gov.legislation.api.responses;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
 
 public class Level {
 
@@ -21,5 +24,14 @@ public class Level {
 
     @Schema(example = "Section 91")
     public String label;
+
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    public boolean prospective;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public LocalDate start;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public LocalDate end;
 
 }

--- a/src/main/java/uk/gov/legislation/api/responses/TableOfContents.java
+++ b/src/main/java/uk/gov/legislation/api/responses/TableOfContents.java
@@ -66,8 +66,14 @@ public class TableOfContents {
         @Schema
         public String title;
 
-        @Schema(example = "section-1")
+        @Schema(example = "crossheading-final-provisions", deprecated = true, description = "use href")
         public String ref;
+
+        @Schema(example = "crossheading-final-provisions")
+        public String id;
+
+        @Schema(example = "crossheading/final-provisions")
+        public String href;
 
         @JsonProperty
         public Set<Extent> extent;

--- a/src/main/java/uk/gov/legislation/converters/FragmentMetadataConverter.java
+++ b/src/main/java/uk/gov/legislation/converters/FragmentMetadataConverter.java
@@ -32,7 +32,7 @@ public class FragmentMetadataConverter {
         converted.next = simple.next();
         if (simple.prevUri != null) {
             converted.prevInfo = new LabelledLink();
-            converted.prevInfo.href = Links.shorten(simple.prevUri.toString());
+            converted.prevInfo.href = Links.extractFragmentIdentifierFromLink(simple.prevUri);
             if (simple.prevTitle != null) {
                 // Split Atom link/@title on ';' and use the first component; see LabelledLink.
                 String[] titleParts = simple.prevTitle.split(";", 2);
@@ -42,7 +42,7 @@ public class FragmentMetadataConverter {
         }
         if (simple.nextUri != null) {
             converted.nextInfo = new LabelledLink();
-            converted.nextInfo.href = Links.shorten(simple.nextUri.toString());
+            converted.nextInfo.href = Links.extractFragmentIdentifierFromLink(simple.nextUri);
             if (simple.nextTitle != null) {
                 // Same as prev; see LabelledLink.
                 String[] titleParts = simple.nextTitle.split(";", 2);

--- a/src/main/java/uk/gov/legislation/converters/TableOfContentsConverter.java
+++ b/src/main/java/uk/gov/legislation/converters/TableOfContentsConverter.java
@@ -3,6 +3,7 @@ package uk.gov.legislation.converters;
 import uk.gov.legislation.api.responses.TableOfContents;
 import uk.gov.legislation.transform.simple.Contents;
 import uk.gov.legislation.util.Extent;
+import uk.gov.legislation.util.Links;
 
 import java.util.EnumSet;
 import java.util.List;
@@ -58,6 +59,8 @@ public class TableOfContentsConverter {
         converted.number = item.number;
         converted.title = item.title;
         converted.ref = item.ref;
+        converted.id = item.ref;
+        converted.href = Links.extractFragmentIdentifierFromLink(item.uri);
         converted.extent = ExtentConverter.convert(item.extent);
         converted.children = convertItems(item.children);
         return converted;

--- a/src/main/java/uk/gov/legislation/transform/simple/Contents.java
+++ b/src/main/java/uk/gov/legislation/transform/simple/Contents.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
+import java.net.URI;
 import java.util.List;
 
 @JacksonXmlRootElement()
@@ -52,7 +53,11 @@ public class Contents {
 
         public String title;
 
+        @JacksonXmlProperty(localName = "ContentRef", isAttribute = true)
         public String ref;
+
+        @JacksonXmlProperty(localName = "DocumentURI", isAttribute = true)
+        public URI uri;
 
         @JacksonXmlProperty(isAttribute = true)
         public String extent;

--- a/src/main/java/uk/gov/legislation/transform/simple/Level.java
+++ b/src/main/java/uk/gov/legislation/transform/simple/Level.java
@@ -41,7 +41,7 @@ public class Level {
         uk.gov.legislation.api.responses.Level other = new uk.gov.legislation.api.responses.Level();
         other.element = this.name;
         other.id = this.id;
-        other.href = Links.shorten(uri);
+        other.href = Links.extractFragmentIdentifierFromLink(uri);
         other.number = this.number;
         other.title = this.title;
         other.label = Labels.make(this);

--- a/src/main/java/uk/gov/legislation/transform/simple/Level.java
+++ b/src/main/java/uk/gov/legislation/transform/simple/Level.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import uk.gov.legislation.util.Labels;
 import uk.gov.legislation.util.Links;
 
+import java.time.LocalDate;
+
 public class Level {
 
     @JacksonXmlProperty(isAttribute = true)
@@ -15,6 +17,16 @@ public class Level {
     @JacksonXmlProperty(localName = "DocumentURI", isAttribute = true)
     public String uri;
 
+    @JacksonXmlProperty(localName = "Status", isAttribute = true)
+    // Prospective, Dead, Discarded, Repealed
+    public String status;
+
+    @JacksonXmlProperty(localName = "RestrictStartDate", isAttribute = true)
+    public LocalDate start;
+
+    @JacksonXmlProperty(localName = "RestrictEndDate", isAttribute = true)
+    public LocalDate end;
+
     @JacksonXmlProperty
     public String number;
 
@@ -22,6 +34,8 @@ public class Level {
     public String title;
 
     /* conversion */
+
+    /* mabye this should be moved to the .converters package? */
 
     uk.gov.legislation.api.responses.Level convert() {
         uk.gov.legislation.api.responses.Level other = new uk.gov.legislation.api.responses.Level();
@@ -31,6 +45,9 @@ public class Level {
         other.number = this.number;
         other.title = this.title;
         other.label = Labels.make(this);
+        other.prospective = "Prospective".equals(this.status);
+        other.start = this.start;
+        other.end = this.end;
         return other;
     }
 

--- a/src/main/java/uk/gov/legislation/util/Links.java
+++ b/src/main/java/uk/gov/legislation/util/Links.java
@@ -113,7 +113,6 @@ public class Links {
         return builder.toString();
     }
 
-    // FixMe should return Optional<String>
     public static String extractFragmentIdentifierFromLink(String link) {
         Components components = parse(link);
         if (components == null)

--- a/src/main/java/uk/gov/legislation/util/Links.java
+++ b/src/main/java/uk/gov/legislation/util/Links.java
@@ -1,5 +1,6 @@
 package uk.gov.legislation.util;
 
+import java.net.URI;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -118,6 +119,12 @@ public class Links {
         if (components == null)
             return null;
         return components.fragment().orElse(null);
+    }
+
+    public static String extractFragmentIdentifierFromLink(URI link) {
+        if (link == null)
+            return null;
+        return extractFragmentIdentifierFromLink(link.toASCIIString());
     }
 
 }

--- a/src/main/resources/transforms/simplify/metadata.xsl
+++ b/src/main/resources/transforms/simplify/metadata.xsl
@@ -325,6 +325,8 @@
         <xsl:attribute name="name" select="local-name(.)" />
         <xsl:copy-of select="@id" />
         <xsl:copy-of select="@DocumentURI" />
+        <xsl:copy-of select="@Status | self::P1/parent::P1group/@Status" />
+        <xsl:copy-of select="@RestrictStartDate | @RestrictEndDate" />
         <xsl:apply-templates select="Number | Pnumber" mode="simplify-number" />
         <xsl:apply-templates select="child::Title | self::P1/parent::P1group/Title" mode="simplify-title" />
     </xsl:element>

--- a/src/main/resources/transforms/simplify/toc.xsl
+++ b/src/main/resources/transforms/simplify/toc.xsl
@@ -29,7 +29,8 @@
             <xsl:variable name="name" select="lower-case($name)" />
             <xsl:sequence select="$name" />
         </xsl:attribute>
-        <xsl:call-template name="ref" />
+        <xsl:copy-of select="@ContentRef" />
+        <xsl:copy-of select="@DocumentURI" />
         <xsl:call-template name="toc-extent" />
         <xsl:apply-templates />
     </item>
@@ -37,7 +38,8 @@
 
 <xsl:template match="ContentsAppendix">
     <appendix name="appendix">
-        <xsl:call-template name="ref" />
+        <xsl:copy-of select="@ContentRef" />
+        <xsl:copy-of select="@DocumentURI" />
         <xsl:call-template name="toc-extent" />
         <xsl:apply-templates />
     </appendix>
@@ -52,7 +54,8 @@
 
 <xsl:template match="ContentsSchedule">
     <schedule name="schedule">
-        <xsl:call-template name="ref" />
+        <xsl:copy-of select="@ContentRef" />
+        <xsl:copy-of select="@DocumentURI" />
         <xsl:call-template name="toc-extent" />
         <xsl:apply-templates />
     </schedule>
@@ -73,16 +76,11 @@
 <xsl:template match="ContentsAttachment">
     <xsl:element name="{ if (exists(../following-sibling::ContentsSchedules)) then 'attachment1' else 'attachment' }">
         <xsl:attribute name="name">attachment</xsl:attribute>
-        <xsl:call-template name="ref" />
+        <xsl:copy-of select="@ContentRef" />
+        <xsl:copy-of select="@DocumentURI" />
         <xsl:call-template name="toc-extent" />
         <xsl:apply-templates />
     </xsl:element>
-</xsl:template>
-
-<xsl:template name="ref">
-    <xsl:attribute name="ref">
-        <xsl:sequence select="@ContentRef" />
-    </xsl:attribute>
 </xsl:template>
 
 <xsl:template name="toc-extent">

--- a/src/test/java/uk/gov/legislation/api/test/FragmentIdentifierExtractionTest.java
+++ b/src/test/java/uk/gov/legislation/api/test/FragmentIdentifierExtractionTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import uk.gov.legislation.util.Links;
 
+import java.net.URI;
+
 class FragmentIdentifierExtractionTest {
 
     @Test
@@ -22,5 +24,22 @@ class FragmentIdentifierExtractionTest {
 		Assertions.assertEquals("section/1", fragment);
 
 	}
+
+    @Test
+    void crossheadingIdentifiersRemainIntact() {
+        // crossheading fragments with multi-word titles must preserve dashes
+        // (e.g., "final-provisions" not "final/provisions").
+        String link = "http://www.legislation.gov.uk/ukpga/2023/29/part/1/chapter/2/crossheading/final-provisions";
+        Assertions.assertEquals(
+            "part/1/chapter/2/crossheading/final-provisions",
+            Links.extractFragmentIdentifierFromLink(link)
+        );
+
+        URI uri = URI.create(link);
+        Assertions.assertEquals(
+            "part/1/chapter/2/crossheading/final-provisions",
+            Links.extractFragmentIdentifierFromLink(uri)
+        );
+    }
 
 }

--- a/src/test/java/uk/gov/legislation/api/test/UnappliedEffectsHelper.java
+++ b/src/test/java/uk/gov/legislation/api/test/UnappliedEffectsHelper.java
@@ -2,9 +2,12 @@ package uk.gov.legislation.api.test;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Objects;
 
 public class UnappliedEffectsHelper {
+
     static String read(String resource) throws IOException {
         String content;
         try (var input = TransformTest.class.getResourceAsStream(resource)) {
@@ -24,4 +27,15 @@ public class UnappliedEffectsHelper {
         String resource = makeResourceName(id, ext);
         return read(resource);
     }
+
+    static void write(String resource, String content) throws IOException {
+        Path path = Path.of("src/test/resources", resource.substring(1));
+        Files.writeString(path, content);
+    }
+
+    static void write(String id, String ext, String content) throws IOException {
+        String resource = makeResourceName(id, ext);
+        write(resource, content);
+    }
+
 }

--- a/src/test/java/uk/gov/legislation/api/test/UnappliedEffectsTest.java
+++ b/src/test/java/uk/gov/legislation/api/test/UnappliedEffectsTest.java
@@ -60,7 +60,7 @@ class UnappliedEffectsTest {
         Assertions.assertEquals(expected, actual);
     }
 
-    private String indent(String xml) throws TransformerException {
+    static String indent(String xml) throws TransformerException {
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
         Transformer transformer = transformerFactory.newTransformer();
         transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");

--- a/src/test/java/uk/gov/legislation/api/test/UnappliedEffectsTestRedo.java
+++ b/src/test/java/uk/gov/legislation/api/test/UnappliedEffectsTestRedo.java
@@ -1,0 +1,113 @@
+package uk.gov.legislation.api.test;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.context.ApplicationContext;
+import uk.gov.legislation.Application;
+import uk.gov.legislation.converters.EffectsFeedConverter;
+import uk.gov.legislation.transform.simple.Metadata;
+import uk.gov.legislation.transform.simple.Simplify;
+import uk.gov.legislation.transform.simple.effects.Effect;
+import uk.gov.legislation.util.Effects;
+import uk.gov.legislation.util.EffectsComparator;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static uk.gov.legislation.api.test.TransformTest.isFragment;
+import static uk.gov.legislation.api.test.UnappliedEffectsHelper.read;
+import static uk.gov.legislation.api.test.UnappliedEffectsHelper.write;
+import static uk.gov.legislation.api.test.UnappliedEffectsTest.indent;
+import static uk.gov.legislation.api.test.UnappliedEffectsTest.mapper;
+
+public class UnappliedEffectsTestRedo {
+
+    public static void main(String[] args) throws Exception {
+        ApplicationContext ctx = SpringApplication.run(Application.class, args);
+        for (String id : UnappliedEffectsTest.provide().toList()) {
+            simplify(ctx, id);
+            raw(ctx, id);
+            sorted(ctx, id);
+            filtered(ctx, id);
+            converted(ctx, id);
+        }
+        SpringApplication.exit(ctx);
+    }
+
+    static void simplify(ApplicationContext ctx, String id) throws Exception {
+        Simplify simplifier = ctx.getBean(Simplify.class);
+        String clml = read(id, ".xml");
+        Simplify.Parameters parameters = new Simplify.Parameters(isFragment(id), false);
+        String actual = indent(simplifier.transform(clml, parameters));
+        String ext = "-simplified.xml";
+        String expected = read(id, ext);
+        if (actual.equals(expected))
+            return;
+        System.out.println("redoing " + id);
+        write(id, ext, actual);
+    }
+
+    static void raw(ApplicationContext ctx, String id) throws Exception {
+        Simplify simplifier = ctx.getBean(Simplify.class);
+        String clml = read(id, ".xml");
+        Metadata meta = isFragment(id) ? simplifier.extractFragmentMetadata(clml) : simplifier.extractDocumentMetadata(clml);
+        String actual = mapper.writeValueAsString(meta.rawEffects);
+        String expected = read(id, "-effects-raw.json");
+        if (actual.equals(expected))
+            return;
+        System.out.println("redoing " + id);
+        write(id, "-effects-raw.json", actual);
+    }
+
+    static void sorted(ApplicationContext ctx, String id) throws Exception {
+        Simplify simplifier = ctx.getBean(Simplify.class);
+        String clml = read(id, ".xml");
+        Metadata meta = isFragment(id) ? simplifier.extractFragmentMetadata(clml) : simplifier.extractDocumentMetadata(clml);
+        List<Effect> effects = meta.rawEffects.stream().sorted(EffectsComparator.INSTANCE).toList();
+        String actual = mapper.writeValueAsString(effects);
+        String ext = "-effects-sorted.json";
+        String expected = read(id, ext);
+        if (actual.equals(expected))
+            return;
+        System.out.println("redoing " + id);
+        write(id, ext, actual);
+    }
+
+    static void filtered(ApplicationContext ctx, String id) throws Exception {
+        Simplify simplifier = ctx.getBean(Simplify.class);
+        String clml = read(id, ".xml");
+        Metadata meta;
+        List<uk.gov.legislation.transform.simple.effects.Effect> effects;
+        if (isFragment(id)) {
+            meta = simplifier.extractFragmentMetadata(clml);
+            Set<String> ids = meta.ancestors().stream().map(l -> l.id).collect(Collectors.toSet());
+            meta.descendants().stream().map(l -> l.id).forEach(ids::add);
+            effects = Effects.removeThoseWithNoRelevantSection(meta.rawEffects, ids, true);
+        } else {
+            meta = simplifier.extractDocumentMetadata(clml);
+            effects = meta.rawEffects;
+        }
+        String actual = mapper.writeValueAsString(effects);
+        String ext = "-effects-filtered.json";
+        String expected = read(id, ext);
+        if (actual.equals(expected))
+            return;
+        System.out.println("redoing " + id);
+        write(id, ext, actual);
+    }
+
+    static void converted(ApplicationContext ctx, String id) throws Exception {
+        Simplify simplifier = ctx.getBean(Simplify.class);
+        String clml = read(id, ".xml");
+        Metadata meta = isFragment(id) ? simplifier.extractFragmentMetadata(clml) : simplifier.extractDocumentMetadata(clml);
+        List<uk.gov.legislation.api.responses.Effect> effects = EffectsFeedConverter.convertEffects(meta.rawEffects);
+        String actual = mapper.writeValueAsString(effects);
+        String ext = "-effects-converted.json";
+        String expected = read(id, ext);
+        if (actual.equals(expected))
+            return;
+        System.out.println("redoing " + id);
+        write(id, ext, actual);
+    }
+
+}

--- a/src/test/java/uk/gov/legislation/api/test/UpToDateTestRedo.java
+++ b/src/test/java/uk/gov/legislation/api/test/UpToDateTestRedo.java
@@ -1,0 +1,37 @@
+package uk.gov.legislation.api.test;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.context.ApplicationContext;
+import uk.gov.legislation.Application;
+import uk.gov.legislation.api.responses.FragmentMetadata;
+import uk.gov.legislation.converters.FragmentMetadataConverter;
+import uk.gov.legislation.transform.simple.Metadata;
+import uk.gov.legislation.transform.simple.Simplify;
+
+import static uk.gov.legislation.api.test.UnappliedEffectsHelper.read;
+import static uk.gov.legislation.api.test.UnappliedEffectsHelper.write;
+import static uk.gov.legislation.api.test.UnappliedEffectsTest.mapper;
+import static uk.gov.legislation.api.test.UpToDateTest.provide;
+
+public class UpToDateTestRedo {
+
+    public static void main(String[] args) throws Exception {
+        ApplicationContext ctx = SpringApplication.run(Application.class, args);
+        Simplify simplifier = ctx.getBean(Simplify.class);
+        for (String id : provide().toList()) {
+            String resource = "/" + id.replace('/', '_') + "/clml.xml";
+            String clml = read(resource);
+            Metadata simple = simplifier.extractFragmentMetadata(clml);
+            FragmentMetadata meta = FragmentMetadataConverter.convert(simple);
+            String actual = mapper.writeValueAsString(meta);
+            String expectedResource = "/" + id.replace('/', '_') + "/meta.json";
+            String expected = read(expectedResource);
+            if (actual.equals(expected))
+                continue;
+            System.out.println("redoing " + id);
+            write(expectedResource, actual);
+        }
+        SpringApplication.exit(ctx);
+    }
+
+}

--- a/src/test/java/uk/gov/legislation/api/test/response/ExpectedWelshResponseDataCy.java
+++ b/src/test/java/uk/gov/legislation/api/test/response/ExpectedWelshResponseDataCy.java
@@ -120,7 +120,7 @@ public class ExpectedWelshResponseDataCy {
                           "fragmentInfo": {
                               "element": "P1",
                               "id": "regulation-2",
-                              "href": "wsi/2024/1002/regulation/2/made/welsh",
+                              "href": "regulation/2",
                               "number": "2",
                               "title": "Diwygio Rheoliadau Addysg (Cydlynu Trefniadau Derbyn Ysgolion a Diwygiadau Amrywiol) (Cymru) 2024",
                               "label": "Regulation 2"
@@ -129,7 +129,7 @@ public class ExpectedWelshResponseDataCy {
                               {
                                   "element": "P1",
                                   "id": "regulation-2",
-                                  "href": "wsi/2024/1002/regulation/2/made/welsh",
+                                  "href": "regulation/2",
                                   "number": "2",
                                   "title": "Diwygio Rheoliadau Addysg (Cydlynu Trefniadau Derbyn Ysgolion a Diwygiadau Amrywiol) (Cymru) 2024",
                                   "label": "Regulation 2"
@@ -139,7 +139,7 @@ public class ExpectedWelshResponseDataCy {
                               {
                                   "element": "P1",
                                   "id": "regulation-2",
-                                  "href": "wsi/2024/1002/regulation/2/made/welsh",
+                                  "href": "regulation/2",
                                   "number": "2",
                                   "title": "Diwygio Rheoliadau Addysg (Cydlynu Trefniadau Derbyn Ysgolion a Diwygiadau Amrywiol) (Cymru) 2024",
                                   "label": "Regulation 2"
@@ -147,7 +147,7 @@ public class ExpectedWelshResponseDataCy {
                               {
                                   "element": "P2",
                                   "id": "regulation-2-1",
-                                  "href": "wsi/2024/1002/regulation/2/1/made/welsh",
+                                  "href": "regulation/2/1",
                                   "number": "1",
                                   "title": null,
                                   "label": "P2"
@@ -155,7 +155,7 @@ public class ExpectedWelshResponseDataCy {
                               {
                                   "element": "P2",
                                   "id": "regulation-2-2",
-                                  "href": "wsi/2024/1002/regulation/2/2/made/welsh",
+                                  "href": "regulation/2/2",
                                   "number": "2",
                                   "title": null,
                                   "label": "P2"
@@ -163,7 +163,7 @@ public class ExpectedWelshResponseDataCy {
                               {
                                   "element": "P3",
                                   "id": "regulation-2-2-a",
-                                  "href": "wsi/2024/1002/regulation/2/2/a/made/welsh",
+                                  "href": "regulation/2/2/a",
                                   "number": "a",
                                   "title": null,
                                   "label": "P3"
@@ -171,7 +171,7 @@ public class ExpectedWelshResponseDataCy {
                               {
                                   "element": "P3",
                                   "id": "regulation-2-2-b",
-                                  "href": "wsi/2024/1002/regulation/2/2/b/made/welsh",
+                                  "href": "regulation/2/2/b",
                                   "number": "b",
                                   "title": null,
                                   "label": "P3"
@@ -179,7 +179,7 @@ public class ExpectedWelshResponseDataCy {
                               {
                                   "element": "P2",
                                   "id": "regulation-2-3",
-                                  "href": "wsi/2024/1002/regulation/2/3/made/welsh",
+                                  "href": "regulation/2/3",
                                   "number": "3",
                                   "title": null,
                                   "label": "P2"

--- a/src/test/resources/aep_Ann_6_11/aep-Ann-6-11-contents-1991-02-01.json
+++ b/src/test/resources/aep_Ann_6_11/aep-Ann-6-11-contents-1991-02-01.json
@@ -38,6 +38,8 @@
       "number" : null,
       "title" : "Introductory Text",
       "ref" : "introduction",
+      "id" : null,
+      "href" : null,
       "extent" : [ "E", "W" ]
     },
     "body" : [ {
@@ -45,12 +47,16 @@
       "number" : "ARTICLE I.",
       "title" : null,
       "ref" : "part-1",
+      "id" : "part-1",
+      "href" : "part/1",
       "extent" : [ "E", "W" ],
       "children" : [ {
         "name" : "item",
         "number" : "",
         "title" : " The Kingdoms United;     Ensigns Armorial",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ ]
       } ]
     }, {
@@ -58,12 +64,16 @@
       "number" : "ARTICLE II.",
       "title" : null,
       "ref" : "part-2",
+      "id" : "part-2",
+      "href" : "part/2",
       "extent" : [ "E", "W" ],
       "children" : [ {
         "name" : "item",
         "number" : "",
         "title" : " Succession to the Monarchy.",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ ]
       } ]
     }, {
@@ -71,12 +81,16 @@
       "number" : "ARTICLE III.",
       "title" : null,
       "ref" : "part-3",
+      "id" : "part-3",
+      "href" : "part/3",
       "extent" : [ "E", "W" ],
       "children" : [ {
         "name" : "item",
         "number" : "",
         "title" : " Parliament.",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ ]
       } ]
     }, {
@@ -84,12 +98,16 @@
       "number" : "ARTICLE IIII.",
       "title" : null,
       "ref" : "part-4",
+      "id" : "part-4",
+      "href" : "part/4",
       "extent" : [ "E", "W" ],
       "children" : [ {
         "name" : "item",
         "number" : "",
         "title" : " Trade and Navigation and other Rights.",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ ]
       } ]
     }, {
@@ -97,12 +115,16 @@
       "number" : "ARTICLE V.",
       "title" : null,
       "ref" : "part-5",
+      "id" : "part-5",
+      "href" : "part/5",
       "extent" : [ "E", "W" ],
       "children" : [ {
         "name" : "item",
         "number" : "",
         "title" : ". . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ ]
       } ]
     }, {
@@ -110,12 +132,16 @@
       "number" : "ARTICLE VI.",
       "title" : null,
       "ref" : "part-6",
+      "id" : "part-6",
+      "href" : "part/6",
       "extent" : [ "E", "W" ],
       "children" : [ {
         "name" : "item",
         "number" : "",
         "title" : " Regulations of Trade, Duties, &c.",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ ]
       } ]
     }, {
@@ -123,12 +149,16 @@
       "number" : "ARTICLE VII.",
       "title" : null,
       "ref" : "part-7",
+      "id" : "part-7",
+      "href" : "part/7",
       "extent" : [ "E", "W" ],
       "children" : [ {
         "name" : "item",
         "number" : "",
         "title" : " Excise.",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ ]
       } ]
     }, {
@@ -136,12 +166,16 @@
       "number" : "ARTICLE VIII-XV.",
       "title" : null,
       "ref" : "part-8",
+      "id" : "part-8",
+      "href" : "part/8",
       "extent" : [ "E", "W" ],
       "children" : [ {
         "name" : "item",
         "number" : "",
         "title" : ". . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ ]
       } ]
     }, {
@@ -149,12 +183,16 @@
       "number" : "ARTICLE XVI.",
       "title" : null,
       "ref" : "part-9",
+      "id" : "part-9",
+      "href" : "part/9",
       "extent" : [ "E", "W" ],
       "children" : [ {
         "name" : "item",
         "number" : "",
         "title" : " Coin.",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ ]
       } ]
     }, {
@@ -162,12 +200,16 @@
       "number" : "ARTICLE XVII.",
       "title" : null,
       "ref" : "part-10",
+      "id" : "part-10",
+      "href" : "part/10",
       "extent" : [ "E", "W" ],
       "children" : [ {
         "name" : "item",
         "number" : "",
         "title" : ". . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ ]
       } ]
     }, {
@@ -175,12 +217,16 @@
       "number" : "ARTICLE XVIII.",
       "title" : null,
       "ref" : "part-11",
+      "id" : "part-11",
+      "href" : "part/11",
       "extent" : [ "E", "W" ],
       "children" : [ {
         "name" : "item",
         "number" : "",
         "title" : " Laws concerning public rights.     Private rights",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ ]
       } ]
     }, {
@@ -188,12 +234,16 @@
       "number" : "ARTICLE Xix.",
       "title" : null,
       "ref" : "part-12",
+      "id" : "part-12",
+      "href" : "part/12",
       "extent" : [ "E", "W" ],
       "children" : [ {
         "name" : "item",
         "number" : "",
         "title" : " Court of Session.     Writers to the Signet admitted Lords of Session.     Court of Justiciary.     Other Courts.     Causes in Scotland not cognizable in Courts in Westminster Hall.",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ ]
       } ]
     }, {
@@ -201,12 +251,16 @@
       "number" : "ARTICLE XX.",
       "title" : null,
       "ref" : "part-13",
+      "id" : "part-13",
+      "href" : "part/13",
       "extent" : [ "E", "W" ],
       "children" : [ {
         "name" : "item",
         "number" : "",
         "title" : " Heritable Offices, &c.",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ ]
       } ]
     }, {
@@ -214,12 +268,16 @@
       "number" : "ARTICLE XXI.",
       "title" : null,
       "ref" : "part-14",
+      "id" : "part-14",
+      "href" : "part/14",
       "extent" : [ "E", "W" ],
       "children" : [ {
         "name" : "item",
         "number" : "",
         "title" : " Royal Burghs.",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ ]
       } ]
     }, {
@@ -227,12 +285,16 @@
       "number" : "ARTICLE XXII.",
       "title" : null,
       "ref" : "part-15",
+      "id" : "part-15",
+      "href" : "part/15",
       "extent" : [ "E", "W" ],
       "children" : [ {
         "name" : "item",
         "number" : "",
         "title" : "Sixteen Peers of Scotland.",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ "E", "W" ]
       } ]
     }, {
@@ -240,12 +302,16 @@
       "number" : "ARTICLE XXIII.",
       "title" : null,
       "ref" : "part-16",
+      "id" : "part-16",
+      "href" : "part/16",
       "extent" : [ "E", "W" ],
       "children" : [ {
         "name" : "item",
         "number" : "",
         "title" : " Privileges of the Sixteen Peers of Scotland.",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ ]
       } ]
     }, {
@@ -253,12 +319,16 @@
       "number" : "ARTICLE XXIV.",
       "title" : null,
       "ref" : "part-17",
+      "id" : "part-17",
+      "href" : "part/17",
       "extent" : [ "E", "W" ],
       "children" : [ {
         "name" : "item",
         "number" : "",
         "title" : " Heraldry;     Great Seal;     Seal kept in Scotland;     Privy Seal, &c. in Scotland;     Regalia",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ ]
       } ]
     }, {
@@ -266,48 +336,64 @@
       "number" : "ARTICLE XXV.",
       "title" : null,
       "ref" : "part-18",
+      "id" : "part-18",
+      "href" : "part/18",
       "extent" : [ "E", "W" ],
       "children" : [ {
         "name" : "item",
         "number" : "",
         "title" : " Laws inconsistent with the Articles, void;",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ ]
       }, {
         "name" : "item",
         "number" : "II",
         "title" : "Acts of Scotland herein mentioned, confirmed;     Universities and colleges of Saint Andrew, Glasgow, Aberdeen and Edinburgh, to continue;     Subjects not liable to Oath, Test, or Subscription, inconsistant with the Presbyterian Church Government;     Successor to swear to maintain the said Settlement of Religion;     This Act to be held a fundamental Condition of Union, and to be inserted in any Act of Parliament for concluding the said Union;     This Ratification of the said Articles not binding until they are ratified by Parliament of England, &c.;     Laws contrary to Articles void.",
         "ref" : "section-II",
+        "id" : "section-II",
+        "href" : "section/II",
         "extent" : [ "E", "W" ]
       }, {
         "name" : "item",
         "number" : "III",
         "title" : "Cap. 8 ante.",
         "ref" : "section-III",
+        "id" : "section-III",
+        "href" : "section/III",
         "extent" : [ "E", "W" ]
       }, {
         "name" : "item",
         "number" : "IV",
         "title" : "The said Articles and Act of Parliament of Scotland confirmed;",
         "ref" : "section-IV",
+        "id" : "section-IV",
+        "href" : "section/IV",
         "extent" : [ "E", "W" ]
       }, {
         "name" : "item",
         "number" : "V",
         "title" : "Cap. 8 ante, and the said Act of Parliament of Scotland to be observed as fundamental Conditions of the said Union; and the said Articles and Acts of Parliament to continue the Union.",
         "ref" : "section-V",
+        "id" : "section-V",
+        "href" : "section/V",
         "extent" : [ "E", "W" ]
       }, {
         "name" : "item",
         "number" : "VI",
         "title" : " Recital of Act of Parliament of Scotland for settling Election of the Sixteen Peers and Forty-five Members for Scotland.",
         "ref" : "section-VI",
+        "id" : "section-VI",
+        "href" : "section/VI",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "VII",
         "title" : "The said Act declared valid as if it had been Part of the said Articles of Union",
         "ref" : "section-VII",
+        "id" : "section-VII",
+        "href" : "section/VII",
         "extent" : [ "E", "W" ]
       } ]
     } ]

--- a/src/test/resources/aep_Ann_6_11/aep-Ann-6-11-part-1-1991-02-01.json
+++ b/src/test/resources/aep_Ann_6_11/aep-Ann-6-11-part-1-1991-02-01.json
@@ -34,23 +34,23 @@
     "fragmentInfo" : {
       "element" : "Part",
       "id" : "part-1",
-      "href" : "aep/Ann/6/11/part/1/1991-02-01",
+      "href" : "part/1",
       "number" : "ARTICLE I.",
       "title" : null,
       "label" : "ARTICLE I."
     },
     "prevInfo" : {
-      "href" : "aep/Ann/6/11/introduction/1991-02-01",
+      "href" : "introduction",
       "label" : "Introduction"
     },
     "nextInfo" : {
-      "href" : "aep/Ann/6/11/part/2/1991-02-01",
+      "href" : "part/2",
       "label" : "Part"
     },
     "ancestors" : [ {
       "element" : "Part",
       "id" : "part-1",
-      "href" : "aep/Ann/6/11/part/1/1991-02-01",
+      "href" : "part/1",
       "number" : "ARTICLE I.",
       "title" : null,
       "label" : "ARTICLE I."
@@ -58,14 +58,14 @@
     "descendants" : [ {
       "element" : "Part",
       "id" : "part-1",
-      "href" : "aep/Ann/6/11/part/1/1991-02-01",
+      "href" : "part/1",
       "number" : "ARTICLE I.",
       "title" : null,
       "label" : "ARTICLE I."
     }, {
       "element" : "P1group",
       "id" : "section-wrapper1",
-      "href" : "aep/Ann/6/11/section/wrapper1/1991-02-01",
+      "href" : "section/wrapper1",
       "number" : null,
       "title" : "The Kingdoms United;     Ensigns Armorial",
       "label" : "P1group"

--- a/src/test/resources/aip_Geo3_40_38/aip-Geo3-40-38-contents-1991-02-01.json
+++ b/src/test/resources/aip_Geo3_40_38/aip-Geo3-40-38-contents-1991-02-01.json
@@ -38,31 +38,41 @@
       "number" : null,
       "title" : "Introductory Text",
       "ref" : "introduction",
+      "id" : null,
+      "href" : null,
       "extent" : [ "E", "W", "S", "NI" ]
     },
     "body" : [ {
       "name" : "item",
       "number" : "",
       "title" : "The parliaments of Great Britain and Ireland have resolved to concur in measures for uniting the two kingdoms:",
-      "ref" : "",
+      "ref" : null,
+      "id" : null,
+      "href" : null,
       "extent" : [ ]
     }, {
       "name" : "item",
       "number" : "[I.]",
       "title" : " said parliaments have agreed upon following articles:",
       "ref" : "section-I.",
+      "id" : "section-I.",
+      "href" : "section/I.",
       "extent" : [ "E", "W", "S", "NI" ]
     }, {
       "name" : "part",
       "number" : "Article First.",
       "title" : null,
       "ref" : "part-1",
+      "id" : "part-1",
+      "href" : "part/1",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "",
         "title" : "Great Britain and Ireland to be united for ever from 1 Jan. 1801.",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ ]
       } ]
     }, {
@@ -70,12 +80,16 @@
       "number" : "Article Second.",
       "title" : null,
       "ref" : "part-2",
+      "id" : "part-2",
+      "href" : "part/2",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "",
         "title" : "Succession to the crown to continue as at present.",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ ]
       } ]
     }, {
@@ -83,104 +97,138 @@
       "number" : "Article Third.",
       "title" : null,
       "ref" : "part-3",
+      "id" : "part-3",
+      "href" : "part/3",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "",
         "title" : "One parliament.",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ ]
       } ]
     }, {
       "name" : "item",
       "number" : "",
       "title" : ". . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . ",
-      "ref" : "",
+      "ref" : null,
+      "id" : null,
+      "href" : null,
       "extent" : [ ]
     }, {
       "name" : "part",
       "number" : "Article Fourth.",
       "title" : null,
       "ref" : "part-4",
+      "id" : "part-4",
+      "href" : "part/4",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "",
         "title" : "",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ ]
       } ]
     }, {
       "name" : "item",
       "number" : "",
       "title" : " The representation act shall be considered as part of the union.",
-      "ref" : "",
+      "ref" : null,
+      "id" : null,
+      "href" : null,
       "extent" : [ ]
     }, {
       "name" : "item",
       "number" : "",
       "title" : ". . . . . . . . . ....",
-      "ref" : "",
+      "ref" : null,
+      "id" : null,
+      "href" : null,
       "extent" : [ ]
     }, {
       "name" : "item",
       "number" : "",
       "title" : " Irish peers who are not elected to serve as peers, may serve as British commoners, during which time they cannot be elected to serve as peers.",
-      "ref" : "",
+      "ref" : null,
+      "id" : null,
+      "href" : null,
       "extent" : [ ]
     }, {
       "name" : "item",
       "number" : "",
       "title" : "Creation of Irish peers.",
-      "ref" : "",
+      "ref" : null,
+      "id" : null,
+      "href" : null,
       "extent" : [ ]
     }, {
       "name" : "item",
       "number" : "",
       "title" : " In what cases peerages may be deemed extinct.",
-      "ref" : "",
+      "ref" : null,
+      "id" : null,
+      "href" : null,
       "extent" : [ ]
     }, {
       "name" : "item",
       "number" : "",
       "title" : "How questions touching election of Irish commoners shall be decided.",
-      "ref" : "",
+      "ref" : null,
+      "id" : null,
+      "href" : null,
       "extent" : [ ]
     }, {
       "name" : "item",
       "number" : "",
       "title" : ". . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . ",
-      "ref" : "",
+      "ref" : null,
+      "id" : null,
+      "href" : null,
       "extent" : [ ]
     }, {
       "name" : "item",
       "number" : "",
       "title" : " How the parliament of the united kingdom shall be constituted.",
-      "ref" : "",
+      "ref" : null,
+      "id" : null,
+      "href" : null,
       "extent" : [ ]
     }, {
       "name" : "item",
       "number" : "",
       "title" : ". . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . ",
-      "ref" : "",
+      "ref" : null,
+      "id" : null,
+      "href" : null,
       "extent" : [ ]
     }, {
       "name" : "item",
       "number" : "",
       "title" : " Privileges, rights, ranks, and precedency of lords temporal in the imperial parliament.",
-      "ref" : "",
+      "ref" : null,
+      "id" : null,
+      "href" : null,
       "extent" : [ ]
     }, {
       "name" : "part",
       "number" : "Article Fifth.",
       "title" : null,
       "ref" : "part-5",
+      "id" : "part-5",
+      "href" : "part/5",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "",
         "title" : " Church of Scotland to continue as at present established.",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ ]
       } ]
     }, {
@@ -188,61 +236,81 @@
       "number" : "Article Sixth.",
       "title" : null,
       "ref" : "part-6",
+      "id" : "part-6",
+      "href" : "part/6",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "",
         "title" : "Subjects of Great Britain and Ireland to be on same footing from 1 Jan. 1801.",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ ]
       } ]
     }, {
       "name" : "item",
       "number" : "",
       "title" : " No duty or bounty on exportation of produce of one country to the other.",
-      "ref" : "",
+      "ref" : null,
+      "id" : null,
+      "href" : null,
       "extent" : [ ]
     }, {
       "name" : "item",
       "number" : "",
       "title" : " All articles the produce of either country shall be imported free from duty.",
-      "ref" : "",
+      "ref" : null,
+      "id" : null,
+      "href" : null,
       "extent" : [ ]
     }, {
       "name" : "item",
       "number" : "",
       "title" : ". . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . ",
-      "ref" : "",
+      "ref" : null,
+      "id" : null,
+      "href" : null,
       "extent" : [ ]
     }, {
       "name" : "item",
       "number" : "",
       "title" : " Produce of either country, subject to internal duty, shall on importation into each country be subject to countervailing duty.",
-      "ref" : "",
+      "ref" : null,
+      "id" : null,
+      "href" : null,
       "extent" : [ ]
     }, {
       "name" : "item",
       "number" : "",
       "title" : "Same charges on produce of either country exported through the other.",
-      "ref" : "",
+      "ref" : null,
+      "id" : null,
+      "href" : null,
       "extent" : [ ]
     }, {
       "name" : "item",
       "number" : "",
       "title" : ". . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . ",
-      "ref" : "",
+      "ref" : null,
+      "id" : null,
+      "href" : null,
       "extent" : [ ]
     }, {
       "name" : "part",
       "number" : "Article Seventh.",
       "title" : null,
       "ref" : "part-7",
+      "id" : "part-7",
+      "href" : "part/7",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "",
         "title" : ". . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . ",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ ]
       } ]
     }, {
@@ -250,67 +318,89 @@
       "number" : "Article Eighth.",
       "title" : null,
       "ref" : "part-8",
+      "id" : "part-8",
+      "href" : "part/8",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "",
         "title" : "All civil and ecclesiastical laws and courts shall remain as now established, subject to future alterations; court of admiralty in Ireland, with appeal to chancery in Ireland; all contrary laws repealed.",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ ]
       } ]
     }, {
       "name" : "item",
       "number" : "",
       "title" : " Said articles were approved of by his Majesty; said articles are hereby declared to be the articles of the union, and in force for ever from 1 January, 1801.",
-      "ref" : "",
+      "ref" : null,
+      "id" : null,
+      "href" : null,
       "extent" : [ ]
     }, {
       "name" : "item",
       "number" : "II",
       "title" : " Recital of the representation act passed this session:",
       "ref" : "section-II",
+      "id" : "section-II",
+      "href" : "section/II",
       "extent" : [ "E", "W", "S", "NI" ]
     }, {
       "name" : "item",
       "number" : "III",
       "title" : ". . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . ",
       "ref" : "section-III",
+      "id" : "section-III",
+      "href" : "section/III",
       "extent" : [ "E", "W", "S", "NI" ]
     }, {
       "name" : "item",
       "number" : "IV",
       "title" : " When vacancies happen in counties, cities, or boroughs new elections shall be held.",
       "ref" : "section-IV",
+      "id" : "section-IV",
+      "href" : "section/IV",
       "extent" : [ "E", "W", "S", "NI" ]
     }, {
       "name" : "item",
       "number" : "V",
       "title" : ". . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . ",
       "ref" : "section-V",
+      "id" : "section-V",
+      "href" : "section/V",
       "extent" : [ "E", "W", "S", "NI" ]
     }, {
       "name" : "item",
       "number" : "VI—VII",
       "title" : ". . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . ",
       "ref" : "section-VIVII.",
+      "id" : "section-VIVII.",
+      "href" : "section/VIVII.",
       "extent" : [ "E", "W", "S", "NI" ]
     }, {
       "name" : "item",
       "number" : "VIII",
       "title" : " When a new parliament of united kingdom shall be summoned, lord chan. shall cause writs to be issued, &c. and so on all vacancies in commons. ",
       "ref" : "section-VIII",
+      "id" : "section-VIII",
+      "href" : "section/VIII",
       "extent" : [ "E", "W", "S", "NI" ]
     }, {
       "name" : "item",
       "number" : "IX",
       "title" : " Recited bill shall be part of this act.",
       "ref" : "section-IX",
+      "id" : "section-IX",
+      "href" : "section/IX",
       "extent" : [ "E", "W", "S", "NI" ]
     }, {
       "name" : "item",
       "number" : "X",
       "title" : " Great seal of Ireland. ",
       "ref" : "section-X",
+      "id" : "section-X",
+      "href" : "section/X",
       "extent" : [ "E", "W", "S", "NI" ]
     } ]
   }

--- a/src/test/resources/aip_Geo3_40_38/aip-Geo3-40-38-part-1-1991-02-01.json
+++ b/src/test/resources/aip_Geo3_40_38/aip-Geo3-40-38-part-1-1991-02-01.json
@@ -34,23 +34,23 @@
     "fragmentInfo" : {
       "element" : "Part",
       "id" : "part-1",
-      "href" : "aip/Geo3/40/38/part/1",
+      "href" : "part/1",
       "number" : "Article First.",
       "title" : null,
       "label" : "Article First."
     },
     "prevInfo" : {
-      "href" : "aip/Geo3/40/38/section/I.",
+      "href" : "section/I.",
       "label" : "Provision"
     },
     "nextInfo" : {
-      "href" : "aip/Geo3/40/38/part/2",
+      "href" : "part/2",
       "label" : "Part"
     },
     "ancestors" : [ {
       "element" : "Part",
       "id" : "part-1",
-      "href" : "aip/Geo3/40/38/part/1",
+      "href" : "part/1",
       "number" : "Article First.",
       "title" : null,
       "label" : "Article First."
@@ -58,14 +58,14 @@
     "descendants" : [ {
       "element" : "Part",
       "id" : "part-1",
-      "href" : "aip/Geo3/40/38/part/1",
+      "href" : "part/1",
       "number" : "Article First.",
       "title" : null,
       "label" : "Article First."
     }, {
       "element" : "P1group",
       "id" : "section-wrapper2",
-      "href" : "aip/Geo3/40/38/section/wrapper2",
+      "href" : "section/wrapper2",
       "number" : null,
       "title" : "Great Britain and Ireland to be united for ever from 1 Jan. 1801.",
       "label" : "P1group"

--- a/src/test/resources/aosp_1707_8/aosp-1707-8-contents-2007-01-01.json
+++ b/src/test/resources/aosp_1707_8/aosp-1707-8-contents-2007-01-01.json
@@ -33,6 +33,8 @@
       "number" : null,
       "title" : "Introductory Text",
       "ref" : "introduction",
+      "id" : null,
+      "href" : null,
       "extent" : [ "S" ]
     },
     "body" : [ {
@@ -40,6 +42,8 @@
       "number" : "",
       "title" : ". . . It is always hereby expressly Provided and...",
       "ref" : "paragraph-p3",
+      "id" : "paragraph-p3",
+      "href" : "paragraph/p3",
       "extent" : [ "S" ]
     } ]
   }

--- a/src/test/resources/aosp_1707_8/aosp-1707-8-paragraph-p3-2007-01-01.json
+++ b/src/test/resources/aosp_1707_8/aosp-1707-8-paragraph-p3-2007-01-01.json
@@ -29,21 +29,21 @@
     "fragmentInfo" : {
       "element" : "P",
       "id" : "paragraph-p3",
-      "href" : "aosp/1707/8/paragraph/p3/2007-01-01",
+      "href" : "paragraph/p3",
       "number" : null,
       "title" : null,
       "label" : "P",
       "end" : "2007-01-01"
     },
     "prevInfo" : {
-      "href" : "aosp/1707/8/introduction/2007-01-01",
+      "href" : "introduction",
       "label" : "Introduction"
     },
     "nextInfo" : null,
     "ancestors" : [ {
       "element" : "P",
       "id" : "paragraph-p3",
-      "href" : "aosp/1707/8/paragraph/p3/2007-01-01",
+      "href" : "paragraph/p3",
       "number" : null,
       "title" : null,
       "label" : "P",
@@ -52,7 +52,7 @@
     "descendants" : [ {
       "element" : "P",
       "id" : "paragraph-p3",
-      "href" : "aosp/1707/8/paragraph/p3/2007-01-01",
+      "href" : "paragraph/p3",
       "number" : null,
       "title" : null,
       "label" : "P",

--- a/src/test/resources/aosp_1707_8/aosp-1707-8-paragraph-p3-2007-01-01.json
+++ b/src/test/resources/aosp_1707_8/aosp-1707-8-paragraph-p3-2007-01-01.json
@@ -32,7 +32,8 @@
       "href" : "aosp/1707/8/paragraph/p3/2007-01-01",
       "number" : null,
       "title" : null,
-      "label" : "P"
+      "label" : "P",
+      "end" : "2007-01-01"
     },
     "prevInfo" : {
       "href" : "aosp/1707/8/introduction/2007-01-01",
@@ -45,7 +46,8 @@
       "href" : "aosp/1707/8/paragraph/p3/2007-01-01",
       "number" : null,
       "title" : null,
-      "label" : "P"
+      "label" : "P",
+      "end" : "2007-01-01"
     } ],
     "descendants" : [ {
       "element" : "P",
@@ -53,7 +55,8 @@
       "href" : "aosp/1707/8/paragraph/p3/2007-01-01",
       "number" : null,
       "title" : null,
-      "label" : "P"
+      "label" : "P",
+      "end" : "2007-01-01"
     } ],
     "unappliedEffects" : {
       "fragment" : [ ],

--- a/src/test/resources/apgb_Geo3_39-40_14/apgb-Geo3-39-40-14-contents.json
+++ b/src/test/resources/apgb_Geo3_39-40_14/apgb-Geo3-39-40-14-contents.json
@@ -38,6 +38,8 @@
       "number" : null,
       "title" : "Introductory Text",
       "ref" : "introduction",
+      "id" : null,
+      "href" : null,
       "extent" : [ "E", "W", "S" ]
     },
     "body" : [ {
@@ -45,12 +47,16 @@
       "number" : "[1.]",
       "title" : "His Majesty may issue his Royal Proclamation for the Meeting of Parliament in not less than 14 Days from the Date, notwithstanding any previous Adjournment to a longer Day.",
       "ref" : "section-1.",
+      "id" : "section-1.",
+      "href" : "section/1.",
       "extent" : [ "E", "W", "S" ]
     }, {
       "name" : "item",
       "number" : "2",
       "title" : " How orders made by Parliament shall be deemed to have been appointed.",
       "ref" : "section-2",
+      "id" : "section-2",
+      "href" : "section/2",
       "extent" : [ "E", "W", "S" ]
     } ]
   }

--- a/src/test/resources/apgb_Geo3_39-40_14/apgb-Geo3-39-40-14-section-2.json
+++ b/src/test/resources/apgb_Geo3_39-40_14/apgb-Geo3-39-40-14-section-2.json
@@ -34,20 +34,20 @@
     "fragmentInfo" : {
       "element" : "P1",
       "id" : "section-2",
-      "href" : "apgb/Geo3/39-40/14/section/2",
+      "href" : "section/2",
       "number" : "2",
       "title" : "How orders made by Parliament shall be deemed to have been appointed.",
       "label" : "Section 2"
     },
     "prevInfo" : {
-      "href" : "apgb/Geo3/39-40/14/section/1.",
+      "href" : "section/1.",
       "label" : "Provision"
     },
     "nextInfo" : null,
     "ancestors" : [ {
       "element" : "P1",
       "id" : "section-2",
-      "href" : "apgb/Geo3/39-40/14/section/2",
+      "href" : "section/2",
       "number" : "2",
       "title" : "How orders made by Parliament shall be deemed to have been appointed.",
       "label" : "Section 2"
@@ -55,7 +55,7 @@
     "descendants" : [ {
       "element" : "P1",
       "id" : "section-2",
-      "href" : "apgb/Geo3/39-40/14/section/2",
+      "href" : "section/2",
       "number" : "2",
       "title" : "How orders made by Parliament shall be deemed to have been appointed.",
       "label" : "Section 2"

--- a/src/test/resources/asc_2025_1/asc-2025-1-contents-2025-03-25.json
+++ b/src/test/resources/asc_2025_1/asc-2025-1-contents-2025-03-25.json
@@ -71,6 +71,8 @@
       "number" : null,
       "title" : "Introductory Text",
       "ref" : "introduction",
+      "id" : null,
+      "href" : null,
       "extent" : [ "E", "W" ]
     },
     "body" : [ {
@@ -78,24 +80,32 @@
       "number" : "PART 1",
       "title" : "SOCIAL CARE",
       "ref" : "part-1",
+      "id" : "part-1",
+      "href" : "part/1",
       "extent" : [ "E", "W" ],
       "children" : [ {
         "name" : "chapter",
         "number" : "CHAPTER 1",
         "title" : "PROVISION OF SOCIAL CARE SERVICES TO CHILDREN: RESTRICTIONS ON PROFIT",
         "ref" : "part-1-chapter-1",
+        "id" : "part-1-chapter-1",
+        "href" : "part/1/chapter/1",
         "extent" : [ "E", "W" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Overview of Chapter",
           "ref" : "part-1-chapter-1-crossheading-overview-of-chapter",
+          "id" : "part-1-chapter-1-crossheading-overview-of-chapter",
+          "href" : "part/1/chapter/1/crossheading/overview-of-chapter",
           "extent" : [ "E", "W" ],
           "children" : [ {
             "name" : "item",
             "number" : "1",
             "title" : "Overview of Chapter 1",
             "ref" : "section-1",
+            "id" : "section-1",
+            "href" : "section/1",
             "extent" : [ "E", "W" ]
           } ]
         }, {
@@ -103,54 +113,72 @@
           "number" : null,
           "title" : "Regulation of social care services provided to children",
           "ref" : "part-1-chapter-1-crossheading-regulation-of-social-care-services-provided-to-children",
+          "id" : "part-1-chapter-1-crossheading-regulation-of-social-care-services-provided-to-children",
+          "href" : "part/1/chapter/1/crossheading/regulation-of-social-care-services-provided-to-children",
           "extent" : [ "E", "W" ],
           "children" : [ {
             "name" : "item",
             "number" : "2",
             "title" : "Restricted children’s services",
             "ref" : "section-2",
+            "id" : "section-2",
+            "href" : "section/2",
             "extent" : [ "E", "W" ]
           }, {
             "name" : "item",
             "number" : "3",
             "title" : "Applications for registration in respect of restricted children’s services",
             "ref" : "section-3",
+            "id" : "section-3",
+            "href" : "section/3",
             "extent" : [ "E", "W" ]
           }, {
             "name" : "item",
             "number" : "4",
             "title" : "Registration in respect of a restricted children’s service: transitional arrangements",
             "ref" : "section-4",
+            "id" : "section-4",
+            "href" : "section/4",
             "extent" : [ "E", "W" ]
           }, {
             "name" : "item",
             "number" : "5",
             "title" : "Grant or refusal of registration in respect of a restricted children’s service",
             "ref" : "section-5",
+            "id" : "section-5",
+            "href" : "section/5",
             "extent" : [ "E", "W" ]
           }, {
             "name" : "item",
             "number" : "6",
             "title" : "Fit and proper person: relevant considerations",
             "ref" : "section-6",
+            "id" : "section-6",
+            "href" : "section/6",
             "extent" : [ "E", "W" ]
           }, {
             "name" : "item",
             "number" : "7",
             "title" : "Providers of restricted children’s services: information contained in annual return",
             "ref" : "section-7",
+            "id" : "section-7",
+            "href" : "section/7",
             "extent" : [ "E", "W" ]
           }, {
             "name" : "item",
             "number" : "8",
             "title" : "Variation or cancellation of registration as a provider of a restricted children’s service",
             "ref" : "section-8",
+            "id" : "section-8",
+            "href" : "section/8",
             "extent" : [ "E", "W" ]
           }, {
             "name" : "item",
             "number" : "9",
             "title" : "Restricted children’s services: information contained in the register of service providers",
             "ref" : "section-9",
+            "id" : "section-9",
+            "href" : "section/9",
             "extent" : [ "E", "W" ]
           } ]
         }, {
@@ -158,30 +186,40 @@
           "number" : null,
           "title" : "Local authority functions in respect of accommodation for looked after children",
           "ref" : "part-1-chapter-1-crossheading-local-authority-functions-in-respect-of-accommodation-for-looked-after-children",
+          "id" : "part-1-chapter-1-crossheading-local-authority-functions-in-respect-of-accommodation-for-looked-after-children",
+          "href" : "part/1/chapter/1/crossheading/local-authority-functions-in-respect-of-accommodation-for-looked-after-children",
           "extent" : [ "E", "W" ],
           "children" : [ {
             "name" : "item",
             "number" : "10",
             "title" : "Local authority duty to secure sufficient accommodation",
             "ref" : "section-10",
+            "id" : "section-10",
+            "href" : "section/10",
             "extent" : [ "E", "W" ]
           }, {
             "name" : "item",
             "number" : "11",
             "title" : "Duty to prepare and publish an annual sufficiency plan",
             "ref" : "section-11",
+            "id" : "section-11",
+            "href" : "section/11",
             "extent" : [ "E", "W" ]
           }, {
             "name" : "item",
             "number" : "12",
             "title" : "Duty to secure accommodation: reporting",
             "ref" : "section-12",
+            "id" : "section-12",
+            "href" : "section/12",
             "extent" : [ "E", "W" ]
           }, {
             "name" : "item",
             "number" : "13",
             "title" : "Ways in which looked after children are to be accommodated",
             "ref" : "section-13",
+            "id" : "section-13",
+            "href" : "section/13",
             "extent" : [ "E", "W" ]
           } ]
         } ]
@@ -190,30 +228,40 @@
         "number" : "CHAPTER 2",
         "title" : "MISCELLANEOUS AMENDMENTS IN RELATION TO SOCIAL CARE SERVICES, SOCIAL CARE WORKERS AND LOCAL AUTHORITY SOCIAL CARE FUNCTIONS",
         "ref" : "part-1-chapter-2",
+        "id" : "part-1-chapter-2",
+        "href" : "part/1/chapter/2",
         "extent" : [ "E", "W" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Regulation of social care services: registration etc. of social care services providers",
           "ref" : "part-1-chapter-2-crossheading-regulation-of-social-care-services-registration-etc-of-social-care-services-providers",
+          "id" : "part-1-chapter-2-crossheading-regulation-of-social-care-services-registration-etc-of-social-care-services-providers",
+          "href" : "part/1/chapter/2/crossheading/regulation-of-social-care-services-registration-etc-of-social-care-services-providers",
           "extent" : [ "E", "W" ],
           "children" : [ {
             "name" : "item",
             "number" : "14",
             "title" : "Duty to submit and publish annual return",
             "ref" : "section-14",
+            "id" : "section-14",
+            "href" : "section/14",
             "extent" : [ "E", "W" ]
           }, {
             "name" : "item",
             "number" : "15",
             "title" : "Application for cancellation of service provider’s registration: information to be provided",
             "ref" : "section-15",
+            "id" : "section-15",
+            "href" : "section/15",
             "extent" : [ "E", "W" ]
           }, {
             "name" : "item",
             "number" : "16",
             "title" : "Cancellation and variation of service provider’s registration without application: notice procedures",
             "ref" : "section-16",
+            "id" : "section-16",
+            "href" : "section/16",
             "extent" : [ "E", "W" ]
           } ]
         }, {
@@ -221,12 +269,16 @@
           "number" : null,
           "title" : "Regulation of social care services: information, inspections and investigations",
           "ref" : "part-1-chapter-2-crossheading-regulation-of-social-care-services-information-inspections-and-investigations",
+          "id" : "part-1-chapter-2-crossheading-regulation-of-social-care-services-information-inspections-and-investigations",
+          "href" : "part/1/chapter/2/crossheading/regulation-of-social-care-services-information-inspections-and-investigations",
           "extent" : [ "E", "W" ],
           "children" : [ {
             "name" : "item",
             "number" : "17",
             "title" : "Information, inspection and investigations",
             "ref" : "section-17",
+            "id" : "section-17",
+            "href" : "section/17",
             "extent" : [ "E", "W" ]
           } ]
         }, {
@@ -234,18 +286,24 @@
           "number" : null,
           "title" : "Social care workers: registration and fitness to practise",
           "ref" : "part-1-chapter-2-crossheading-social-care-workers-registration-and-fitness-to-practise",
+          "id" : "part-1-chapter-2-crossheading-social-care-workers-registration-and-fitness-to-practise",
+          "href" : "part/1/chapter/2/crossheading/social-care-workers-registration-and-fitness-to-practise",
           "extent" : [ "E", "W" ],
           "children" : [ {
             "name" : "item",
             "number" : "18",
             "title" : "Meaning of social care worker: childcare workers",
             "ref" : "section-18",
+            "id" : "section-18",
+            "href" : "section/18",
             "extent" : [ "E", "W" ]
           }, {
             "name" : "item",
             "number" : "19",
             "title" : "Fitness to practise cases: powers to extend interim orders",
             "ref" : "section-19",
+            "id" : "section-19",
+            "href" : "section/19",
             "extent" : [ "E", "W" ]
           } ]
         }, {
@@ -253,18 +311,24 @@
           "number" : null,
           "title" : "Local authority social services functions",
           "ref" : "part-1-chapter-2-crossheading-local-authority-social-services-functions",
+          "id" : "part-1-chapter-2-crossheading-local-authority-social-services-functions",
+          "href" : "part/1/chapter/2/crossheading/local-authority-social-services-functions",
           "extent" : [ "E", "W" ],
           "children" : [ {
             "name" : "item",
             "number" : "20",
             "title" : "Direct payments in social care",
             "ref" : "section-20",
+            "id" : "section-20",
+            "href" : "section/20",
             "extent" : [ "E", "W" ]
           }, {
             "name" : "item",
             "number" : "21",
             "title" : "Accommodation of children",
             "ref" : "section-21",
+            "id" : "section-21",
+            "href" : "section/21",
             "extent" : [ "E", "W" ]
           } ]
         }, {
@@ -272,12 +336,16 @@
           "number" : null,
           "title" : "Minor and consequential amendments",
           "ref" : "part-1-chapter-2-crossheading-minor-and-consequential-amendments",
+          "id" : "part-1-chapter-2-crossheading-minor-and-consequential-amendments",
+          "href" : "part/1/chapter/2/crossheading/minor-and-consequential-amendments",
           "extent" : [ "E", "W" ],
           "children" : [ {
             "name" : "item",
             "number" : "22",
             "title" : "Social care: minor and consequential amendments",
             "ref" : "section-22",
+            "id" : "section-22",
+            "href" : "section/22",
             "extent" : [ "E", "W" ]
           } ]
         } ]
@@ -287,30 +355,40 @@
       "number" : "PART 2",
       "title" : "HEALTH CARE",
       "ref" : "part-2",
+      "id" : "part-2",
+      "href" : "part/2",
       "extent" : [ "E", "W" ],
       "children" : [ {
         "name" : "item",
         "number" : "23",
         "title" : "Overview of Part 2",
         "ref" : "section-23",
+        "id" : "section-23",
+        "href" : "section/23",
         "extent" : [ "E", "W" ]
       }, {
         "name" : "item",
         "number" : "24",
         "title" : "Direct payments for health care",
         "ref" : "section-24",
+        "id" : "section-24",
+        "href" : "section/24",
         "extent" : [ "E", "W" ]
       }, {
         "name" : "item",
         "number" : "25",
         "title" : "Direct payments for health care: minor and consequential amendments",
         "ref" : "section-25",
+        "id" : "section-25",
+        "href" : "section/25",
         "extent" : [ "E", "W" ]
       }, {
         "name" : "item",
         "number" : "26",
         "title" : "Provision of health services by local authorities",
         "ref" : "section-26",
+        "id" : "section-26",
+        "href" : "section/26",
         "extent" : [ "E", "W" ]
       } ]
     }, {
@@ -318,30 +396,40 @@
       "number" : "PART 3",
       "title" : "GENERAL",
       "ref" : "part-3",
+      "id" : "part-3",
+      "href" : "part/3",
       "extent" : [ "E", "W" ],
       "children" : [ {
         "name" : "item",
         "number" : "27",
         "title" : "General interpretation",
         "ref" : "section-27",
+        "id" : "section-27",
+        "href" : "section/27",
         "extent" : [ "E", "W" ]
       }, {
         "name" : "item",
         "number" : "28",
         "title" : "Consequential and transitional provision etc.",
         "ref" : "section-28",
+        "id" : "section-28",
+        "href" : "section/28",
         "extent" : [ "E", "W" ]
       }, {
         "name" : "item",
         "number" : "29",
         "title" : "Coming into force",
         "ref" : "section-29",
+        "id" : "section-29",
+        "href" : "section/29",
         "extent" : [ "E", "W" ]
       }, {
         "name" : "item",
         "number" : "30",
         "title" : "Short title",
         "ref" : "section-30",
+        "id" : "section-30",
+        "href" : "section/30",
         "extent" : [ "E", "W" ]
       } ]
     } ],
@@ -350,24 +438,32 @@
       "number" : "SCHEDULE 1",
       "title" : "SOCIAL CARE: MINOR AND CONSEQUENTIAL AMENDMENTS",
       "ref" : "schedule-1",
+      "id" : "schedule-1",
+      "href" : "schedule/1",
       "extent" : [ "E", "W" ],
       "children" : [ {
         "name" : "part",
         "number" : "PART 1",
         "title" : "PROVISION OF SOCIAL CARE SERVICES TO CHILDREN: MINOR AND CONSEQUENTIAL AMENDMENTS",
         "ref" : "schedule-1-part-1",
+        "id" : "schedule-1-part-1",
+        "href" : "schedule/1/part/1",
         "extent" : [ "E", "W" ],
         "children" : [ {
           "name" : "item",
           "number" : "1",
           "title" : "Social Services and Well-being (Wales) Act 2014 (anaw 4)",
           "ref" : "schedule-1-paragraph-1",
+          "id" : "schedule-1-paragraph-1",
+          "href" : "schedule/1/paragraph/1",
           "extent" : [ "E", "W" ]
         }, {
           "name" : "item",
           "number" : "2",
           "title" : "Regulation and Inspection of Social Care (Wales) Act 2016 (anaw 2)",
           "ref" : "schedule-1-paragraph-2",
+          "id" : "schedule-1-paragraph-2",
+          "href" : "schedule/1/paragraph/2",
           "extent" : [ "E", "W" ]
         } ]
       }, {
@@ -375,42 +471,56 @@
         "number" : "PART 2",
         "title" : "MISCELLANEOUS AMENDMENTS IN RELATION TO SOCIAL CARE SERVICES ETC.: MINOR AND CONSEQUENTIAL AMENDMENTS",
         "ref" : "schedule-1-part-2",
+        "id" : "schedule-1-part-2",
+        "href" : "schedule/1/part/2",
         "extent" : [ "E", "W" ],
         "children" : [ {
           "name" : "item",
           "number" : "3",
           "title" : "Mental Health Act 1983 (c. 20)",
           "ref" : "schedule-1-paragraph-3",
+          "id" : "schedule-1-paragraph-3",
+          "href" : "schedule/1/paragraph/3",
           "extent" : [ "E", "W" ]
         }, {
           "name" : "item",
           "number" : "4",
           "title" : "Safeguarding Vulnerable Groups Act 2006 (c. 47)",
           "ref" : "schedule-1-paragraph-4",
+          "id" : "schedule-1-paragraph-4",
+          "href" : "schedule/1/paragraph/4",
           "extent" : [ "E", "W" ]
         }, {
           "name" : "item",
           "number" : "5",
           "title" : "Social Services and Well-being (Wales) Act 2014 (anaw 4)",
           "ref" : "schedule-1-paragraph-5",
+          "id" : "schedule-1-paragraph-5",
+          "href" : "schedule/1/paragraph/5",
           "extent" : [ "E", "W" ]
         }, {
           "name" : "item",
           "number" : "6",
           "title" : "Criminal Justice and Courts Act 2015 (c. 2)",
           "ref" : "schedule-1-paragraph-6",
+          "id" : "schedule-1-paragraph-6",
+          "href" : "schedule/1/paragraph/6",
           "extent" : [ "E", "W" ]
         }, {
           "name" : "item",
           "number" : "7",
           "title" : "Regulation and Inspection of Social Care (Wales) Act 2016 (anaw 2)",
           "ref" : "schedule-1-paragraph-7",
+          "id" : "schedule-1-paragraph-7",
+          "href" : "schedule/1/paragraph/7",
           "extent" : [ "E", "W" ]
         }, {
           "name" : "item",
           "number" : "8",
           "title" : "Social Services and Well-being (Wales) Act 2014 (Consequential Amendments) Regulations 2016 (S.I. 2016/413 (W. 131))",
           "ref" : "schedule-1-paragraph-8",
+          "id" : "schedule-1-paragraph-8",
+          "href" : "schedule/1/paragraph/8",
           "extent" : [ "E", "W" ]
         } ]
       } ]
@@ -419,42 +529,56 @@
       "number" : "SCHEDULE 2",
       "title" : "DIRECT PAYMENTS FOR HEALTH CARE: MINOR AND CONSEQUENTIAL AMENDMENTS",
       "ref" : "schedule-2",
+      "id" : "schedule-2",
+      "href" : "schedule/2",
       "extent" : [ "E", "W" ],
       "children" : [ {
         "name" : "item",
         "number" : "1",
         "title" : "Mental Health Act 1983 (c. 20)",
         "ref" : "schedule-2-paragraph-1",
+        "id" : "schedule-2-paragraph-1",
+        "href" : "schedule/2/paragraph/1",
         "extent" : [ "E", "W" ]
       }, {
         "name" : "item",
         "number" : "2",
         "title" : "Disabled Persons (Services, Consultation and Representation) Act 1986 (c. 33)",
         "ref" : "schedule-2-paragraph-2",
+        "id" : "schedule-2-paragraph-2",
+        "href" : "schedule/2/paragraph/2",
         "extent" : [ "E", "W" ]
       }, {
         "name" : "item",
         "number" : "3",
         "title" : "National Health Service (Wales) Act 2006 (c. 42)",
         "ref" : "schedule-2-paragraph-3",
+        "id" : "schedule-2-paragraph-3",
+        "href" : "schedule/2/paragraph/3",
         "extent" : [ "E", "W" ]
       }, {
         "name" : "item",
         "number" : "4",
         "title" : "Safeguarding Vulnerable Groups Act 2006 (c. 47)",
         "ref" : "schedule-2-paragraph-4",
+        "id" : "schedule-2-paragraph-4",
+        "href" : "schedule/2/paragraph/4",
         "extent" : [ "E", "W" ]
       }, {
         "name" : "item",
         "number" : "5",
         "title" : "Criminal Justice and Courts Act 2015 (c. 2)",
         "ref" : "schedule-2-paragraph-5",
+        "id" : "schedule-2-paragraph-5",
+        "href" : "schedule/2/paragraph/5",
         "extent" : [ "E", "W" ]
       }, {
         "name" : "item",
         "number" : "6",
         "title" : "Public Services Ombudsman (Wales) Act 2019 (anaw 3)",
         "ref" : "schedule-2-paragraph-6",
+        "id" : "schedule-2-paragraph-6",
+        "href" : "schedule/2/paragraph/6",
         "extent" : [ "E", "W" ]
       } ]
     } ]

--- a/src/test/resources/asc_2025_1/asc-2025-1-part-1-chapter-2-2025-03-25.json
+++ b/src/test/resources/asc_2025_1/asc-2025-1-part-1-chapter-2-2025-03-25.json
@@ -67,24 +67,24 @@
     "fragmentInfo" : {
       "element" : "Chapter",
       "id" : "part-1-chapter-2",
-      "href" : "asc/2025/1/part/1/chapter/2/2025-03-25",
+      "href" : "part/1/chapter/2",
       "number" : "CHAPTER 2",
       "title" : "MISCELLANEOUS AMENDMENTS IN RELATION TO SOCIAL CARE SERVICES, SOCIAL CARE WORKERS AND LOCAL AUTHORITY SOCIAL CARE FUNCTIONS",
       "label" : "CHAPTER 2",
       "start" : "2025-03-25"
     },
     "prevInfo" : {
-      "href" : "asc/2025/1/part/1/chapter/1/2025-03-25",
+      "href" : "part/1/chapter/1",
       "label" : "Chapter"
     },
     "nextInfo" : {
-      "href" : "asc/2025/1/part/2/2025-03-25",
+      "href" : "part/2",
       "label" : "Part"
     },
     "ancestors" : [ {
       "element" : "Part",
       "id" : "part-1",
-      "href" : "asc/2025/1/part/1/2025-03-25",
+      "href" : "part/1",
       "number" : "PART 1",
       "title" : "SOCIAL CARE",
       "label" : "PART 1",
@@ -92,7 +92,7 @@
     }, {
       "element" : "Chapter",
       "id" : "part-1-chapter-2",
-      "href" : "asc/2025/1/part/1/chapter/2/2025-03-25",
+      "href" : "part/1/chapter/2",
       "number" : "CHAPTER 2",
       "title" : "MISCELLANEOUS AMENDMENTS IN RELATION TO SOCIAL CARE SERVICES, SOCIAL CARE WORKERS AND LOCAL AUTHORITY SOCIAL CARE FUNCTIONS",
       "label" : "CHAPTER 2",
@@ -101,7 +101,7 @@
     "descendants" : [ {
       "element" : "Chapter",
       "id" : "part-1-chapter-2",
-      "href" : "asc/2025/1/part/1/chapter/2/2025-03-25",
+      "href" : "part/1/chapter/2",
       "number" : "CHAPTER 2",
       "title" : "MISCELLANEOUS AMENDMENTS IN RELATION TO SOCIAL CARE SERVICES, SOCIAL CARE WORKERS AND LOCAL AUTHORITY SOCIAL CARE FUNCTIONS",
       "label" : "CHAPTER 2",
@@ -109,7 +109,7 @@
     }, {
       "element" : "Pblock",
       "id" : "part-1-chapter-2-crossheading-regulation-of-social-care-services-registration-etc-of-social-care-services-providers",
-      "href" : "asc/2025/1/part/1/chapter/2/crossheading/regulation-of-social-care-services-registration-etc-of-social-care-services-providers/2025-03-25",
+      "href" : "part/1/chapter/2/crossheading/regulation-of-social-care-services-registration-etc-of-social-care-services-providers",
       "number" : null,
       "title" : "Regulation of social care services: registration etc. of social care services providers",
       "label" : "Regulation of social care services: registration etc. of social care services providers",
@@ -117,7 +117,7 @@
     }, {
       "element" : "P1",
       "id" : "section-14",
-      "href" : "asc/2025/1/section/14/2025-03-25",
+      "href" : "section/14",
       "number" : "14",
       "title" : "Duty to submit and publish annual return",
       "label" : "Section 14",
@@ -125,84 +125,84 @@
     }, {
       "element" : "P2",
       "id" : "section-14-1",
-      "href" : "asc/2025/1/section/14/1/2025-03-25",
+      "href" : "section/14/1",
       "number" : "1",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-14-1-a",
-      "href" : "asc/2025/1/section/14/1/a/2025-03-25",
+      "href" : "section/14/1/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-14-1-b",
-      "href" : "asc/2025/1/section/14/1/b/2025-03-25",
+      "href" : "section/14/1/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P2",
       "id" : "section-14-2",
-      "href" : "asc/2025/1/section/14/2/2025-03-25",
+      "href" : "section/14/2",
       "number" : "2",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-14-2-a",
-      "href" : "asc/2025/1/section/14/2/a/2025-03-25",
+      "href" : "section/14/2/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-14-2-b",
-      "href" : "asc/2025/1/section/14/2/b/2025-03-25",
+      "href" : "section/14/2/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-14-2-c",
-      "href" : "asc/2025/1/section/14/2/c/2025-03-25",
+      "href" : "section/14/2/c",
       "number" : "c",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-14-2-d",
-      "href" : "asc/2025/1/section/14/2/d/2025-03-25",
+      "href" : "section/14/2/d",
       "number" : "d",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P2",
       "id" : "section-14-3",
-      "href" : "asc/2025/1/section/14/3/2025-03-25",
+      "href" : "section/14/3",
       "number" : "3",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-14-3-a",
-      "href" : "asc/2025/1/section/14/3/a/2025-03-25",
+      "href" : "section/14/3/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-14-3-b",
-      "href" : "asc/2025/1/section/14/3/b/2025-03-25",
+      "href" : "section/14/3/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P1",
       "id" : "section-15",
-      "href" : "asc/2025/1/section/15/2025-03-25",
+      "href" : "section/15",
       "number" : "15",
       "title" : "Application for cancellation of service provider’s registration: information to be provided",
       "label" : "Section 15",
@@ -210,126 +210,126 @@
     }, {
       "element" : "P2",
       "id" : "section-15-1",
-      "href" : "asc/2025/1/section/15/1/2025-03-25",
+      "href" : "section/15/1",
       "number" : "1",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "section-15-2",
-      "href" : "asc/2025/1/section/15/2/2025-03-25",
+      "href" : "section/15/2",
       "number" : "2",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P1",
       "id" : "section-16",
-      "href" : "asc/2025/1/section/16/2025-03-25",
+      "href" : "section/16",
       "number" : "16",
       "title" : "Cancellation and variation of service provider’s registration without application: notice procedures",
       "label" : "Section 16"
     }, {
       "element" : "P2",
       "id" : "section-16-1",
-      "href" : "asc/2025/1/section/16/1/2025-03-25",
+      "href" : "section/16/1",
       "number" : "1",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "section-16-2",
-      "href" : "asc/2025/1/section/16/2/2025-03-25",
+      "href" : "section/16/2",
       "number" : "2",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-16-2-a",
-      "href" : "asc/2025/1/section/16/2/a/2025-03-25",
+      "href" : "section/16/2/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-16-2-b",
-      "href" : "asc/2025/1/section/16/2/b/2025-03-25",
+      "href" : "section/16/2/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-16-2-c",
-      "href" : "asc/2025/1/section/16/2/c/2025-03-25",
+      "href" : "section/16/2/c",
       "number" : "c",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-16-2-d",
-      "href" : "asc/2025/1/section/16/2/d/2025-03-25",
+      "href" : "section/16/2/d",
       "number" : "d",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-16-2-e",
-      "href" : "asc/2025/1/section/16/2/e/2025-03-25",
+      "href" : "section/16/2/e",
       "number" : "e",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P2",
       "id" : "section-16-3",
-      "href" : "asc/2025/1/section/16/3/2025-03-25",
+      "href" : "section/16/3",
       "number" : "3",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-16-3-a",
-      "href" : "asc/2025/1/section/16/3/a/2025-03-25",
+      "href" : "section/16/3/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P4",
       "id" : "section-16-3-a-i",
-      "href" : "asc/2025/1/section/16/3/a/i/2025-03-25",
+      "href" : "section/16/3/a/i",
       "number" : "i",
       "title" : null,
       "label" : "P4"
     }, {
       "element" : "P4",
       "id" : "section-16-3-a-ii",
-      "href" : "asc/2025/1/section/16/3/a/ii/2025-03-25",
+      "href" : "section/16/3/a/ii",
       "number" : "ii",
       "title" : null,
       "label" : "P4"
     }, {
       "element" : "P3",
       "id" : "section-16-3-b",
-      "href" : "asc/2025/1/section/16/3/b/2025-03-25",
+      "href" : "section/16/3/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-16-3-c",
-      "href" : "asc/2025/1/section/16/3/c/2025-03-25",
+      "href" : "section/16/3/c",
       "number" : "c",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-16-3-d",
-      "href" : "asc/2025/1/section/16/3/d/2025-03-25",
+      "href" : "section/16/3/d",
       "number" : "d",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "Pblock",
       "id" : "part-1-chapter-2-crossheading-regulation-of-social-care-services-information-inspections-and-investigations",
-      "href" : "asc/2025/1/part/1/chapter/2/crossheading/regulation-of-social-care-services-information-inspections-and-investigations/2025-03-25",
+      "href" : "part/1/chapter/2/crossheading/regulation-of-social-care-services-information-inspections-and-investigations",
       "number" : null,
       "title" : "Regulation of social care services: information, inspections and investigations",
       "label" : "Regulation of social care services: information, inspections and investigations",
@@ -337,7 +337,7 @@
     }, {
       "element" : "P1",
       "id" : "section-17",
-      "href" : "asc/2025/1/section/17/2025-03-25",
+      "href" : "section/17",
       "number" : "17",
       "title" : "Information, inspection and investigations",
       "label" : "Section 17",
@@ -345,217 +345,217 @@
     }, {
       "element" : "P2",
       "id" : "section-17-1",
-      "href" : "asc/2025/1/section/17/1/2025-03-25",
+      "href" : "section/17/1",
       "number" : "1",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "section-17-2",
-      "href" : "asc/2025/1/section/17/2/2025-03-25",
+      "href" : "section/17/2",
       "number" : "2",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-17-2-a",
-      "href" : "asc/2025/1/section/17/2/a/2025-03-25",
+      "href" : "section/17/2/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P4",
       "id" : "section-17-2-a-i",
-      "href" : "asc/2025/1/section/17/2/a/i/2025-03-25",
+      "href" : "section/17/2/a/i",
       "number" : "i",
       "title" : null,
       "label" : "P4"
     }, {
       "element" : "P4",
       "id" : "section-17-2-a-ii",
-      "href" : "asc/2025/1/section/17/2/a/ii/2025-03-25",
+      "href" : "section/17/2/a/ii",
       "number" : "ii",
       "title" : null,
       "label" : "P4"
     }, {
       "element" : "P3",
       "id" : "section-17-2-b",
-      "href" : "asc/2025/1/section/17/2/b/2025-03-25",
+      "href" : "section/17/2/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-17-2-c",
-      "href" : "asc/2025/1/section/17/2/c/2025-03-25",
+      "href" : "section/17/2/c",
       "number" : "c",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-17-2-d",
-      "href" : "asc/2025/1/section/17/2/d/2025-03-25",
+      "href" : "section/17/2/d",
       "number" : "d",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P2",
       "id" : "section-17-3",
-      "href" : "asc/2025/1/section/17/3/2025-03-25",
+      "href" : "section/17/3",
       "number" : "3",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "section-17-4",
-      "href" : "asc/2025/1/section/17/4/2025-03-25",
+      "href" : "section/17/4",
       "number" : "4",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-17-4-a",
-      "href" : "asc/2025/1/section/17/4/a/2025-03-25",
+      "href" : "section/17/4/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-17-4-b",
-      "href" : "asc/2025/1/section/17/4/b/2025-03-25",
+      "href" : "section/17/4/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-17-4-c",
-      "href" : "asc/2025/1/section/17/4/c/2025-03-25",
+      "href" : "section/17/4/c",
       "number" : "c",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P2",
       "id" : "section-17-5",
-      "href" : "asc/2025/1/section/17/5/2025-03-25",
+      "href" : "section/17/5",
       "number" : "5",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-17-5-a",
-      "href" : "asc/2025/1/section/17/5/a/2025-03-25",
+      "href" : "section/17/5/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P4",
       "id" : "section-17-5-a-i",
-      "href" : "asc/2025/1/section/17/5/a/i/2025-03-25",
+      "href" : "section/17/5/a/i",
       "number" : "i",
       "title" : null,
       "label" : "P4"
     }, {
       "element" : "P4",
       "id" : "section-17-5-a-ii",
-      "href" : "asc/2025/1/section/17/5/a/ii/2025-03-25",
+      "href" : "section/17/5/a/ii",
       "number" : "ii",
       "title" : null,
       "label" : "P4"
     }, {
       "element" : "P3",
       "id" : "section-17-5-b",
-      "href" : "asc/2025/1/section/17/5/b/2025-03-25",
+      "href" : "section/17/5/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-17-5-c",
-      "href" : "asc/2025/1/section/17/5/c/2025-03-25",
+      "href" : "section/17/5/c",
       "number" : "c",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-17-5-d",
-      "href" : "asc/2025/1/section/17/5/d/2025-03-25",
+      "href" : "section/17/5/d",
       "number" : "d",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P2",
       "id" : "section-17-6",
-      "href" : "asc/2025/1/section/17/6/2025-03-25",
+      "href" : "section/17/6",
       "number" : "6",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-17-6-a",
-      "href" : "asc/2025/1/section/17/6/a/2025-03-25",
+      "href" : "section/17/6/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P4",
       "id" : "section-17-6-a-i",
-      "href" : "asc/2025/1/section/17/6/a/i/2025-03-25",
+      "href" : "section/17/6/a/i",
       "number" : "i",
       "title" : null,
       "label" : "P4"
     }, {
       "element" : "P4",
       "id" : "section-17-6-a-ii",
-      "href" : "asc/2025/1/section/17/6/a/ii/2025-03-25",
+      "href" : "section/17/6/a/ii",
       "number" : "ii",
       "title" : null,
       "label" : "P4"
     }, {
       "element" : "P3",
       "id" : "section-17-6-b",
-      "href" : "asc/2025/1/section/17/6/b/2025-03-25",
+      "href" : "section/17/6/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-17-6-c",
-      "href" : "asc/2025/1/section/17/6/c/2025-03-25",
+      "href" : "section/17/6/c",
       "number" : "c",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-17-6-d",
-      "href" : "asc/2025/1/section/17/6/d/2025-03-25",
+      "href" : "section/17/6/d",
       "number" : "d",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P2",
       "id" : "section-17-7",
-      "href" : "asc/2025/1/section/17/7/2025-03-25",
+      "href" : "section/17/7",
       "number" : "7",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-17-7-a",
-      "href" : "asc/2025/1/section/17/7/a/2025-03-25",
+      "href" : "section/17/7/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-17-7-b",
-      "href" : "asc/2025/1/section/17/7/b/2025-03-25",
+      "href" : "section/17/7/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "Pblock",
       "id" : "part-1-chapter-2-crossheading-social-care-workers-registration-and-fitness-to-practise",
-      "href" : "asc/2025/1/part/1/chapter/2/crossheading/social-care-workers-registration-and-fitness-to-practise/2025-03-25",
+      "href" : "part/1/chapter/2/crossheading/social-care-workers-registration-and-fitness-to-practise",
       "number" : null,
       "title" : "Social care workers: registration and fitness to practise",
       "label" : "Social care workers: registration and fitness to practise",
@@ -563,7 +563,7 @@
     }, {
       "element" : "P1",
       "id" : "section-18",
-      "href" : "asc/2025/1/section/18/2025-03-25",
+      "href" : "section/18",
       "number" : "18",
       "title" : "Meaning of social care worker: childcare workers",
       "label" : "Section 18",
@@ -571,49 +571,49 @@
     }, {
       "element" : "P2",
       "id" : "section-18-1",
-      "href" : "asc/2025/1/section/18/1/2025-03-25",
+      "href" : "section/18/1",
       "number" : "1",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "section-18-2",
-      "href" : "asc/2025/1/section/18/2/2025-03-25",
+      "href" : "section/18/2",
       "number" : "2",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-18-2-a",
-      "href" : "asc/2025/1/section/18/2/a/2025-03-25",
+      "href" : "section/18/2/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P4",
       "id" : "section-18-2-a-i",
-      "href" : "asc/2025/1/section/18/2/a/i/2025-03-25",
+      "href" : "section/18/2/a/i",
       "number" : "i",
       "title" : null,
       "label" : "P4"
     }, {
       "element" : "P4",
       "id" : "section-18-2-a-ii",
-      "href" : "asc/2025/1/section/18/2/a/ii/2025-03-25",
+      "href" : "section/18/2/a/ii",
       "number" : "ii",
       "title" : null,
       "label" : "P4"
     }, {
       "element" : "P3",
       "id" : "section-18-2-b",
-      "href" : "asc/2025/1/section/18/2/b/2025-03-25",
+      "href" : "section/18/2/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P1",
       "id" : "section-19",
-      "href" : "asc/2025/1/section/19/2025-03-25",
+      "href" : "section/19",
       "number" : "19",
       "title" : "Fitness to practise cases: powers to extend interim orders",
       "label" : "Section 19",
@@ -621,56 +621,56 @@
     }, {
       "element" : "P2",
       "id" : "section-19-1",
-      "href" : "asc/2025/1/section/19/1/2025-03-25",
+      "href" : "section/19/1",
       "number" : "1",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "section-19-2",
-      "href" : "asc/2025/1/section/19/2/2025-03-25",
+      "href" : "section/19/2",
       "number" : "2",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-19-2-a",
-      "href" : "asc/2025/1/section/19/2/a/2025-03-25",
+      "href" : "section/19/2/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-19-2-b",
-      "href" : "asc/2025/1/section/19/2/b/2025-03-25",
+      "href" : "section/19/2/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-19-2-c",
-      "href" : "asc/2025/1/section/19/2/c/2025-03-25",
+      "href" : "section/19/2/c",
       "number" : "c",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-19-2-d",
-      "href" : "asc/2025/1/section/19/2/d/2025-03-25",
+      "href" : "section/19/2/d",
       "number" : "d",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-19-2-e",
-      "href" : "asc/2025/1/section/19/2/e/2025-03-25",
+      "href" : "section/19/2/e",
       "number" : "e",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "Pblock",
       "id" : "part-1-chapter-2-crossheading-local-authority-social-services-functions",
-      "href" : "asc/2025/1/part/1/chapter/2/crossheading/local-authority-social-services-functions/2025-03-25",
+      "href" : "part/1/chapter/2/crossheading/local-authority-social-services-functions",
       "number" : null,
       "title" : "Local authority social services functions",
       "label" : "Local authority social services functions",
@@ -678,7 +678,7 @@
     }, {
       "element" : "P1",
       "id" : "section-20",
-      "href" : "asc/2025/1/section/20/2025-03-25",
+      "href" : "section/20",
       "number" : "20",
       "title" : "Direct payments in social care",
       "label" : "Section 20",
@@ -686,91 +686,91 @@
     }, {
       "element" : "P2",
       "id" : "section-20-1",
-      "href" : "asc/2025/1/section/20/1/2025-03-25",
+      "href" : "section/20/1",
       "number" : "1",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "section-20-2",
-      "href" : "asc/2025/1/section/20/2/2025-03-25",
+      "href" : "section/20/2",
       "number" : "2",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-20-2-a",
-      "href" : "asc/2025/1/section/20/2/a/2025-03-25",
+      "href" : "section/20/2/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-20-2-b",
-      "href" : "asc/2025/1/section/20/2/b/2025-03-25",
+      "href" : "section/20/2/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-20-2-c",
-      "href" : "asc/2025/1/section/20/2/c/2025-03-25",
+      "href" : "section/20/2/c",
       "number" : "c",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-20-2-d",
-      "href" : "asc/2025/1/section/20/2/d/2025-03-25",
+      "href" : "section/20/2/d",
       "number" : "d",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P1",
       "id" : "section-21",
-      "href" : "asc/2025/1/section/21/2025-03-25",
+      "href" : "section/21",
       "number" : "21",
       "title" : "Accommodation of children",
       "label" : "Section 21"
     }, {
       "element" : "P2",
       "id" : "section-21-1",
-      "href" : "asc/2025/1/section/21/1/2025-03-25",
+      "href" : "section/21/1",
       "number" : "1",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-21-1-a",
-      "href" : "asc/2025/1/section/21/1/a/2025-03-25",
+      "href" : "section/21/1/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-21-1-b",
-      "href" : "asc/2025/1/section/21/1/b/2025-03-25",
+      "href" : "section/21/1/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P2",
       "id" : "section-21-2",
-      "href" : "asc/2025/1/section/21/2/2025-03-25",
+      "href" : "section/21/2",
       "number" : "2",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "section-21-3",
-      "href" : "asc/2025/1/section/21/3/2025-03-25",
+      "href" : "section/21/3",
       "number" : "3",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "Pblock",
       "id" : "part-1-chapter-2-crossheading-minor-and-consequential-amendments",
-      "href" : "asc/2025/1/part/1/chapter/2/crossheading/minor-and-consequential-amendments/2025-03-25",
+      "href" : "part/1/chapter/2/crossheading/minor-and-consequential-amendments",
       "number" : null,
       "title" : "Minor and consequential amendments",
       "label" : "Minor and consequential amendments",
@@ -778,7 +778,7 @@
     }, {
       "element" : "P1",
       "id" : "section-22",
-      "href" : "asc/2025/1/section/22/2025-03-25",
+      "href" : "section/22",
       "number" : "22",
       "title" : "Social care: minor and consequential amendments",
       "label" : "Section 22"

--- a/src/test/resources/asc_2025_1/asc-2025-1-part-1-chapter-2-2025-03-25.json
+++ b/src/test/resources/asc_2025_1/asc-2025-1-part-1-chapter-2-2025-03-25.json
@@ -70,7 +70,8 @@
       "href" : "asc/2025/1/part/1/chapter/2/2025-03-25",
       "number" : "CHAPTER 2",
       "title" : "MISCELLANEOUS AMENDMENTS IN RELATION TO SOCIAL CARE SERVICES, SOCIAL CARE WORKERS AND LOCAL AUTHORITY SOCIAL CARE FUNCTIONS",
-      "label" : "CHAPTER 2"
+      "label" : "CHAPTER 2",
+      "start" : "2025-03-25"
     },
     "prevInfo" : {
       "href" : "asc/2025/1/part/1/chapter/1/2025-03-25",
@@ -86,14 +87,16 @@
       "href" : "asc/2025/1/part/1/2025-03-25",
       "number" : "PART 1",
       "title" : "SOCIAL CARE",
-      "label" : "PART 1"
+      "label" : "PART 1",
+      "start" : "2025-03-25"
     }, {
       "element" : "Chapter",
       "id" : "part-1-chapter-2",
       "href" : "asc/2025/1/part/1/chapter/2/2025-03-25",
       "number" : "CHAPTER 2",
       "title" : "MISCELLANEOUS AMENDMENTS IN RELATION TO SOCIAL CARE SERVICES, SOCIAL CARE WORKERS AND LOCAL AUTHORITY SOCIAL CARE FUNCTIONS",
-      "label" : "CHAPTER 2"
+      "label" : "CHAPTER 2",
+      "start" : "2025-03-25"
     } ],
     "descendants" : [ {
       "element" : "Chapter",
@@ -101,21 +104,24 @@
       "href" : "asc/2025/1/part/1/chapter/2/2025-03-25",
       "number" : "CHAPTER 2",
       "title" : "MISCELLANEOUS AMENDMENTS IN RELATION TO SOCIAL CARE SERVICES, SOCIAL CARE WORKERS AND LOCAL AUTHORITY SOCIAL CARE FUNCTIONS",
-      "label" : "CHAPTER 2"
+      "label" : "CHAPTER 2",
+      "start" : "2025-03-25"
     }, {
       "element" : "Pblock",
       "id" : "part-1-chapter-2-crossheading-regulation-of-social-care-services-registration-etc-of-social-care-services-providers",
       "href" : "asc/2025/1/part/1/chapter/2/crossheading/regulation-of-social-care-services-registration-etc-of-social-care-services-providers/2025-03-25",
       "number" : null,
       "title" : "Regulation of social care services: registration etc. of social care services providers",
-      "label" : "Regulation of social care services: registration etc. of social care services providers"
+      "label" : "Regulation of social care services: registration etc. of social care services providers",
+      "start" : "2025-03-25"
     }, {
       "element" : "P1",
       "id" : "section-14",
       "href" : "asc/2025/1/section/14/2025-03-25",
       "number" : "14",
       "title" : "Duty to submit and publish annual return",
-      "label" : "Section 14"
+      "label" : "Section 14",
+      "prospective" : true
     }, {
       "element" : "P2",
       "id" : "section-14-1",
@@ -199,7 +205,8 @@
       "href" : "asc/2025/1/section/15/2025-03-25",
       "number" : "15",
       "title" : "Application for cancellation of service provider’s registration: information to be provided",
-      "label" : "Section 15"
+      "label" : "Section 15",
+      "prospective" : true
     }, {
       "element" : "P2",
       "id" : "section-15-1",
@@ -325,14 +332,16 @@
       "href" : "asc/2025/1/part/1/chapter/2/crossheading/regulation-of-social-care-services-information-inspections-and-investigations/2025-03-25",
       "number" : null,
       "title" : "Regulation of social care services: information, inspections and investigations",
-      "label" : "Regulation of social care services: information, inspections and investigations"
+      "label" : "Regulation of social care services: information, inspections and investigations",
+      "prospective" : true
     }, {
       "element" : "P1",
       "id" : "section-17",
       "href" : "asc/2025/1/section/17/2025-03-25",
       "number" : "17",
       "title" : "Information, inspection and investigations",
-      "label" : "Section 17"
+      "label" : "Section 17",
+      "prospective" : true
     }, {
       "element" : "P2",
       "id" : "section-17-1",
@@ -549,14 +558,16 @@
       "href" : "asc/2025/1/part/1/chapter/2/crossheading/social-care-workers-registration-and-fitness-to-practise/2025-03-25",
       "number" : null,
       "title" : "Social care workers: registration and fitness to practise",
-      "label" : "Social care workers: registration and fitness to practise"
+      "label" : "Social care workers: registration and fitness to practise",
+      "prospective" : true
     }, {
       "element" : "P1",
       "id" : "section-18",
       "href" : "asc/2025/1/section/18/2025-03-25",
       "number" : "18",
       "title" : "Meaning of social care worker: childcare workers",
-      "label" : "Section 18"
+      "label" : "Section 18",
+      "prospective" : true
     }, {
       "element" : "P2",
       "id" : "section-18-1",
@@ -605,7 +616,8 @@
       "href" : "asc/2025/1/section/19/2025-03-25",
       "number" : "19",
       "title" : "Fitness to practise cases: powers to extend interim orders",
-      "label" : "Section 19"
+      "label" : "Section 19",
+      "prospective" : true
     }, {
       "element" : "P2",
       "id" : "section-19-1",
@@ -661,14 +673,16 @@
       "href" : "asc/2025/1/part/1/chapter/2/crossheading/local-authority-social-services-functions/2025-03-25",
       "number" : null,
       "title" : "Local authority social services functions",
-      "label" : "Local authority social services functions"
+      "label" : "Local authority social services functions",
+      "start" : "2025-03-25"
     }, {
       "element" : "P1",
       "id" : "section-20",
       "href" : "asc/2025/1/section/20/2025-03-25",
       "number" : "20",
       "title" : "Direct payments in social care",
-      "label" : "Section 20"
+      "label" : "Section 20",
+      "prospective" : true
     }, {
       "element" : "P2",
       "id" : "section-20-1",
@@ -759,7 +773,8 @@
       "href" : "asc/2025/1/part/1/chapter/2/crossheading/minor-and-consequential-amendments/2025-03-25",
       "number" : null,
       "title" : "Minor and consequential amendments",
-      "label" : "Minor and consequential amendments"
+      "label" : "Minor and consequential amendments",
+      "start" : "2025-03-25"
     }, {
       "element" : "P1",
       "id" : "section-22",

--- a/src/test/resources/asp_2025_11/asp-2025-11-contents-2025-08-07.json
+++ b/src/test/resources/asp_2025_11/asp-2025-11-contents-2025-08-07.json
@@ -41,6 +41,8 @@
       "number" : null,
       "title" : "Introductory Text",
       "ref" : "introduction",
+      "id" : null,
+      "href" : null,
       "extent" : [ "S" ]
     },
     "body" : [ {
@@ -48,18 +50,24 @@
       "number" : "Part 1",
       "title" : "Qualifications Scotland",
       "ref" : "part-1",
+      "id" : "part-1",
+      "href" : "part/1",
       "extent" : [ "S" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : "Establishment",
         "ref" : "part-1-crossheading-establishment",
+        "id" : "part-1-crossheading-establishment",
+        "href" : "part/1/crossheading/establishment",
         "extent" : [ "S" ],
         "children" : [ {
           "name" : "item",
           "number" : "1",
           "title" : "Qualifications Scotland",
           "ref" : "section-1",
+          "id" : "section-1",
+          "href" : "section/1",
           "extent" : [ "S" ]
         } ]
       }, {
@@ -67,48 +75,64 @@
         "number" : null,
         "title" : "Functions",
         "ref" : "part-1-crossheading-functions",
+        "id" : "part-1-crossheading-functions",
+        "href" : "part/1/crossheading/functions",
         "extent" : [ "S" ],
         "children" : [ {
           "name" : "item",
           "number" : "2",
           "title" : "The function of awarding qualifications",
           "ref" : "section-2",
+          "id" : "section-2",
+          "href" : "section/2",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "3",
           "title" : "The quality assurance function",
           "ref" : "section-3",
+          "id" : "section-3",
+          "href" : "section/3",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "4",
           "title" : "The accreditation function",
           "ref" : "section-4",
+          "id" : "section-4",
+          "href" : "section/4",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "5",
           "title" : "The advisory function",
           "ref" : "section-5",
+          "id" : "section-5",
+          "href" : "section/5",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "6",
           "title" : "Working with, or recognition of, others",
           "ref" : "section-6",
+          "id" : "section-6",
+          "href" : "section/6",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "7",
           "title" : "Duties when exercising functions",
           "ref" : "section-7",
+          "id" : "section-7",
+          "href" : "section/7",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "8",
           "title" : "Consultation with Strategic Advisory Council",
           "ref" : "section-8",
+          "id" : "section-8",
+          "href" : "section/8",
           "extent" : [ "S" ]
         } ]
       }, {
@@ -116,12 +140,16 @@
         "number" : null,
         "title" : "Strategic Advisory Council",
         "ref" : "part-1-crossheading-strategic-advisory-council",
+        "id" : "part-1-crossheading-strategic-advisory-council",
+        "href" : "part/1/crossheading/strategic-advisory-council",
         "extent" : [ "S" ],
         "children" : [ {
           "name" : "item",
           "number" : "9",
           "title" : "Strategic Advisory Council",
           "ref" : "section-9",
+          "id" : "section-9",
+          "href" : "section/9",
           "extent" : [ "S" ]
         } ]
       }, {
@@ -129,12 +157,16 @@
         "number" : null,
         "title" : "Expert Group on Qualifications Standards",
         "ref" : "part-1-crossheading-expert-group-on-qualifications-standards",
+        "id" : "part-1-crossheading-expert-group-on-qualifications-standards",
+        "href" : "part/1/crossheading/expert-group-on-qualifications-standards",
         "extent" : [ "S" ],
         "children" : [ {
           "name" : "item",
           "number" : "10",
           "title" : "Expert Group on Qualifications Standards",
           "ref" : "section-10",
+          "id" : "section-10",
+          "href" : "section/10",
           "extent" : [ "S" ]
         } ]
       }, {
@@ -142,30 +174,40 @@
         "number" : null,
         "title" : "Charters",
         "ref" : "part-1-crossheading-charters",
+        "id" : "part-1-crossheading-charters",
+        "href" : "part/1/crossheading/charters",
         "extent" : [ "S" ],
         "children" : [ {
           "name" : "item",
           "number" : "11",
           "title" : "The learner charter",
           "ref" : "section-11",
+          "id" : "section-11",
+          "href" : "section/11",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "12",
           "title" : "The teacher and practitioner charter",
           "ref" : "section-12",
+          "id" : "section-12",
+          "href" : "section/12",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "13",
           "title" : "Reviewing and revising the charters",
           "ref" : "section-13",
+          "id" : "section-13",
+          "href" : "section/13",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "14",
           "title" : "Other charters",
           "ref" : "section-14",
+          "id" : "section-14",
+          "href" : "section/14",
           "extent" : [ "S" ]
         } ]
       }, {
@@ -173,12 +215,16 @@
         "number" : null,
         "title" : "Guidance",
         "ref" : "part-1-crossheading-guidance",
+        "id" : "part-1-crossheading-guidance",
+        "href" : "part/1/crossheading/guidance",
         "extent" : [ "S" ],
         "children" : [ {
           "name" : "item",
           "number" : "15",
           "title" : "Guidance about assistance for people with educational support needs",
           "ref" : "section-15",
+          "id" : "section-15",
+          "href" : "section/15",
           "extent" : [ "S" ]
         } ]
       }, {
@@ -186,54 +232,72 @@
         "number" : null,
         "title" : "Accountability of Qualifications Scotland",
         "ref" : "part-1-crossheading-accountability-of-qualifications-scotland",
+        "id" : "part-1-crossheading-accountability-of-qualifications-scotland",
+        "href" : "part/1/crossheading/accountability-of-qualifications-scotland",
         "extent" : [ "S" ],
         "children" : [ {
           "name" : "item",
           "number" : "16",
           "title" : "Corporate plan of Qualifications Scotland",
           "ref" : "section-16",
+          "id" : "section-16",
+          "href" : "section/16",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "17",
           "title" : "Annual report of Qualifications Scotland",
           "ref" : "section-17",
+          "id" : "section-17",
+          "href" : "section/17",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "18",
           "title" : "Annual quality assurance compliance report of Qualifications Scotland",
           "ref" : "section-18",
+          "id" : "section-18",
+          "href" : "section/18",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "19",
           "title" : "Reports of advice to Qualifications Scotland from certain committees",
           "ref" : "section-19",
+          "id" : "section-19",
+          "href" : "section/19",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "20",
           "title" : "Accounts and audit of Qualifications Scotland",
           "ref" : "section-20",
+          "id" : "section-20",
+          "href" : "section/20",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "21",
           "title" : "Scottish Ministers’ power to direct Qualifications Scotland",
           "ref" : "section-21",
+          "id" : "section-21",
+          "href" : "section/21",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "22",
           "title" : "Guidance by the Scottish Ministers to Qualifications Scotland",
           "ref" : "section-22",
+          "id" : "section-22",
+          "href" : "section/22",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "23",
           "title" : "Provision of information by Qualifications Scotland",
           "ref" : "section-23",
+          "id" : "section-23",
+          "href" : "section/23",
           "extent" : [ "S" ]
         } ]
       }, {
@@ -241,24 +305,32 @@
         "number" : null,
         "title" : "Accountability of the Accreditation Committee",
         "ref" : "part-1-crossheading-accountability-of-the-accreditation-committee",
+        "id" : "part-1-crossheading-accountability-of-the-accreditation-committee",
+        "href" : "part/1/crossheading/accountability-of-the-accreditation-committee",
         "extent" : [ "S" ],
         "children" : [ {
           "name" : "item",
           "number" : "24",
           "title" : "Corporate plan of the Accreditation Committee",
           "ref" : "section-24",
+          "id" : "section-24",
+          "href" : "section/24",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "25",
           "title" : "Annual report of the Accreditation Committee",
           "ref" : "section-25",
+          "id" : "section-25",
+          "href" : "section/25",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "26",
           "title" : "Scottish Ministers’ power to direct the Accreditation Committee",
           "ref" : "section-26",
+          "id" : "section-26",
+          "href" : "section/26",
           "extent" : [ "S" ]
         } ]
       }, {
@@ -266,24 +338,32 @@
         "number" : null,
         "title" : "Funding and powers",
         "ref" : "part-1-crossheading-funding-and-powers",
+        "id" : "part-1-crossheading-funding-and-powers",
+        "href" : "part/1/crossheading/funding-and-powers",
         "extent" : [ "S" ],
         "children" : [ {
           "name" : "item",
           "number" : "27",
           "title" : "Financial assistance",
           "ref" : "section-27",
+          "id" : "section-27",
+          "href" : "section/27",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "28",
           "title" : "Funding and use of resources",
           "ref" : "section-28",
+          "id" : "section-28",
+          "href" : "section/28",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "29",
           "title" : "General powers",
           "ref" : "section-29",
+          "id" : "section-29",
+          "href" : "section/29",
           "extent" : [ "S" ]
         } ]
       }, {
@@ -291,12 +371,16 @@
         "number" : null,
         "title" : "Supporting provisions",
         "ref" : "part-1-crossheading-supporting-provisions",
+        "id" : "part-1-crossheading-supporting-provisions",
+        "href" : "part/1/crossheading/supporting-provisions",
         "extent" : [ "S" ],
         "children" : [ {
           "name" : "item",
           "number" : "30",
           "title" : "Publication of documents",
           "ref" : "section-30",
+          "id" : "section-30",
+          "href" : "section/30",
           "extent" : [ "S" ]
         } ]
       }, {
@@ -304,18 +388,24 @@
         "number" : null,
         "title" : "Reviews",
         "ref" : "part-1-crossheading-reviews",
+        "id" : "part-1-crossheading-reviews",
+        "href" : "part/1/crossheading/reviews",
         "extent" : [ "S" ],
         "children" : [ {
           "name" : "item",
           "number" : "31",
           "title" : "Review of arrangements for assuring quality of qualifications",
           "ref" : "section-31",
+          "id" : "section-31",
+          "href" : "section/31",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "32",
           "title" : "Review of accreditation function",
           "ref" : "section-32",
+          "id" : "section-32",
+          "href" : "section/32",
           "extent" : [ "S" ]
         } ]
       } ]
@@ -324,36 +414,48 @@
       "number" : "Part 2",
       "title" : "His Majesty’s Chief Inspector of Education in Scotland",
       "ref" : "part-2",
+      "id" : "part-2",
+      "href" : "part/2",
       "extent" : [ "S" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : "Establishment",
         "ref" : "part-2-crossheading-establishment",
+        "id" : "part-2-crossheading-establishment",
+        "href" : "part/2/crossheading/establishment",
         "extent" : [ "S" ],
         "children" : [ {
           "name" : "item",
           "number" : "33",
           "title" : "His Majesty’s Chief Inspector of Education in Scotland",
           "ref" : "section-33",
+          "id" : "section-33",
+          "href" : "section/33",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "34",
           "title" : "Deputy Chief Inspector of Education in Scotland",
           "ref" : "section-34",
+          "id" : "section-34",
+          "href" : "section/34",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "35",
           "title" : "His Majesty’s Inspectors of Education in Scotland",
           "ref" : "section-35",
+          "id" : "section-35",
+          "href" : "section/35",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "36",
           "title" : "Assistance with inspections",
           "ref" : "section-36",
+          "id" : "section-36",
+          "href" : "section/36",
           "extent" : [ "S" ]
         } ]
       }, {
@@ -361,48 +463,64 @@
         "number" : null,
         "title" : "Functions",
         "ref" : "part-2-crossheading-functions",
+        "id" : "part-2-crossheading-functions",
+        "href" : "part/2/crossheading/functions",
         "extent" : [ "S" ],
         "children" : [ {
           "name" : "item",
           "number" : "37",
           "title" : "Purpose of inspection",
           "ref" : "section-37",
+          "id" : "section-37",
+          "href" : "section/37",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "38",
           "title" : "The inspection function",
           "ref" : "section-38",
+          "id" : "section-38",
+          "href" : "section/38",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "39",
           "title" : "Meaning of “relevant educational establishment” and “excepted establishment”",
           "ref" : "section-39",
+          "id" : "section-39",
+          "href" : "section/39",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "40",
           "title" : "The voluntary arrangements function",
           "ref" : "section-40",
+          "id" : "section-40",
+          "href" : "section/40",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "41",
           "title" : "The advisory function",
           "ref" : "section-41",
+          "id" : "section-41",
+          "href" : "section/41",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "42",
           "title" : "Working with others",
           "ref" : "section-42",
+          "id" : "section-42",
+          "href" : "section/42",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "43",
           "title" : "Duties when exercising functions",
           "ref" : "section-43",
+          "id" : "section-43",
+          "href" : "section/43",
           "extent" : [ "S" ]
         } ]
       }, {
@@ -410,12 +528,16 @@
         "number" : null,
         "title" : "Advisory Council",
         "ref" : "part-2-crossheading-advisory-council",
+        "id" : "part-2-crossheading-advisory-council",
+        "href" : "part/2/crossheading/advisory-council",
         "extent" : [ "S" ],
         "children" : [ {
           "name" : "item",
           "number" : "44",
           "title" : "Advisory Council",
           "ref" : "section-44",
+          "id" : "section-44",
+          "href" : "section/44",
           "extent" : [ "S" ]
         } ]
       }, {
@@ -423,42 +545,56 @@
         "number" : null,
         "title" : "Accountability",
         "ref" : "part-2-crossheading-accountability",
+        "id" : "part-2-crossheading-accountability",
+        "href" : "part/2/crossheading/accountability",
         "extent" : [ "S" ],
         "children" : [ {
           "name" : "item",
           "number" : "45",
           "title" : "Inspection plan",
           "ref" : "section-45",
+          "id" : "section-45",
+          "href" : "section/45",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "46",
           "title" : "Reports on inspections",
           "ref" : "section-46",
+          "id" : "section-46",
+          "href" : "section/46",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "47",
           "title" : "Annual report",
           "ref" : "section-47",
+          "id" : "section-47",
+          "href" : "section/47",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "48",
           "title" : "Report on performance of the Scottish education system",
           "ref" : "section-48",
+          "id" : "section-48",
+          "href" : "section/48",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "49",
           "title" : "Other reports",
           "ref" : "section-49",
+          "id" : "section-49",
+          "href" : "section/49",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "50",
           "title" : "Protection from actions of defamation",
           "ref" : "section-50",
+          "id" : "section-50",
+          "href" : "section/50",
           "extent" : [ "S" ]
         } ]
       }, {
@@ -466,12 +602,16 @@
         "number" : null,
         "title" : "Powers",
         "ref" : "part-2-crossheading-powers",
+        "id" : "part-2-crossheading-powers",
+        "href" : "part/2/crossheading/powers",
         "extent" : [ "S" ],
         "children" : [ {
           "name" : "item",
           "number" : "51",
           "title" : "General powers",
           "ref" : "section-51",
+          "id" : "section-51",
+          "href" : "section/51",
           "extent" : [ "S" ]
         } ]
       }, {
@@ -479,24 +619,32 @@
         "number" : null,
         "title" : "Cooperation with inspections",
         "ref" : "part-2-crossheading-cooperation-with-inspections",
+        "id" : "part-2-crossheading-cooperation-with-inspections",
+        "href" : "part/2/crossheading/cooperation-with-inspections",
         "extent" : [ "S" ],
         "children" : [ {
           "name" : "item",
           "number" : "52",
           "title" : "Powers of entry and inspection",
           "ref" : "section-52",
+          "id" : "section-52",
+          "href" : "section/52",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "53",
           "title" : "Duty to provide assistance",
           "ref" : "section-53",
+          "id" : "section-53",
+          "href" : "section/53",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "54",
           "title" : "Offences",
           "ref" : "section-54",
+          "id" : "section-54",
+          "href" : "section/54",
           "extent" : [ "S" ]
         } ]
       }, {
@@ -504,24 +652,32 @@
         "number" : null,
         "title" : "Enforcement following school-related inspections",
         "ref" : "part-2-crossheading-enforcement-following-schoolrelated-inspections",
+        "id" : "part-2-crossheading-enforcement-following-schoolrelated-inspections",
+        "href" : "part/2/crossheading/enforcement-following-schoolrelated-inspections",
         "extent" : [ "S" ],
         "children" : [ {
           "name" : "item",
           "number" : "55",
           "title" : "Necessary improvements: referral to Scottish Ministers",
           "ref" : "section-55",
+          "id" : "section-55",
+          "href" : "section/55",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "56",
           "title" : "Preliminary notice of enforcement action",
           "ref" : "section-56",
+          "id" : "section-56",
+          "href" : "section/56",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "57",
           "title" : "Enforcement direction",
           "ref" : "section-57",
+          "id" : "section-57",
+          "href" : "section/57",
           "extent" : [ "S" ]
         } ]
       }, {
@@ -529,12 +685,16 @@
         "number" : null,
         "title" : "Supporting provisions",
         "ref" : "part-2-crossheading-supporting-provisions",
+        "id" : "part-2-crossheading-supporting-provisions",
+        "href" : "part/2/crossheading/supporting-provisions",
         "extent" : [ "S" ],
         "children" : [ {
           "name" : "item",
           "number" : "58",
           "title" : "Publication of documents",
           "ref" : "section-58",
+          "id" : "section-58",
+          "href" : "section/58",
           "extent" : [ "S" ]
         } ]
       } ]
@@ -543,60 +703,80 @@
       "number" : "Part 3",
       "title" : "General and miscellaneous",
       "ref" : "part-3",
+      "id" : "part-3",
+      "href" : "part/3",
       "extent" : [ "S" ],
       "children" : [ {
         "name" : "item",
         "number" : "59",
         "title" : "Transfer of staff, property etc. to Qualifications Scotland",
         "ref" : "section-59",
+        "id" : "section-59",
+        "href" : "section/59",
         "extent" : [ "S" ]
       }, {
         "name" : "item",
         "number" : "60",
         "title" : "Dissolution of the Scottish Qualifications Authority",
         "ref" : "section-60",
+        "id" : "section-60",
+        "href" : "section/60",
         "extent" : [ "S" ]
       }, {
         "name" : "item",
         "number" : "61",
         "title" : "Transitional provisions",
         "ref" : "section-61",
+        "id" : "section-61",
+        "href" : "section/61",
         "extent" : [ "S" ]
       }, {
         "name" : "item",
         "number" : "62",
         "title" : "Consequential modifications",
         "ref" : "section-62",
+        "id" : "section-62",
+        "href" : "section/62",
         "extent" : [ "S" ]
       }, {
         "name" : "item",
         "number" : "63",
         "title" : "Interpretation",
         "ref" : "section-63",
+        "id" : "section-63",
+        "href" : "section/63",
         "extent" : [ "S" ]
       }, {
         "name" : "item",
         "number" : "64",
         "title" : "Regulation-making powers",
         "ref" : "section-64",
+        "id" : "section-64",
+        "href" : "section/64",
         "extent" : [ "S" ]
       }, {
         "name" : "item",
         "number" : "65",
         "title" : "Ancillary provision",
         "ref" : "section-65",
+        "id" : "section-65",
+        "href" : "section/65",
         "extent" : [ "S" ]
       }, {
         "name" : "item",
         "number" : "66",
         "title" : "Commencement",
         "ref" : "section-66",
+        "id" : "section-66",
+        "href" : "section/66",
         "extent" : [ "S" ]
       }, {
         "name" : "item",
         "number" : "67",
         "title" : "Short title",
         "ref" : "section-67",
+        "id" : "section-67",
+        "href" : "section/67",
         "extent" : [ "S" ]
       } ]
     } ],
@@ -605,18 +785,24 @@
       "number" : "Schedule 1",
       "title" : "Qualifications Scotland",
       "ref" : "schedule-1",
+      "id" : "schedule-1",
+      "href" : "schedule/1",
       "extent" : [ "S" ],
       "children" : [ {
         "name" : "part",
         "number" : "Part 1",
         "title" : "Status",
         "ref" : "schedule-1-part-1",
+        "id" : "schedule-1-part-1",
+        "href" : "schedule/1/part/1",
         "extent" : [ "S" ],
         "children" : [ {
           "name" : "item",
           "number" : "1",
           "title" : "Exclusion of Crown status",
           "ref" : "schedule-1-paragraph-1",
+          "id" : "schedule-1-paragraph-1",
+          "href" : "schedule/1/paragraph/1",
           "extent" : [ "S" ]
         } ]
       }, {
@@ -624,42 +810,56 @@
         "number" : "Part 2",
         "title" : "Membership",
         "ref" : "schedule-1-part-2",
+        "id" : "schedule-1-part-2",
+        "href" : "schedule/1/part/2",
         "extent" : [ "S" ],
         "children" : [ {
           "name" : "item",
           "number" : "2",
           "title" : "Number and appointment of members",
           "ref" : "schedule-1-paragraph-2",
+          "id" : "schedule-1-paragraph-2",
+          "href" : "schedule/1/paragraph/2",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "3",
           "title" : "Appointment as a member: criteria",
           "ref" : "schedule-1-paragraph-3",
+          "id" : "schedule-1-paragraph-3",
+          "href" : "schedule/1/paragraph/3",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "4",
           "title" : "Period and conditions of membership",
           "ref" : "schedule-1-paragraph-4",
+          "id" : "schedule-1-paragraph-4",
+          "href" : "schedule/1/paragraph/4",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "5",
           "title" : "Early termination of membership",
           "ref" : "schedule-1-paragraph-5",
+          "id" : "schedule-1-paragraph-5",
+          "href" : "schedule/1/paragraph/5",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "6",
           "title" : "Members’ remuneration and allowances",
           "ref" : "schedule-1-paragraph-6",
+          "id" : "schedule-1-paragraph-6",
+          "href" : "schedule/1/paragraph/6",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "7",
           "title" : "Co-opted members",
           "ref" : "schedule-1-paragraph-7",
+          "id" : "schedule-1-paragraph-7",
+          "href" : "schedule/1/paragraph/7",
           "extent" : [ "S" ]
         } ]
       }, {
@@ -667,18 +867,24 @@
         "number" : "Part 3",
         "title" : "Staff",
         "ref" : "schedule-1-part-3",
+        "id" : "schedule-1-part-3",
+        "href" : "schedule/1/part/3",
         "extent" : [ "S" ],
         "children" : [ {
           "name" : "item",
           "number" : "8",
           "title" : "Chief executive, chief examiner, chief accreditation officer and other staff",
           "ref" : "schedule-1-paragraph-8",
+          "id" : "schedule-1-paragraph-8",
+          "href" : "schedule/1/paragraph/8",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "9",
           "title" : "Staff pensions",
           "ref" : "schedule-1-paragraph-9",
+          "id" : "schedule-1-paragraph-9",
+          "href" : "schedule/1/paragraph/9",
           "extent" : [ "S" ]
         } ]
       }, {
@@ -686,36 +892,48 @@
         "number" : "Part 4",
         "title" : "Procedure",
         "ref" : "schedule-1-part-4",
+        "id" : "schedule-1-part-4",
+        "href" : "schedule/1/part/4",
         "extent" : [ "S" ],
         "children" : [ {
           "name" : "chapter",
           "number" : "Chapter 1",
           "title" : "Committees",
           "ref" : "schedule-1-part-4-chapter-1",
+          "id" : "schedule-1-part-4-chapter-1",
+          "href" : "schedule/1/part/4/chapter/1",
           "extent" : [ "S" ],
           "children" : [ {
             "name" : "item",
             "number" : "10",
             "title" : "Committees",
             "ref" : "schedule-1-paragraph-10",
+            "id" : "schedule-1-paragraph-10",
+            "href" : "schedule/1/paragraph/10",
             "extent" : [ "S" ]
           }, {
             "name" : "item",
             "number" : "11",
             "title" : "The Learner Interest Committee",
             "ref" : "schedule-1-paragraph-11",
+            "id" : "schedule-1-paragraph-11",
+            "href" : "schedule/1/paragraph/11",
             "extent" : [ "S" ]
           }, {
             "name" : "item",
             "number" : "12",
             "title" : "The Teacher and Practitioner Interest Committee",
             "ref" : "schedule-1-paragraph-12",
+            "id" : "schedule-1-paragraph-12",
+            "href" : "schedule/1/paragraph/12",
             "extent" : [ "S" ]
           }, {
             "name" : "item",
             "number" : "13",
             "title" : "The Accreditation Committee",
             "ref" : "schedule-1-paragraph-13",
+            "id" : "schedule-1-paragraph-13",
+            "href" : "schedule/1/paragraph/13",
             "extent" : [ "S" ]
           } ]
         }, {
@@ -723,30 +941,40 @@
           "number" : "Chapter 2",
           "title" : "Administration of Qualifications Scotland and its committees",
           "ref" : "schedule-1-part-4-chapter-2",
+          "id" : "schedule-1-part-4-chapter-2",
+          "href" : "schedule/1/part/4/chapter/2",
           "extent" : [ "S" ],
           "children" : [ {
             "name" : "item",
             "number" : "14",
             "title" : "Regulation of procedure",
             "ref" : "schedule-1-paragraph-14",
+            "id" : "schedule-1-paragraph-14",
+            "href" : "schedule/1/paragraph/14",
             "extent" : [ "S" ]
           }, {
             "name" : "item",
             "number" : "15",
             "title" : "Authority to perform functions",
             "ref" : "schedule-1-paragraph-15",
+            "id" : "schedule-1-paragraph-15",
+            "href" : "schedule/1/paragraph/15",
             "extent" : [ "S" ]
           }, {
             "name" : "item",
             "number" : "16",
             "title" : "Member consultation requirement",
             "ref" : "schedule-1-paragraph-16",
+            "id" : "schedule-1-paragraph-16",
+            "href" : "schedule/1/paragraph/16",
             "extent" : [ "S" ]
           }, {
             "name" : "item",
             "number" : "17",
             "title" : "Validity of things done",
             "ref" : "schedule-1-paragraph-17",
+            "id" : "schedule-1-paragraph-17",
+            "href" : "schedule/1/paragraph/17",
             "extent" : [ "S" ]
           } ]
         } ]
@@ -756,24 +984,32 @@
       "number" : "Schedule 2",
       "title" : "The Office of His Majesty’s Chief Inspector of Education in Scotland",
       "ref" : "schedule-2",
+      "id" : "schedule-2",
+      "href" : "schedule/2",
       "extent" : [ "S" ],
       "children" : [ {
         "name" : "part",
         "number" : "Part 1",
         "title" : "Status",
         "ref" : "schedule-2-part-1",
+        "id" : "schedule-2-part-1",
+        "href" : "schedule/2/part/1",
         "extent" : [ "S" ],
         "children" : [ {
           "name" : "item",
           "number" : "1",
           "title" : "Status",
           "ref" : "schedule-2-paragraph-1",
+          "id" : "schedule-2-paragraph-1",
+          "href" : "schedule/2/paragraph/1",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "2",
           "title" : "Independence",
           "ref" : "schedule-2-paragraph-2",
+          "id" : "schedule-2-paragraph-2",
+          "href" : "schedule/2/paragraph/2",
           "extent" : [ "S" ]
         } ]
       }, {
@@ -781,18 +1017,24 @@
         "number" : "Part 2",
         "title" : "Appointment and terms",
         "ref" : "schedule-2-part-2",
+        "id" : "schedule-2-part-2",
+        "href" : "schedule/2/part/2",
         "extent" : [ "S" ],
         "children" : [ {
           "name" : "item",
           "number" : "3",
           "title" : "Appointment",
           "ref" : "schedule-2-paragraph-3",
+          "id" : "schedule-2-paragraph-3",
+          "href" : "schedule/2/paragraph/3",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "4",
           "title" : "Period and conditions of office",
           "ref" : "schedule-2-paragraph-4",
+          "id" : "schedule-2-paragraph-4",
+          "href" : "schedule/2/paragraph/4",
           "extent" : [ "S" ]
         } ]
       }, {
@@ -800,12 +1042,16 @@
         "number" : "Part 3",
         "title" : "Staff",
         "ref" : "schedule-2-part-3",
+        "id" : "schedule-2-part-3",
+        "href" : "schedule/2/part/3",
         "extent" : [ "S" ],
         "children" : [ {
           "name" : "item",
           "number" : "5",
           "title" : "Staff",
           "ref" : "schedule-2-paragraph-5",
+          "id" : "schedule-2-paragraph-5",
+          "href" : "schedule/2/paragraph/5",
           "extent" : [ "S" ]
         } ]
       }, {
@@ -813,24 +1059,32 @@
         "number" : "Part 4",
         "title" : "Procedure",
         "ref" : "schedule-2-part-4",
+        "id" : "schedule-2-part-4",
+        "href" : "schedule/2/part/4",
         "extent" : [ "S" ],
         "children" : [ {
           "name" : "item",
           "number" : "6",
           "title" : "Authority to perform functions",
           "ref" : "schedule-2-paragraph-6",
+          "id" : "schedule-2-paragraph-6",
+          "href" : "schedule/2/paragraph/6",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "7",
           "title" : "(1) The Scottish Ministers may assign to an Inspector the...",
           "ref" : "schedule-2-paragraph-7",
+          "id" : "schedule-2-paragraph-7",
+          "href" : "schedule/2/paragraph/7",
           "extent" : [ "S" ]
         }, {
           "name" : "item",
           "number" : "8",
           "title" : "Validity of things done",
           "ref" : "schedule-2-paragraph-8",
+          "id" : "schedule-2-paragraph-8",
+          "href" : "schedule/2/paragraph/8",
           "extent" : [ "S" ]
         } ]
       } ]
@@ -839,36 +1093,48 @@
       "number" : "Schedule 3",
       "title" : "Transfer of staff, property etc. to Qualifications Scotland",
       "ref" : "schedule-3",
+      "id" : "schedule-3",
+      "href" : "schedule/3",
       "extent" : [ "S" ],
       "children" : [ {
         "name" : "item",
         "number" : "1",
         "title" : "Transfer date",
         "ref" : "schedule-3-paragraph-1",
+        "id" : "schedule-3-paragraph-1",
+        "href" : "schedule/3/paragraph/1",
         "extent" : [ "S" ]
       }, {
         "name" : "item",
         "number" : "2",
         "title" : "Transfer of staff",
         "ref" : "schedule-3-paragraph-2",
+        "id" : "schedule-3-paragraph-2",
+        "href" : "schedule/3/paragraph/2",
         "extent" : [ "S" ]
       }, {
         "name" : "item",
         "number" : "3",
         "title" : "Transfer of property",
         "ref" : "schedule-3-paragraph-3",
+        "id" : "schedule-3-paragraph-3",
+        "href" : "schedule/3/paragraph/3",
         "extent" : [ "S" ]
       }, {
         "name" : "item",
         "number" : "4",
         "title" : "Duty to secure vesting of foreign property",
         "ref" : "schedule-3-paragraph-4",
+        "id" : "schedule-3-paragraph-4",
+        "href" : "schedule/3/paragraph/4",
         "extent" : [ "S" ]
       }, {
         "name" : "item",
         "number" : "5",
         "title" : "Appointment of initial board members",
         "ref" : "schedule-3-paragraph-5",
+        "id" : "schedule-3-paragraph-5",
+        "href" : "schedule/3/paragraph/5",
         "extent" : [ "S" ]
       } ]
     }, {
@@ -876,72 +1142,96 @@
       "number" : "Schedule 4",
       "title" : "Consequential modifications",
       "ref" : "schedule-4",
+      "id" : "schedule-4",
+      "href" : "schedule/4",
       "extent" : [ "S" ],
       "children" : [ {
         "name" : "part",
         "number" : "Part 1",
         "title" : "Qualifications Scotland",
         "ref" : "schedule-4-part-1",
+        "id" : "schedule-4-part-1",
+        "href" : "schedule/4/part/1",
         "extent" : [ "S" ],
         "children" : [ {
           "name" : "chapter",
           "number" : "Chapter 1",
           "title" : "Application of legislation relating to public bodies to Qualifications Scotland",
           "ref" : "schedule-4-part-1-chapter-1",
+          "id" : "schedule-4-part-1-chapter-1",
+          "href" : "schedule/4/part/1/chapter/1",
           "extent" : [ "S" ],
           "children" : [ {
             "name" : "item",
             "number" : "1",
             "title" : "Ethical Standards in Public Life etc. (Scotland) Act 2000",
             "ref" : "schedule-4-paragraph-1",
+            "id" : "schedule-4-paragraph-1",
+            "href" : "schedule/4/paragraph/1",
             "extent" : [ "S" ]
           }, {
             "name" : "item",
             "number" : "2",
             "title" : "Scottish Public Services Ombudsman Act 2002",
             "ref" : "schedule-4-paragraph-2",
+            "id" : "schedule-4-paragraph-2",
+            "href" : "schedule/4/paragraph/2",
             "extent" : [ "S" ]
           }, {
             "name" : "item",
             "number" : "3",
             "title" : "Freedom of Information (Scotland) Act 2002",
             "ref" : "schedule-4-paragraph-3",
+            "id" : "schedule-4-paragraph-3",
+            "href" : "schedule/4/paragraph/3",
             "extent" : [ "S" ]
           }, {
             "name" : "item",
             "number" : "4",
             "title" : "Public Appointments and Public Bodies etc. (Scotland) Act 2003",
             "ref" : "schedule-4-paragraph-4",
+            "id" : "schedule-4-paragraph-4",
+            "href" : "schedule/4/paragraph/4",
             "extent" : [ "S" ]
           }, {
             "name" : "item",
             "number" : "5",
             "title" : "Public Services Reform (Scotland) Act 2010",
             "ref" : "schedule-4-paragraph-5",
+            "id" : "schedule-4-paragraph-5",
+            "href" : "schedule/4/paragraph/5",
             "extent" : [ "S" ]
           }, {
             "name" : "item",
             "number" : "6",
             "title" : "Public Records (Scotland) Act 2011",
             "ref" : "schedule-4-paragraph-6",
+            "id" : "schedule-4-paragraph-6",
+            "href" : "schedule/4/paragraph/6",
             "extent" : [ "S" ]
           }, {
             "name" : "item",
             "number" : "7",
             "title" : "Procurement Reform (Scotland) Act 2014",
             "ref" : "schedule-4-paragraph-7",
+            "id" : "schedule-4-paragraph-7",
+            "href" : "schedule/4/paragraph/7",
             "extent" : [ "S" ]
           }, {
             "name" : "item",
             "number" : "8",
             "title" : "Gender Representation on Public Boards (Scotland) Act 2018",
             "ref" : "schedule-4-paragraph-8",
+            "id" : "schedule-4-paragraph-8",
+            "href" : "schedule/4/paragraph/8",
             "extent" : [ "S" ]
           }, {
             "name" : "item",
             "number" : "9",
             "title" : "Islands (Scotland) Act 2018",
             "ref" : "schedule-4-paragraph-9",
+            "id" : "schedule-4-paragraph-9",
+            "href" : "schedule/4/paragraph/9",
             "extent" : [ "S" ]
           } ]
         }, {
@@ -949,42 +1239,56 @@
           "number" : "Chapter 2",
           "title" : "Other modifications relating to Qualifications Scotland",
           "ref" : "schedule-4-part-1-chapter-2",
+          "id" : "schedule-4-part-1-chapter-2",
+          "href" : "schedule/4/part/1/chapter/2",
           "extent" : [ "S" ],
           "children" : [ {
             "name" : "item",
             "number" : "10",
             "title" : "Further and Higher Education (Scotland) Act 1992",
             "ref" : "schedule-4-paragraph-10",
+            "id" : "schedule-4-paragraph-10",
+            "href" : "schedule/4/paragraph/10",
             "extent" : [ "S" ]
           }, {
             "name" : "item",
             "number" : "11",
             "title" : "Education (Scotland) Act 1996",
             "ref" : "schedule-4-paragraph-11",
+            "id" : "schedule-4-paragraph-11",
+            "href" : "schedule/4/paragraph/11",
             "extent" : [ "S" ]
           }, {
             "name" : "item",
             "number" : "12",
             "title" : "Scottish Qualifications Authority Act 2002",
             "ref" : "schedule-4-paragraph-12",
+            "id" : "schedule-4-paragraph-12",
+            "href" : "schedule/4/paragraph/12",
             "extent" : [ "S" ]
           }, {
             "name" : "item",
             "number" : "13",
             "title" : "Further and Higher Education (Scotland) Act 2005",
             "ref" : "schedule-4-paragraph-13",
+            "id" : "schedule-4-paragraph-13",
+            "href" : "schedule/4/paragraph/13",
             "extent" : [ "S" ]
           }, {
             "name" : "item",
             "number" : "14",
             "title" : "Children and Young People (Scotland) Act 2014",
             "ref" : "schedule-4-paragraph-14",
+            "id" : "schedule-4-paragraph-14",
+            "href" : "schedule/4/paragraph/14",
             "extent" : [ "S" ]
           }, {
             "name" : "item",
             "number" : "15",
             "title" : "Coronavirus (Recovery and Reform) (Scotland) Act 2022",
             "ref" : "schedule-4-paragraph-15",
+            "id" : "schedule-4-paragraph-15",
+            "href" : "schedule/4/paragraph/15",
             "extent" : [ "S" ]
           } ]
         } ]
@@ -993,42 +1297,56 @@
         "number" : "Part 2",
         "title" : "The office of His Majesty’s Chief Inspector of Education in Scotland",
         "ref" : "schedule-4-part-2",
+        "id" : "schedule-4-part-2",
+        "href" : "schedule/4/part/2",
         "extent" : [ "S" ],
         "children" : [ {
           "name" : "chapter",
           "number" : "Chapter 1",
           "title" : "Application of legislation relating to office-holders to the Chief Inspector",
           "ref" : "schedule-4-part-2-chapter-1",
+          "id" : "schedule-4-part-2-chapter-1",
+          "href" : "schedule/4/part/2/chapter/1",
           "extent" : [ "S" ],
           "children" : [ {
             "name" : "item",
             "number" : "16",
             "title" : "Freedom of Information (Scotland) Act 2002",
             "ref" : "schedule-4-paragraph-16",
+            "id" : "schedule-4-paragraph-16",
+            "href" : "schedule/4/paragraph/16",
             "extent" : [ "S" ]
           }, {
             "name" : "item",
             "number" : "17",
             "title" : "Protection of Vulnerable Groups (Scotland) Act 2007",
             "ref" : "schedule-4-paragraph-17",
+            "id" : "schedule-4-paragraph-17",
+            "href" : "schedule/4/paragraph/17",
             "extent" : [ "S" ]
           }, {
             "name" : "item",
             "number" : "18",
             "title" : "Public Services Reform (Scotland) Act 2010",
             "ref" : "schedule-4-paragraph-18",
+            "id" : "schedule-4-paragraph-18",
+            "href" : "schedule/4/paragraph/18",
             "extent" : [ "S" ]
           }, {
             "name" : "item",
             "number" : "19",
             "title" : "Public Records (Scotland) Act 2011",
             "ref" : "schedule-4-paragraph-19",
+            "id" : "schedule-4-paragraph-19",
+            "href" : "schedule/4/paragraph/19",
             "extent" : [ "S" ]
           }, {
             "name" : "item",
             "number" : "20",
             "title" : "Procurement Reform (Scotland) Act 2014",
             "ref" : "schedule-4-paragraph-20",
+            "id" : "schedule-4-paragraph-20",
+            "href" : "schedule/4/paragraph/20",
             "extent" : [ "S" ]
           } ]
         }, {
@@ -1036,48 +1354,64 @@
           "number" : "Chapter 2",
           "title" : "Other modifications relating to the Chief Inspector",
           "ref" : "schedule-4-part-2-chapter-2",
+          "id" : "schedule-4-part-2-chapter-2",
+          "href" : "schedule/4/part/2/chapter/2",
           "extent" : [ "S" ],
           "children" : [ {
             "name" : "item",
             "number" : "21",
             "title" : "Education (Scotland) Act 1980",
             "ref" : "schedule-4-paragraph-21",
+            "id" : "schedule-4-paragraph-21",
+            "href" : "schedule/4/paragraph/21",
             "extent" : [ "S" ]
           }, {
             "name" : "item",
             "number" : "22",
             "title" : "Standards in Scotland’s Schools etc. Act 2000",
             "ref" : "schedule-4-paragraph-22",
+            "id" : "schedule-4-paragraph-22",
+            "href" : "schedule/4/paragraph/22",
             "extent" : [ "S" ]
           }, {
             "name" : "item",
             "number" : "23",
             "title" : "Scottish Schools (Parental Involvement) Act 2006",
             "ref" : "schedule-4-paragraph-23",
+            "id" : "schedule-4-paragraph-23",
+            "href" : "schedule/4/paragraph/23",
             "extent" : [ "S" ]
           }, {
             "name" : "item",
             "number" : "24",
             "title" : "Schools (Consultation) (Scotland) Act 2010",
             "ref" : "schedule-4-paragraph-24",
+            "id" : "schedule-4-paragraph-24",
+            "href" : "schedule/4/paragraph/24",
             "extent" : [ "S" ]
           }, {
             "name" : "item",
             "number" : "25",
             "title" : "Public Services Reform (Scotland) Act 2010",
             "ref" : "schedule-4-paragraph-25",
+            "id" : "schedule-4-paragraph-25",
+            "href" : "schedule/4/paragraph/25",
             "extent" : [ "S" ]
           }, {
             "name" : "item",
             "number" : "26",
             "title" : "Education (Scotland) Act 2016",
             "ref" : "schedule-4-paragraph-26",
+            "id" : "schedule-4-paragraph-26",
+            "href" : "schedule/4/paragraph/26",
             "extent" : [ "S" ]
           }, {
             "name" : "item",
             "number" : "27",
             "title" : "Schools General (Scotland) Regulations 1975",
             "ref" : "schedule-4-paragraph-27",
+            "id" : "schedule-4-paragraph-27",
+            "href" : "schedule/4/paragraph/27",
             "extent" : [ "S" ]
           } ]
         } ]

--- a/src/test/resources/asp_2025_11/asp-2025-11-part-1-crossheading-reviews-2025-08-07.json
+++ b/src/test/resources/asp_2025_11/asp-2025-11-part-1-crossheading-reviews-2025-08-07.json
@@ -37,24 +37,24 @@
     "fragmentInfo" : {
       "element" : "Pblock",
       "id" : "part-1-crossheading-reviews",
-      "href" : "asp/2025/11/part/1/crossheading/reviews/2025-08-07",
+      "href" : "part/1/crossheading/reviews",
       "number" : null,
       "title" : "Reviews",
       "label" : "Reviews",
       "prospective" : true
     },
     "prevInfo" : {
-      "href" : "asp/2025/11/part/1/crossheading/supporting-provisions/2025-08-07",
+      "href" : "part/1/crossheading/supporting-provisions",
       "label" : "Crossheading"
     },
     "nextInfo" : {
-      "href" : "asp/2025/11/part/2/crossheading/establishment/2025-08-07",
+      "href" : "part/2/crossheading/establishment",
       "label" : "Crossheading"
     },
     "ancestors" : [ {
       "element" : "Part",
       "id" : "part-1",
-      "href" : "asp/2025/11/part/1/2025-08-07",
+      "href" : "part/1",
       "number" : "Part 1",
       "title" : "Qualifications Scotland",
       "label" : "Part 1",
@@ -62,7 +62,7 @@
     }, {
       "element" : "Pblock",
       "id" : "part-1-crossheading-reviews",
-      "href" : "asp/2025/11/part/1/crossheading/reviews/2025-08-07",
+      "href" : "part/1/crossheading/reviews",
       "number" : null,
       "title" : "Reviews",
       "label" : "Reviews",
@@ -71,7 +71,7 @@
     "descendants" : [ {
       "element" : "Pblock",
       "id" : "part-1-crossheading-reviews",
-      "href" : "asp/2025/11/part/1/crossheading/reviews/2025-08-07",
+      "href" : "part/1/crossheading/reviews",
       "number" : null,
       "title" : "Reviews",
       "label" : "Reviews",
@@ -79,7 +79,7 @@
     }, {
       "element" : "P1",
       "id" : "section-31",
-      "href" : "asp/2025/11/section/31/2025-08-07",
+      "href" : "section/31",
       "number" : "31",
       "title" : "Review of arrangements for assuring quality of qualifications",
       "label" : "Section 31",
@@ -87,105 +87,105 @@
     }, {
       "element" : "P2",
       "id" : "section-31-1",
-      "href" : "asp/2025/11/section/31/1/2025-08-07",
+      "href" : "section/31/1",
       "number" : "1",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "section-31-2",
-      "href" : "asp/2025/11/section/31/2/2025-08-07",
+      "href" : "section/31/2",
       "number" : "2",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-31-2-a",
-      "href" : "asp/2025/11/section/31/2/a/2025-08-07",
+      "href" : "section/31/2/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "InternalLink",
       "id" : null,
-      "href" : "asp/2025/11/section/31/1/2025-08-07",
+      "href" : "section/31/1",
       "number" : null,
       "title" : null,
       "label" : "InternalLink"
     }, {
       "element" : "P3",
       "id" : "section-31-2-b",
-      "href" : "asp/2025/11/section/31/2/b/2025-08-07",
+      "href" : "section/31/2/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "InternalLink",
       "id" : null,
-      "href" : "asp/2025/11/section/31/1/2025-08-07",
+      "href" : "section/31/1",
       "number" : null,
       "title" : null,
       "label" : "InternalLink"
     }, {
       "element" : "P2",
       "id" : "section-31-3",
-      "href" : "asp/2025/11/section/31/3/2025-08-07",
+      "href" : "section/31/3",
       "number" : "3",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "InternalLink",
       "id" : null,
-      "href" : "asp/2025/11/section/31/1/2025-08-07",
+      "href" : "section/31/1",
       "number" : null,
       "title" : null,
       "label" : "InternalLink"
     }, {
       "element" : "P3",
       "id" : "section-31-3-a",
-      "href" : "asp/2025/11/section/31/3/a/2025-08-07",
+      "href" : "section/31/3/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-31-3-b",
-      "href" : "asp/2025/11/section/31/3/b/2025-08-07",
+      "href" : "section/31/3/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P2",
       "id" : "section-31-4",
-      "href" : "asp/2025/11/section/31/4/2025-08-07",
+      "href" : "section/31/4",
       "number" : "4",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-31-4-a",
-      "href" : "asp/2025/11/section/31/4/a/2025-08-07",
+      "href" : "section/31/4/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-31-4-b",
-      "href" : "asp/2025/11/section/31/4/b/2025-08-07",
+      "href" : "section/31/4/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-31-4-c",
-      "href" : "asp/2025/11/section/31/4/c/2025-08-07",
+      "href" : "section/31/4/c",
       "number" : "c",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P1",
       "id" : "section-32",
-      "href" : "asp/2025/11/section/32/2025-08-07",
+      "href" : "section/32",
       "number" : "32",
       "title" : "Review of accreditation function",
       "label" : "Section 32",
@@ -193,133 +193,133 @@
     }, {
       "element" : "P2",
       "id" : "section-32-1",
-      "href" : "asp/2025/11/section/32/1/2025-08-07",
+      "href" : "section/32/1",
       "number" : "1",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-32-1-a",
-      "href" : "asp/2025/11/section/32/1/a/2025-08-07",
+      "href" : "section/32/1/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-32-1-b",
-      "href" : "asp/2025/11/section/32/1/b/2025-08-07",
+      "href" : "section/32/1/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-32-1-c",
-      "href" : "asp/2025/11/section/32/1/c/2025-08-07",
+      "href" : "section/32/1/c",
       "number" : "c",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P2",
       "id" : "section-32-2",
-      "href" : "asp/2025/11/section/32/2/2025-08-07",
+      "href" : "section/32/2",
       "number" : "2",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-32-2-a",
-      "href" : "asp/2025/11/section/32/2/a/2025-08-07",
+      "href" : "section/32/2/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-32-2-b",
-      "href" : "asp/2025/11/section/32/2/b/2025-08-07",
+      "href" : "section/32/2/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-32-2-c",
-      "href" : "asp/2025/11/section/32/2/c/2025-08-07",
+      "href" : "section/32/2/c",
       "number" : "c",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P2",
       "id" : "section-32-3",
-      "href" : "asp/2025/11/section/32/3/2025-08-07",
+      "href" : "section/32/3",
       "number" : "3",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-32-3-a",
-      "href" : "asp/2025/11/section/32/3/a/2025-08-07",
+      "href" : "section/32/3/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-32-3-b",
-      "href" : "asp/2025/11/section/32/3/b/2025-08-07",
+      "href" : "section/32/3/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P4",
       "id" : "section-32-3-b-i",
-      "href" : "asp/2025/11/section/32/3/b/i/2025-08-07",
+      "href" : "section/32/3/b/i",
       "number" : "i",
       "title" : null,
       "label" : "P4"
     }, {
       "element" : "P4",
       "id" : "section-32-3-b-ii",
-      "href" : "asp/2025/11/section/32/3/b/ii/2025-08-07",
+      "href" : "section/32/3/b/ii",
       "number" : "ii",
       "title" : null,
       "label" : "P4"
     }, {
       "element" : "P4",
       "id" : "section-32-3-b-iii",
-      "href" : "asp/2025/11/section/32/3/b/iii/2025-08-07",
+      "href" : "section/32/3/b/iii",
       "number" : "iii",
       "title" : null,
       "label" : "P4"
     }, {
       "element" : "P2",
       "id" : "section-32-4",
-      "href" : "asp/2025/11/section/32/4/2025-08-07",
+      "href" : "section/32/4",
       "number" : "4",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "section-32-5",
-      "href" : "asp/2025/11/section/32/5/2025-08-07",
+      "href" : "section/32/5",
       "number" : "5",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-32-5-a",
-      "href" : "asp/2025/11/section/32/5/a/2025-08-07",
+      "href" : "section/32/5/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-32-5-b",
-      "href" : "asp/2025/11/section/32/5/b/2025-08-07",
+      "href" : "section/32/5/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P2",
       "id" : "section-32-6",
-      "href" : "asp/2025/11/section/32/6/2025-08-07",
+      "href" : "section/32/6",
       "number" : "6",
       "title" : null,
       "label" : "P2"

--- a/src/test/resources/asp_2025_11/asp-2025-11-part-1-crossheading-reviews-2025-08-07.json
+++ b/src/test/resources/asp_2025_11/asp-2025-11-part-1-crossheading-reviews-2025-08-07.json
@@ -8,14 +8,14 @@
     "isbn" : "9780105904403",
     "date" : "2025-08-06",
     "cite" : "2025 asp 11",
-    "version" : "2025-08-07",
+    "version" : "prospective",
     "status" : "revised",
     "title" : "Education (Scotland) Act 2025",
     "extent" : [ "S" ],
     "lang" : null,
     "publisher" : "Statute Law Database",
     "modified" : "2025-09-11",
-    "versions" : [ "enacted", "2025-08-07" ],
+    "versions" : [ "enacted", "prospective" ],
     "has" : {
       "introduction" : true,
       "schedules" : true
@@ -40,7 +40,8 @@
       "href" : "asp/2025/11/part/1/crossheading/reviews/2025-08-07",
       "number" : null,
       "title" : "Reviews",
-      "label" : "Reviews"
+      "label" : "Reviews",
+      "prospective" : true
     },
     "prevInfo" : {
       "href" : "asp/2025/11/part/1/crossheading/supporting-provisions/2025-08-07",
@@ -56,14 +57,16 @@
       "href" : "asp/2025/11/part/1/2025-08-07",
       "number" : "Part 1",
       "title" : "Qualifications Scotland",
-      "label" : "Part 1"
+      "label" : "Part 1",
+      "prospective" : true
     }, {
       "element" : "Pblock",
       "id" : "part-1-crossheading-reviews",
       "href" : "asp/2025/11/part/1/crossheading/reviews/2025-08-07",
       "number" : null,
       "title" : "Reviews",
-      "label" : "Reviews"
+      "label" : "Reviews",
+      "prospective" : true
     } ],
     "descendants" : [ {
       "element" : "Pblock",
@@ -71,14 +74,16 @@
       "href" : "asp/2025/11/part/1/crossheading/reviews/2025-08-07",
       "number" : null,
       "title" : "Reviews",
-      "label" : "Reviews"
+      "label" : "Reviews",
+      "prospective" : true
     }, {
       "element" : "P1",
       "id" : "section-31",
       "href" : "asp/2025/11/section/31/2025-08-07",
       "number" : "31",
       "title" : "Review of arrangements for assuring quality of qualifications",
-      "label" : "Section 31"
+      "label" : "Section 31",
+      "prospective" : true
     }, {
       "element" : "P2",
       "id" : "section-31-1",
@@ -183,7 +188,8 @@
       "href" : "asp/2025/11/section/32/2025-08-07",
       "number" : "32",
       "title" : "Review of accreditation function",
-      "label" : "Section 32"
+      "label" : "Section 32",
+      "prospective" : true
     }, {
       "element" : "P2",
       "id" : "section-32-1",

--- a/src/test/resources/nia_2022_21/nia-2022-21-contents-enacted.json
+++ b/src/test/resources/nia_2022_21/nia-2022-21-contents-enacted.json
@@ -40,6 +40,8 @@
       "number" : null,
       "title" : "Introductory Text",
       "ref" : "introduction",
+      "id" : null,
+      "href" : null,
       "extent" : [ "E", "W", "S", "NI" ]
     },
     "body" : [ {
@@ -47,24 +49,32 @@
       "number" : "1",
       "title" : "Meaning of “compulsory school age”",
       "ref" : "section-1",
+      "id" : "section-1",
+      "href" : "section/1",
       "extent" : [ "E", "W", "S", "NI" ]
     }, {
       "name" : "item",
       "number" : "2",
       "title" : "Consequential amendments",
       "ref" : "section-2",
+      "id" : "section-2",
+      "href" : "section/2",
       "extent" : [ "E", "W", "S", "NI" ]
     }, {
       "name" : "item",
       "number" : "3",
       "title" : "Review",
       "ref" : "section-3",
+      "id" : "section-3",
+      "href" : "section/3",
       "extent" : [ "E", "W", "S", "NI" ]
     }, {
       "name" : "item",
       "number" : "4",
       "title" : "Commencement and short title",
       "ref" : "section-4",
+      "id" : "section-4",
+      "href" : "section/4",
       "extent" : [ "E", "W", "S", "NI" ]
     } ]
   }

--- a/src/test/resources/nia_2022_21/nia-2022-21-introduction-enacted.json
+++ b/src/test/resources/nia_2022_21/nia-2022-21-introduction-enacted.json
@@ -36,21 +36,21 @@
     "fragmentInfo" : {
       "element" : "PrimaryPrelims",
       "id" : null,
-      "href" : "nia/2022/21/introduction/enacted",
+      "href" : "introduction",
       "number" : "2022 Chapter 21",
       "title" : "School Age Act (Northern Ireland) 2022",
       "label" : "PrimaryPrelims"
     },
     "prevInfo" : null,
     "nextInfo" : {
-      "href" : "nia/2022/21/section/1/enacted",
+      "href" : "section/1",
       "label" : "Provision"
     },
     "ancestors" : [ ],
     "descendants" : [ {
       "element" : "PrimaryPrelims",
       "id" : null,
-      "href" : "nia/2022/21/introduction/enacted",
+      "href" : "introduction",
       "number" : "2022 Chapter 21",
       "title" : "School Age Act (Northern Ireland) 2022",
       "label" : "PrimaryPrelims"

--- a/src/test/resources/ukla_2017_1/ukla-2017-1-contents-enacted.json
+++ b/src/test/resources/ukla_2017_1/ukla-2017-1-contents-enacted.json
@@ -41,6 +41,8 @@
       "number" : null,
       "title" : "Introductory Text",
       "ref" : "introduction",
+      "id" : null,
+      "href" : null,
       "extent" : [ "E", "W", "S", "NI" ]
     },
     "body" : [ {
@@ -48,18 +50,24 @@
       "number" : "PART 1",
       "title" : "INTRODUCTORY",
       "ref" : "part-1",
+      "id" : "part-1",
+      "href" : "part/1",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "1",
         "title" : "Citation",
         "ref" : "section-1",
+        "id" : "section-1",
+        "href" : "section/1",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "2",
         "title" : "Interpretation",
         "ref" : "section-2",
+        "id" : "section-2",
+        "href" : "section/2",
         "extent" : [ "E", "W", "S", "NI" ]
       } ]
     }, {
@@ -67,60 +75,80 @@
       "number" : "PART 2",
       "title" : "CONSTITUTION AND POWERS OF THE COMPANY",
       "ref" : "part-2",
+      "id" : "part-2",
+      "href" : "part/2",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "3",
         "title" : "Company name and adoption of model articles",
         "ref" : "section-3",
+        "id" : "section-3",
+        "href" : "section/3",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "4",
         "title" : "Alteration of objects and powers",
         "ref" : "section-4",
+        "id" : "section-4",
+        "href" : "section/4",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "5",
         "title" : "Disapplication of Companies Clauses Acts",
         "ref" : "section-5",
+        "id" : "section-5",
+        "href" : "section/5",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "6",
         "title" : "Liability of members",
         "ref" : "section-6",
+        "id" : "section-6",
+        "href" : "section/6",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "7",
         "title" : "Power to raise additional capital",
         "ref" : "section-7",
+        "id" : "section-7",
+        "href" : "section/7",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "8",
         "title" : "Power to borrow",
         "ref" : "section-8",
+        "id" : "section-8",
+        "href" : "section/8",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "9",
         "title" : "Subscriptions for shares and loans",
         "ref" : "section-9",
+        "id" : "section-9",
+        "href" : "section/9",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "10",
         "title" : "Powers relating to land",
         "ref" : "section-10",
+        "id" : "section-10",
+        "href" : "section/10",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "11",
         "title" : "Repeal of outdated legislation",
         "ref" : "section-11",
+        "id" : "section-11",
+        "href" : "section/11",
         "extent" : [ "E", "W", "S", "NI" ]
       } ]
     }, {
@@ -128,36 +156,48 @@
       "number" : "PART 3",
       "title" : "MISSING SHAREHOLDERS AND CLAIMS",
       "ref" : "part-3",
+      "id" : "part-3",
+      "href" : "part/3",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "12",
         "title" : "Interpretation of Part 3",
         "ref" : "section-12",
+        "id" : "section-12",
+        "href" : "section/12",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "13",
         "title" : "Notices and procedure for claims",
         "ref" : "section-13",
+        "id" : "section-13",
+        "href" : "section/13",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "14",
         "title" : "Sale of shares",
         "ref" : "section-14",
+        "id" : "section-14",
+        "href" : "section/14",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "15",
         "title" : "Notices in electronic form",
         "ref" : "section-15",
+        "id" : "section-15",
+        "href" : "section/15",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "16",
         "title" : "Saving for section 125 of 2006 Act",
         "ref" : "section-16",
+        "id" : "section-16",
+        "href" : "section/16",
         "extent" : [ "E", "W", "S", "NI" ]
       } ]
     }, {
@@ -165,30 +205,40 @@
       "number" : "PART 4",
       "title" : "FINAL PROVISIONS",
       "ref" : "part-4",
+      "id" : "part-4",
+      "href" : "part/4",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "17",
         "title" : "Saving for rights over the fishery, etc",
         "ref" : "section-17",
+        "id" : "section-17",
+        "href" : "section/17",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "18",
         "title" : "Saving for Port of Sheerness Limited and harbourmaster",
         "ref" : "section-18",
+        "id" : "section-18",
+        "href" : "section/18",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "19",
         "title" : "Costs of this Act",
         "ref" : "section-19",
+        "id" : "section-19",
+        "href" : "section/19",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "20",
         "title" : "Commencement",
         "ref" : "section-20",
+        "id" : "section-20",
+        "href" : "section/20",
         "extent" : [ "E", "W", "S", "NI" ]
       } ]
     } ],
@@ -197,78 +247,104 @@
       "number" : "SCHEDULE",
       "title" : "REPEALS",
       "ref" : "schedule",
+      "id" : "schedule",
+      "href" : "schedule",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "1",
         "title" : "The following provisions of the 1930 Act are repealed. ",
         "ref" : "schedule-paragraph-1",
+        "id" : "schedule-paragraph-1",
+        "href" : "schedule/paragraph/1",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "2",
         "title" : "In section 2 (Act divided into Parts) the words “Part...",
         "ref" : "schedule-paragraph-2",
+        "id" : "schedule-paragraph-2",
+        "href" : "schedule/paragraph/2",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "3",
         "title" : "In section 3 (incorporation of general Acts)— ",
         "ref" : "schedule-paragraph-3",
+        "id" : "schedule-paragraph-3",
+        "href" : "schedule/paragraph/3",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "4",
         "title" : "Section 21 (new shares to be subject to same incidents...",
         "ref" : "schedule-paragraph-4",
+        "id" : "schedule-paragraph-4",
+        "href" : "schedule/paragraph/4",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "5",
         "title" : "Section 24 (for appointment of receiver). ",
         "ref" : "schedule-paragraph-5",
+        "id" : "schedule-paragraph-5",
+        "href" : "schedule/paragraph/5",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "6",
         "title" : "Section 25 (debenture stock). ",
         "ref" : "schedule-paragraph-6",
+        "id" : "schedule-paragraph-6",
+        "href" : "schedule/paragraph/6",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "7",
         "title" : "Section 26 (priority of mortgages over other debts). ",
         "ref" : "schedule-paragraph-7",
+        "id" : "schedule-paragraph-7",
+        "href" : "schedule/paragraph/7",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "8",
         "title" : "Section 27 (application of moneys). ",
         "ref" : "schedule-paragraph-8",
+        "id" : "schedule-paragraph-8",
+        "href" : "schedule/paragraph/8",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "9",
         "title" : "Section 28 (company may incur temporary loans). ",
         "ref" : "schedule-paragraph-9",
+        "id" : "schedule-paragraph-9",
+        "href" : "schedule/paragraph/9",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "10",
         "title" : "Section 29 (as to disposal of shares or stock). ",
         "ref" : "schedule-paragraph-10",
+        "id" : "schedule-paragraph-10",
+        "href" : "schedule/paragraph/10",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "11",
         "title" : "In section 33 (company not bound to regard trusts) the...",
         "ref" : "schedule-paragraph-11",
+        "id" : "schedule-paragraph-11",
+        "href" : "schedule/paragraph/11",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "12",
         "title" : "Part IV (meetings, directors and administrative provisions). ",
         "ref" : "schedule-paragraph-12",
+        "id" : "schedule-paragraph-12",
+        "href" : "schedule/paragraph/12",
         "extent" : [ "E", "W", "S", "NI" ]
       } ]
     } ]

--- a/src/test/resources/ukla_2017_1/ukla-2017-1-part-3-enacted.json
+++ b/src/test/resources/ukla_2017_1/ukla-2017-1-part-3-enacted.json
@@ -37,23 +37,23 @@
     "fragmentInfo" : {
       "element" : "Part",
       "id" : "part-3",
-      "href" : "ukla/2017/1/part/3/enacted",
+      "href" : "part/3",
       "number" : "PART 3",
       "title" : "MISSING SHAREHOLDERS AND CLAIMS",
       "label" : "PART 3"
     },
     "prevInfo" : {
-      "href" : "ukla/2017/1/part/2/enacted",
+      "href" : "part/2",
       "label" : "Part"
     },
     "nextInfo" : {
-      "href" : "ukla/2017/1/part/4/enacted",
+      "href" : "part/4",
       "label" : "Part"
     },
     "ancestors" : [ {
       "element" : "Part",
       "id" : "part-3",
-      "href" : "ukla/2017/1/part/3/enacted",
+      "href" : "part/3",
       "number" : "PART 3",
       "title" : "MISSING SHAREHOLDERS AND CLAIMS",
       "label" : "PART 3"
@@ -61,518 +61,518 @@
     "descendants" : [ {
       "element" : "Part",
       "id" : "part-3",
-      "href" : "ukla/2017/1/part/3/enacted",
+      "href" : "part/3",
       "number" : "PART 3",
       "title" : "MISSING SHAREHOLDERS AND CLAIMS",
       "label" : "PART 3"
     }, {
       "element" : "P1",
       "id" : "section-12",
-      "href" : "ukla/2017/1/section/12/enacted",
+      "href" : "section/12",
       "number" : "12",
       "title" : "Interpretation of Part 3",
       "label" : "Section 12"
     }, {
       "element" : "P2",
       "id" : "section-12-1",
-      "href" : "ukla/2017/1/section/12/1/enacted",
+      "href" : "section/12/1",
       "number" : "1",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "section-12-2",
-      "href" : "ukla/2017/1/section/12/2/enacted",
+      "href" : "section/12/2",
       "number" : "2",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-12-2-a",
-      "href" : "ukla/2017/1/section/12/2/a/enacted",
+      "href" : "section/12/2/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-12-2-b",
-      "href" : "ukla/2017/1/section/12/2/b/enacted",
+      "href" : "section/12/2/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-12-2-c",
-      "href" : "ukla/2017/1/section/12/2/c/enacted",
+      "href" : "section/12/2/c",
       "number" : "c",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P4",
       "id" : "section-12-2-c-i",
-      "href" : "ukla/2017/1/section/12/2/c/i/enacted",
+      "href" : "section/12/2/c/i",
       "number" : "i",
       "title" : null,
       "label" : "P4"
     }, {
       "element" : "P4",
       "id" : "section-12-2-c-ii",
-      "href" : "ukla/2017/1/section/12/2/c/ii/enacted",
+      "href" : "section/12/2/c/ii",
       "number" : "ii",
       "title" : null,
       "label" : "P4"
     }, {
       "element" : "P3",
       "id" : "section-12-2-d",
-      "href" : "ukla/2017/1/section/12/2/d/enacted",
+      "href" : "section/12/2/d",
       "number" : "d",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-12-2-e",
-      "href" : "ukla/2017/1/section/12/2/e/enacted",
+      "href" : "section/12/2/e",
       "number" : "e",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P2",
       "id" : "section-12-3",
-      "href" : "ukla/2017/1/section/12/3/enacted",
+      "href" : "section/12/3",
       "number" : "3",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "section-12-4",
-      "href" : "ukla/2017/1/section/12/4/enacted",
+      "href" : "section/12/4",
       "number" : "4",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-12-4-a",
-      "href" : "ukla/2017/1/section/12/4/a/enacted",
+      "href" : "section/12/4/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-12-4-b",
-      "href" : "ukla/2017/1/section/12/4/b/enacted",
+      "href" : "section/12/4/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P2",
       "id" : "section-12-5",
-      "href" : "ukla/2017/1/section/12/5/enacted",
+      "href" : "section/12/5",
       "number" : "5",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P1",
       "id" : "section-13",
-      "href" : "ukla/2017/1/section/13/enacted",
+      "href" : "section/13",
       "number" : "13",
       "title" : "Notices and procedure for claims",
       "label" : "Section 13"
     }, {
       "element" : "P2",
       "id" : "section-13-1",
-      "href" : "ukla/2017/1/section/13/1/enacted",
+      "href" : "section/13/1",
       "number" : "1",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "section-13-2",
-      "href" : "ukla/2017/1/section/13/2/enacted",
+      "href" : "section/13/2",
       "number" : "2",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-13-2-a",
-      "href" : "ukla/2017/1/section/13/2/a/enacted",
+      "href" : "section/13/2/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-13-2-b",
-      "href" : "ukla/2017/1/section/13/2/b/enacted",
+      "href" : "section/13/2/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-13-2-c",
-      "href" : "ukla/2017/1/section/13/2/c/enacted",
+      "href" : "section/13/2/c",
       "number" : "c",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P2",
       "id" : "section-13-3",
-      "href" : "ukla/2017/1/section/13/3/enacted",
+      "href" : "section/13/3",
       "number" : "3",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "section-13-4",
-      "href" : "ukla/2017/1/section/13/4/enacted",
+      "href" : "section/13/4",
       "number" : "4",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-13-4-a",
-      "href" : "ukla/2017/1/section/13/4/a/enacted",
+      "href" : "section/13/4/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-13-4-b",
-      "href" : "ukla/2017/1/section/13/4/b/enacted",
+      "href" : "section/13/4/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P2",
       "id" : "section-13-5",
-      "href" : "ukla/2017/1/section/13/5/enacted",
+      "href" : "section/13/5",
       "number" : "5",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "section-13-6",
-      "href" : "ukla/2017/1/section/13/6/enacted",
+      "href" : "section/13/6",
       "number" : "6",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-13-6-a",
-      "href" : "ukla/2017/1/section/13/6/a/enacted",
+      "href" : "section/13/6/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-13-6-b",
-      "href" : "ukla/2017/1/section/13/6/b/enacted",
+      "href" : "section/13/6/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P2",
       "id" : "section-13-7",
-      "href" : "ukla/2017/1/section/13/7/enacted",
+      "href" : "section/13/7",
       "number" : "7",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-13-7-a",
-      "href" : "ukla/2017/1/section/13/7/a/enacted",
+      "href" : "section/13/7/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-13-7-b",
-      "href" : "ukla/2017/1/section/13/7/b/enacted",
+      "href" : "section/13/7/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P2",
       "id" : "section-13-8",
-      "href" : "ukla/2017/1/section/13/8/enacted",
+      "href" : "section/13/8",
       "number" : "8",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-13-8-a",
-      "href" : "ukla/2017/1/section/13/8/a/enacted",
+      "href" : "section/13/8/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-13-8-b",
-      "href" : "ukla/2017/1/section/13/8/b/enacted",
+      "href" : "section/13/8/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-13-8-c",
-      "href" : "ukla/2017/1/section/13/8/c/enacted",
+      "href" : "section/13/8/c",
       "number" : "c",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P2",
       "id" : "section-13-9",
-      "href" : "ukla/2017/1/section/13/9/enacted",
+      "href" : "section/13/9",
       "number" : "9",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "section-13-10",
-      "href" : "ukla/2017/1/section/13/10/enacted",
+      "href" : "section/13/10",
       "number" : "10",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "section-13-11",
-      "href" : "ukla/2017/1/section/13/11/enacted",
+      "href" : "section/13/11",
       "number" : "11",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P1",
       "id" : "section-14",
-      "href" : "ukla/2017/1/section/14/enacted",
+      "href" : "section/14",
       "number" : "14",
       "title" : "Sale of shares",
       "label" : "Section 14"
     }, {
       "element" : "P2",
       "id" : "section-14-1",
-      "href" : "ukla/2017/1/section/14/1/enacted",
+      "href" : "section/14/1",
       "number" : "1",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "section-14-2",
-      "href" : "ukla/2017/1/section/14/2/enacted",
+      "href" : "section/14/2",
       "number" : "2",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "section-14-3",
-      "href" : "ukla/2017/1/section/14/3/enacted",
+      "href" : "section/14/3",
       "number" : "3",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "section-14-4",
-      "href" : "ukla/2017/1/section/14/4/enacted",
+      "href" : "section/14/4",
       "number" : "4",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "section-14-5",
-      "href" : "ukla/2017/1/section/14/5/enacted",
+      "href" : "section/14/5",
       "number" : "5",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-14-5-a",
-      "href" : "ukla/2017/1/section/14/5/a/enacted",
+      "href" : "section/14/5/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-14-5-b",
-      "href" : "ukla/2017/1/section/14/5/b/enacted",
+      "href" : "section/14/5/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-14-5-c",
-      "href" : "ukla/2017/1/section/14/5/c/enacted",
+      "href" : "section/14/5/c",
       "number" : "c",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P2",
       "id" : "section-14-6",
-      "href" : "ukla/2017/1/section/14/6/enacted",
+      "href" : "section/14/6",
       "number" : "6",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "section-14-7",
-      "href" : "ukla/2017/1/section/14/7/enacted",
+      "href" : "section/14/7",
       "number" : "7",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "section-14-8",
-      "href" : "ukla/2017/1/section/14/8/enacted",
+      "href" : "section/14/8",
       "number" : "8",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-14-8-a",
-      "href" : "ukla/2017/1/section/14/8/a/enacted",
+      "href" : "section/14/8/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-14-8-b",
-      "href" : "ukla/2017/1/section/14/8/b/enacted",
+      "href" : "section/14/8/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P2",
       "id" : "section-14-9",
-      "href" : "ukla/2017/1/section/14/9/enacted",
+      "href" : "section/14/9",
       "number" : "9",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-14-9-a",
-      "href" : "ukla/2017/1/section/14/9/a/enacted",
+      "href" : "section/14/9/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-14-9-b",
-      "href" : "ukla/2017/1/section/14/9/b/enacted",
+      "href" : "section/14/9/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P2",
       "id" : "section-14-10",
-      "href" : "ukla/2017/1/section/14/10/enacted",
+      "href" : "section/14/10",
       "number" : "10",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "section-14-11",
-      "href" : "ukla/2017/1/section/14/11/enacted",
+      "href" : "section/14/11",
       "number" : "11",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "section-14-12",
-      "href" : "ukla/2017/1/section/14/12/enacted",
+      "href" : "section/14/12",
       "number" : "12",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "section-14-13",
-      "href" : "ukla/2017/1/section/14/13/enacted",
+      "href" : "section/14/13",
       "number" : "13",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "section-14-14",
-      "href" : "ukla/2017/1/section/14/14/enacted",
+      "href" : "section/14/14",
       "number" : "14",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P1",
       "id" : "section-15",
-      "href" : "ukla/2017/1/section/15/enacted",
+      "href" : "section/15",
       "number" : "15",
       "title" : "Notices in electronic form",
       "label" : "Section 15"
     }, {
       "element" : "P2",
       "id" : "section-15-1",
-      "href" : "ukla/2017/1/section/15/1/enacted",
+      "href" : "section/15/1",
       "number" : "1",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-15-1-a",
-      "href" : "ukla/2017/1/section/15/1/a/enacted",
+      "href" : "section/15/1/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-15-1-b",
-      "href" : "ukla/2017/1/section/15/1/b/enacted",
+      "href" : "section/15/1/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P2",
       "id" : "section-15-2",
-      "href" : "ukla/2017/1/section/15/2/enacted",
+      "href" : "section/15/2",
       "number" : "2",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "section-15-3",
-      "href" : "ukla/2017/1/section/15/3/enacted",
+      "href" : "section/15/3",
       "number" : "3",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-15-3-a",
-      "href" : "ukla/2017/1/section/15/3/a/enacted",
+      "href" : "section/15/3/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-15-3-b",
-      "href" : "ukla/2017/1/section/15/3/b/enacted",
+      "href" : "section/15/3/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-15-3-c",
-      "href" : "ukla/2017/1/section/15/3/c/enacted",
+      "href" : "section/15/3/c",
       "number" : "c",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-15-3-d",
-      "href" : "ukla/2017/1/section/15/3/d/enacted",
+      "href" : "section/15/3/d",
       "number" : "d",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P2",
       "id" : "section-15-4",
-      "href" : "ukla/2017/1/section/15/4/enacted",
+      "href" : "section/15/4",
       "number" : "4",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P1",
       "id" : "section-16",
-      "href" : "ukla/2017/1/section/16/enacted",
+      "href" : "section/16",
       "number" : "16",
       "title" : "Saving for section 125 of 2006 Act",
       "label" : "Section 16"

--- a/src/test/resources/ukpga_2000_8/ukpga-2000-8-contents.json
+++ b/src/test/resources/ukpga_2000_8/ukpga-2000-8-contents.json
@@ -9899,6 +9899,8 @@
       "number" : null,
       "title" : "Introductory Text",
       "ref" : "introduction",
+      "id" : null,
+      "href" : null,
       "extent" : [ "E", "W", "S", "NI" ]
     },
     "body" : [ {
@@ -9906,24 +9908,32 @@
       "number" : "Part I",
       "title" : "The Regulator",
       "ref" : "part-I",
+      "id" : "part-I",
+      "href" : "part/I",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "1",
         "title" : "The Financial Services Authority.",
         "ref" : "section-1",
+        "id" : "section-1",
+        "href" : "section/1",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "pblock",
         "number" : null,
         "title" : "The Authority’s general duties",
         "ref" : "part-I-crossheading-the-authoritys-general-duties",
+        "id" : "part-I-crossheading-the-authoritys-general-duties",
+        "href" : "part/I/crossheading/the-authoritys-general-duties",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "2",
           "title" : "The Authority’s general duties.",
           "ref" : "section-2",
+          "id" : "section-2",
+          "href" : "section/2",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -9931,36 +9941,48 @@
         "number" : null,
         "title" : "The regulatory objectives",
         "ref" : "part-I-crossheading-the-regulatory-objectives",
+        "id" : "part-I-crossheading-the-regulatory-objectives",
+        "href" : "part/I/crossheading/the-regulatory-objectives",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "3",
           "title" : "Market confidence.",
           "ref" : "section-3",
+          "id" : "section-3",
+          "href" : "section/3",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "3A",
           "title" : "Financial stability",
           "ref" : "section-3A",
+          "id" : "section-3A",
+          "href" : "section/3A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "4",
           "title" : "Public awareness.",
           "ref" : "section-4",
+          "id" : "section-4",
+          "href" : "section/4",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "5",
           "title" : "The protection of consumers.",
           "ref" : "section-5",
+          "id" : "section-5",
+          "href" : "section/5",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "6",
           "title" : "The reduction of financial crime.",
           "ref" : "section-6",
+          "id" : "section-6",
+          "href" : "section/6",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -9968,12 +9990,16 @@
         "number" : null,
         "title" : "Enhancing public understanding of financial matters etc",
         "ref" : "part-I-crossheading-enhancing-public-understanding-of-financial-matters-etc",
+        "id" : "part-I-crossheading-enhancing-public-understanding-of-financial-matters-etc",
+        "href" : "part/I/crossheading/enhancing-public-understanding-of-financial-matters-etc",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "6A",
           "title" : "Enhancing public understanding of financial matters etc",
           "ref" : "section-6A",
+          "id" : "section-6A",
+          "href" : "section/6A",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -9981,12 +10007,16 @@
         "number" : null,
         "title" : "Corporate governance",
         "ref" : "part-I-crossheading-corporate-governance",
+        "id" : "part-I-crossheading-corporate-governance",
+        "href" : "part/I/crossheading/corporate-governance",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "7",
           "title" : "Duty of Authority to follow principles of good governance.",
           "ref" : "section-7",
+          "id" : "section-7",
+          "href" : "section/7",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -9994,30 +10024,40 @@
         "number" : null,
         "title" : "Arrangements for consulting practitioners and consumers",
         "ref" : "part-I-crossheading-arrangements-for-consulting-practitioners-and-consumers",
+        "id" : "part-I-crossheading-arrangements-for-consulting-practitioners-and-consumers",
+        "href" : "part/I/crossheading/arrangements-for-consulting-practitioners-and-consumers",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "8",
           "title" : "The Authority’s general duty to consult.",
           "ref" : "section-8",
+          "id" : "section-8",
+          "href" : "section/8",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "9",
           "title" : "The Practitioner Panel.",
           "ref" : "section-9",
+          "id" : "section-9",
+          "href" : "section/9",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "10",
           "title" : "The Consumer Panel.",
           "ref" : "section-10",
+          "id" : "section-10",
+          "href" : "section/10",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "11",
           "title" : "Duty to consider representations by the Panels.",
           "ref" : "section-11",
+          "id" : "section-11",
+          "href" : "section/11",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -10025,18 +10065,24 @@
         "number" : null,
         "title" : "Reviews",
         "ref" : "part-I-crossheading-reviews",
+        "id" : "part-I-crossheading-reviews",
+        "href" : "part/I/crossheading/reviews",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "12",
           "title" : "Reviews.",
           "ref" : "section-12",
+          "id" : "section-12",
+          "href" : "section/12",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "13",
           "title" : "Right to obtain documents and information.",
           "ref" : "section-13",
+          "id" : "section-13",
+          "href" : "section/13",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -10044,36 +10090,48 @@
         "number" : null,
         "title" : "Inquiries",
         "ref" : "part-I-crossheading-inquiries",
+        "id" : "part-I-crossheading-inquiries",
+        "href" : "part/I/crossheading/inquiries",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "14",
           "title" : "Cases in which the Treasury may arrange independent inquiries.",
           "ref" : "section-14",
+          "id" : "section-14",
+          "href" : "section/14",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "15",
           "title" : "Power to appoint person to hold an inquiry.",
           "ref" : "section-15",
+          "id" : "section-15",
+          "href" : "section/15",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "16",
           "title" : "Powers of appointed person and procedure.",
           "ref" : "section-16",
+          "id" : "section-16",
+          "href" : "section/16",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "17",
           "title" : "Conclusion of inquiry.",
           "ref" : "section-17",
+          "id" : "section-17",
+          "href" : "section/17",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "18",
           "title" : "Obstruction and contempt.",
           "ref" : "section-18",
+          "id" : "section-18",
+          "href" : "section/18",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -10082,24 +10140,32 @@
       "number" : "PART 1A",
       "title" : "The Regulators",
       "ref" : "part-1A",
+      "id" : "part-1A",
+      "href" : "part/1A",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "chapter",
         "number" : "CHAPTER 1",
         "title" : "The Financial Conduct Authority",
         "ref" : "part-1A-chapter-1",
+        "id" : "part-1A-chapter-1",
+        "href" : "part/1A/chapter/1",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "The Financial Conduct Authority",
           "ref" : "part-1A-chapter-1-crossheading-the-financial-conduct-authority",
+          "id" : "part-1A-chapter-1-crossheading-the-financial-conduct-authority",
+          "href" : "part/1A/chapter/1/crossheading/the-financial-conduct-authority",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "1A",
             "title" : "The Financial Conduct Authority",
             "ref" : "section-1A",
+            "id" : "section-1A",
+            "href" : "section/1A",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -10107,36 +10173,48 @@
           "number" : null,
           "title" : "The FCA's general duties",
           "ref" : "part-1A-chapter-1-crossheading-the-fcas-general-duties",
+          "id" : "part-1A-chapter-1-crossheading-the-fcas-general-duties",
+          "href" : "part/1A/chapter/1/crossheading/the-fcas-general-duties",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "1B",
             "title" : "The FCA's general duties",
             "ref" : "section-1B",
+            "id" : "section-1B",
+            "href" : "section/1B",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "1C",
             "title" : "The consumer protection objective",
             "ref" : "section-1C",
+            "id" : "section-1C",
+            "href" : "section/1C",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "1D",
             "title" : "The integrity objective",
             "ref" : "section-1D",
+            "id" : "section-1D",
+            "href" : "section/1D",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "1E",
             "title" : "The competition objective",
             "ref" : "section-1E",
+            "id" : "section-1E",
+            "href" : "section/1E",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "1EB",
             "title" : "Competitiveness and growth objective",
             "ref" : "section-1EB",
+            "id" : "section-1EB",
+            "href" : "section/1EB",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -10144,30 +10222,40 @@
           "number" : null,
           "title" : "Interpretation of terms used in relation to FCA's general duties",
           "ref" : "part-1A-chapter-1-crossheading-interpretation-of-terms-used-in-relation-to-fcas-general-duties",
+          "id" : "part-1A-chapter-1-crossheading-interpretation-of-terms-used-in-relation-to-fcas-general-duties",
+          "href" : "part/1A/chapter/1/crossheading/interpretation-of-terms-used-in-relation-to-fcas-general-duties",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "1F",
             "title" : "Meaning of “relevant markets” in strategic objective",
             "ref" : "section-1F",
+            "id" : "section-1F",
+            "href" : "section/1F",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "1G",
             "title" : "Meaning of “consumer”",
             "ref" : "section-1G",
+            "id" : "section-1G",
+            "href" : "section/1G",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "1H",
             "title" : "Further interpretative provisions for sections 1B to 1G",
             "ref" : "section-1H",
+            "id" : "section-1H",
+            "href" : "section/1H",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "1I",
             "title" : "Meaning of “the UK financial system”",
             "ref" : "section-1I",
+            "id" : "section-1I",
+            "href" : "section/1I",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -10175,12 +10263,16 @@
           "number" : null,
           "title" : "Modifications applying if core activity not regulated by PRA",
           "ref" : "chapter-1-crossheading-modifications-applying-if-core-activity-not-regulated-by-pra",
+          "id" : "chapter-1-crossheading-modifications-applying-if-core-activity-not-regulated-by-pra",
+          "href" : "chapter/1/crossheading/modifications-applying-if-core-activity-not-regulated-by-pra",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "1IA",
             "title" : "Modifications applying if core activity not regulated by PRA",
             "ref" : "section-1IA",
+            "id" : "section-1IA",
+            "href" : "section/1IA",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -10188,12 +10280,16 @@
           "number" : null,
           "title" : "Power to amend objectives",
           "ref" : "part-1A-chapter-1-crossheading-power-to-amend-objectives",
+          "id" : "part-1A-chapter-1-crossheading-power-to-amend-objectives",
+          "href" : "part/1A/chapter/1/crossheading/power-to-amend-objectives",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "1J",
             "title" : "Power to amend objectives",
             "ref" : "section-1J",
+            "id" : "section-1J",
+            "href" : "section/1J",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -10201,12 +10297,16 @@
           "number" : null,
           "title" : "Recommendations",
           "ref" : "chapter-1-crossheading-recommendations",
+          "id" : "chapter-1-crossheading-recommendations",
+          "href" : "chapter/1/crossheading/recommendations",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "1JA",
             "title" : "Recommendations by Treasury in connection with general duties",
             "ref" : "section-1JA",
+            "id" : "section-1JA",
+            "href" : "section/1JA",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -10214,12 +10314,16 @@
           "number" : null,
           "title" : "Guidance about objectives",
           "ref" : "part-1A-chapter-1-crossheading-guidance-about-objectives",
+          "id" : "part-1A-chapter-1-crossheading-guidance-about-objectives",
+          "href" : "part/1A/chapter/1/crossheading/guidance-about-objectives",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "1K",
             "title" : "Guidance about objectives",
             "ref" : "section-1K",
+            "id" : "section-1K",
+            "href" : "section/1K",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -10227,12 +10331,16 @@
           "number" : null,
           "title" : "Supervision, monitoring and enforcement",
           "ref" : "part-1A-chapter-1-crossheading-supervision-monitoring-and-enforcement",
+          "id" : "part-1A-chapter-1-crossheading-supervision-monitoring-and-enforcement",
+          "href" : "part/1A/chapter/1/crossheading/supervision-monitoring-and-enforcement",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "1L",
             "title" : "Supervision, monitoring and enforcement",
             "ref" : "section-1L",
+            "id" : "section-1L",
+            "href" : "section/1L",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -10240,60 +10348,80 @@
           "number" : null,
           "title" : "Arrangements for consulting practitioners and consumers",
           "ref" : "part-1A-chapter-1-crossheading-arrangements-for-consulting-practitioners-and-consumers",
+          "id" : "part-1A-chapter-1-crossheading-arrangements-for-consulting-practitioners-and-consumers",
+          "href" : "part/1A/chapter/1/crossheading/arrangements-for-consulting-practitioners-and-consumers",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "1M",
             "title" : "The FCA's general duty to consult",
             "ref" : "section-1M",
+            "id" : "section-1M",
+            "href" : "section/1M",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "1MA",
             "title" : "Composition of Panels",
             "ref" : "section-1MA",
+            "id" : "section-1MA",
+            "href" : "section/1MA",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "1N",
             "title" : "The FCA Practitioner Panel",
             "ref" : "section-1N",
+            "id" : "section-1N",
+            "href" : "section/1N",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "1O",
             "title" : "The Smaller Business Practitioner Panel",
             "ref" : "section-1O",
+            "id" : "section-1O",
+            "href" : "section/1O",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "1P",
             "title" : "The Markets Practitioner Panel",
             "ref" : "section-1P",
+            "id" : "section-1P",
+            "href" : "section/1P",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "1Q",
             "title" : "The Consumer Panel",
             "ref" : "section-1Q",
+            "id" : "section-1Q",
+            "href" : "section/1Q",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "1QA",
             "title" : "The Listing Authority Advisory Panel",
             "ref" : "section-1QA",
+            "id" : "section-1QA",
+            "href" : "section/1QA",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "1R",
             "title" : "Duty to consider representations made by the Panels",
             "ref" : "section-1R",
+            "id" : "section-1R",
+            "href" : "section/1R",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "1RA",
             "title" : "Statement of policy on panel appointments",
             "ref" : "section-1RA",
+            "id" : "section-1RA",
+            "href" : "section/1RA",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -10301,12 +10429,16 @@
           "number" : null,
           "title" : "Requirements for public consultation",
           "ref" : "chapter-1-crossheading-requirements-for-public-consultation",
+          "id" : "chapter-1-crossheading-requirements-for-public-consultation",
+          "href" : "chapter/1/crossheading/requirements-for-public-consultation",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "1RB",
             "title" : "Requirements in connection with public consultations",
             "ref" : "section-1RB",
+            "id" : "section-1RB",
+            "href" : "section/1RB",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -10314,18 +10446,24 @@
           "number" : null,
           "title" : "Reviews",
           "ref" : "part-1A-chapter-1-crossheading-reviews",
+          "id" : "part-1A-chapter-1-crossheading-reviews",
+          "href" : "part/1A/chapter/1/crossheading/reviews",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "1S",
             "title" : "Reviews",
             "ref" : "section-1S",
+            "id" : "section-1S",
+            "href" : "section/1S",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "1T",
             "title" : "Right to obtain documents and information",
             "ref" : "section-1T",
+            "id" : "section-1T",
+            "href" : "section/1T",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -10334,24 +10472,32 @@
         "number" : "CHAPTER 2",
         "title" : "The Prudential Regulation Authority",
         "ref" : "part-1A-chapter-2",
+        "id" : "part-1A-chapter-2",
+        "href" : "part/1A/chapter/2",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "The Prudential Regulation Authority",
           "ref" : "part-1A-chapter-2-crossheading-the-prudential-regulation-authority",
+          "id" : "part-1A-chapter-2-crossheading-the-prudential-regulation-authority",
+          "href" : "part/1A/chapter/2/crossheading/the-prudential-regulation-authority",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "2A",
             "title" : "The Prudential Regulation Authority",
             "ref" : "section-2A",
+            "id" : "section-2A",
+            "href" : "section/2A",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "2AB",
             "title" : "Functions of the PRA",
             "ref" : "section-2AB",
+            "id" : "section-2AB",
+            "href" : "section/2AB",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -10359,60 +10505,80 @@
           "number" : null,
           "title" : "The PRA's general duties",
           "ref" : "part-1A-chapter-2-crossheading-the-pras-general-duties",
+          "id" : "part-1A-chapter-2-crossheading-the-pras-general-duties",
+          "href" : "part/1A/chapter/2/crossheading/the-pras-general-duties",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "2B",
             "title" : "The PRA's general objective",
             "ref" : "section-2B",
+            "id" : "section-2B",
+            "href" : "section/2B",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "2C",
             "title" : "Insurance objective",
             "ref" : "section-2C",
+            "id" : "section-2C",
+            "href" : "section/2C",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "2D",
             "title" : "Power to provide for additional objectives",
             "ref" : "section-2D",
+            "id" : "section-2D",
+            "href" : "section/2D",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "2E",
             "title" : "Strategy",
             "ref" : "section-2E",
+            "id" : "section-2E",
+            "href" : "section/2E",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "2F",
             "title" : "Interpretation of references to objectives",
             "ref" : "section-2F",
+            "id" : "section-2F",
+            "href" : "section/2F",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "2G",
             "title" : "Limit on effect of sections 2B to 2D",
             "ref" : "section-2G",
+            "id" : "section-2G",
+            "href" : "section/2G",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "2H",
             "title" : "Secondary objectives and duty to have regard to regulatory principles",
             "ref" : "section-2H",
+            "id" : "section-2H",
+            "href" : "section/2H",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "2I",
             "title" : "Guidance about objectives",
             "ref" : "section-2I",
+            "id" : "section-2I",
+            "href" : "section/2I",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "2J",
             "title" : "Interpretation of Chapter 2",
             "ref" : "section-2J",
+            "id" : "section-2J",
+            "href" : "section/2J",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -10420,12 +10586,16 @@
           "number" : null,
           "title" : "Supervision",
           "ref" : "part-1A-chapter-2-crossheading-supervision",
+          "id" : "part-1A-chapter-2-crossheading-supervision",
+          "href" : "part/1A/chapter/2/crossheading/supervision",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "2K",
             "title" : "Arrangements for supervision of PRA-authorised persons",
             "ref" : "section-2K",
+            "id" : "section-2K",
+            "href" : "section/2K",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -10433,42 +10603,56 @@
           "number" : null,
           "title" : "Arrangements for consulting practitioners",
           "ref" : "part-1A-chapter-2-crossheading-arrangements-for-consulting-practitioners",
+          "id" : "part-1A-chapter-2-crossheading-arrangements-for-consulting-practitioners",
+          "href" : "part/1A/chapter/2/crossheading/arrangements-for-consulting-practitioners",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "2L",
             "title" : "The PRA's general duty to consult",
             "ref" : "section-2L",
+            "id" : "section-2L",
+            "href" : "section/2L",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "2LA",
             "title" : "Composition of Panels",
             "ref" : "section-2LA",
+            "id" : "section-2LA",
+            "href" : "section/2LA",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "2M",
             "title" : "The PRA Practitioner Panel",
             "ref" : "section-2M",
+            "id" : "section-2M",
+            "href" : "section/2M",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "2MA",
             "title" : "The Insurance Practitioner Panel",
             "ref" : "section-2MA",
+            "id" : "section-2MA",
+            "href" : "section/2MA",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "2N",
             "title" : "Duty to consider representations",
             "ref" : "section-2N",
+            "id" : "section-2N",
+            "href" : "section/2N",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "2NA",
             "title" : "Statement of policy on panel appointments",
             "ref" : "section-2NA",
+            "id" : "section-2NA",
+            "href" : "section/2NA",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -10476,12 +10660,16 @@
           "number" : null,
           "title" : "Requirements for public consultation",
           "ref" : "chapter-2-crossheading-requirements-for-public-consultation",
+          "id" : "chapter-2-crossheading-requirements-for-public-consultation",
+          "href" : "chapter/2/crossheading/requirements-for-public-consultation",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "2NB",
             "title" : "Requirements in connection with public consultations",
             "ref" : "section-2NB",
+            "id" : "section-2NB",
+            "href" : "section/2NB",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -10489,18 +10677,24 @@
           "number" : null,
           "title" : "Reviews",
           "ref" : "part-1A-chapter-2-crossheading-reviews",
+          "id" : "part-1A-chapter-2-crossheading-reviews",
+          "href" : "part/1A/chapter/2/crossheading/reviews",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "2O",
             "title" : "Reviews",
             "ref" : "section-2O",
+            "id" : "section-2O",
+            "href" : "section/2O",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "2P",
             "title" : "Right to obtain documents and information",
             "ref" : "section-2P",
+            "id" : "section-2P",
+            "href" : "section/2P",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -10509,18 +10703,24 @@
         "number" : "CHAPTER 3",
         "title" : "Further provisions relating to FCA and PRA",
         "ref" : "part-1A-chapter-3",
+        "id" : "part-1A-chapter-3",
+        "href" : "part/1A/chapter/3",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Introductory",
           "ref" : "part-1A-chapter-3-crossheading-introductory",
+          "id" : "part-1A-chapter-3-crossheading-introductory",
+          "href" : "part/1A/chapter/3/crossheading/introductory",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "3A",
             "title" : "Meaning of “regulator”",
             "ref" : "section-3An1",
+            "id" : "section-3An1",
+            "href" : "section/3An1",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -10528,12 +10728,16 @@
           "number" : null,
           "title" : "Regulatory principles",
           "ref" : "part-1A-chapter-3-crossheading-regulatory-principles",
+          "id" : "part-1A-chapter-3-crossheading-regulatory-principles",
+          "href" : "part/1A/chapter/3/crossheading/regulatory-principles",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "3B",
             "title" : "Regulatory principles to be applied by both regulators",
             "ref" : "section-3B",
+            "id" : "section-3B",
+            "href" : "section/3B",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -10541,12 +10745,16 @@
           "number" : null,
           "title" : "Corporate governance",
           "ref" : "part-1A-chapter-3-crossheading-corporate-governance",
+          "id" : "part-1A-chapter-3-crossheading-corporate-governance",
+          "href" : "part/1A/chapter/3/crossheading/corporate-governance",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "3C",
             "title" : "Duty to follow principles of good governance",
             "ref" : "section-3C",
+            "id" : "section-3C",
+            "href" : "section/3C",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -10554,36 +10762,48 @@
           "number" : null,
           "title" : "Relationship between FCA and PRA",
           "ref" : "part-1A-chapter-3-crossheading-relationship-between-fca-and-pra",
+          "id" : "part-1A-chapter-3-crossheading-relationship-between-fca-and-pra",
+          "href" : "part/1A/chapter/3/crossheading/relationship-between-fca-and-pra",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "3D",
             "title" : "Duty of FCA and PRA to ensure co-ordinated exercise of functions",
             "ref" : "section-3D",
+            "id" : "section-3D",
+            "href" : "section/3D",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "3E",
             "title" : "Memorandum of understanding",
             "ref" : "section-3E",
+            "id" : "section-3E",
+            "href" : "section/3E",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "3F",
             "title" : "With-profits insurance policies",
             "ref" : "section-3F",
+            "id" : "section-3F",
+            "href" : "section/3F",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "3G",
             "title" : "Power to establish boundary between FCA and PRA responsibilities",
             "ref" : "section-3G",
+            "id" : "section-3G",
+            "href" : "section/3G",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "3H",
             "title" : "Parliamentary control of orders under section 3G",
             "ref" : "section-3H",
+            "id" : "section-3H",
+            "href" : "section/3H",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -10591,30 +10811,40 @@
           "number" : null,
           "title" : "Power of PRA to restrain proposed action by FCA",
           "ref" : "part-1A-chapter-3-crossheading-power-of-pra-to-restrain-proposed-action-by-fca",
+          "id" : "part-1A-chapter-3-crossheading-power-of-pra-to-restrain-proposed-action-by-fca",
+          "href" : "part/1A/chapter/3/crossheading/power-of-pra-to-restrain-proposed-action-by-fca",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "3I",
             "title" : "Power of PRA to require FCA to refrain from specified action",
             "ref" : "section-3I",
+            "id" : "section-3I",
+            "href" : "section/3I",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "3J",
             "title" : "Power of PRA in relation to with-profits policies",
             "ref" : "section-3J",
+            "id" : "section-3J",
+            "href" : "section/3J",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "3K",
             "title" : "Revocation of directions under section 3I or 3J",
             "ref" : "section-3K",
+            "id" : "section-3K",
+            "href" : "section/3K",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "3L",
             "title" : "Further provisions about directions under section 3I or 3J",
             "ref" : "section-3L",
+            "id" : "section-3L",
+            "href" : "section/3L",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -10622,30 +10852,40 @@
           "number" : null,
           "title" : "Directions relating to consolidated supervision",
           "ref" : "part-1A-chapter-3-crossheading-directions-relating-to-consolidated-supervision",
+          "id" : "part-1A-chapter-3-crossheading-directions-relating-to-consolidated-supervision",
+          "href" : "part/1A/chapter/3/crossheading/directions-relating-to-consolidated-supervision",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "3M",
             "title" : "Directions relating to consolidated supervision of groups",
             "ref" : "section-3M",
+            "id" : "section-3M",
+            "href" : "section/3M",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "3N",
             "title" : "Revocation of directions under section 3M",
             "ref" : "section-3N",
+            "id" : "section-3N",
+            "href" : "section/3N",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "3O",
             "title" : "Further provisions about directions under section 3M",
             "ref" : "section-3O",
+            "id" : "section-3O",
+            "href" : "section/3O",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "3P",
             "title" : "Consultation by regulator complying with direction",
             "ref" : "section-3P",
+            "id" : "section-3P",
+            "href" : "section/3P",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -10653,12 +10893,16 @@
           "number" : null,
           "title" : "Co-operation with Bank of England",
           "ref" : "part-1A-chapter-3-crossheading-cooperation-with-bank-of-england",
+          "id" : "part-1A-chapter-3-crossheading-cooperation-with-bank-of-england",
+          "href" : "part/1A/chapter/3/crossheading/cooperation-with-bank-of-england",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "3Q",
             "title" : "Co-operation by FCA ... with Bank of England",
             "ref" : "section-3Q",
+            "id" : "section-3Q",
+            "href" : "section/3Q",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -10666,12 +10910,16 @@
           "number" : null,
           "title" : "Arrangements for provision of services",
           "ref" : "part-1A-chapter-3-crossheading-arrangements-for-provision-of-services",
+          "id" : "part-1A-chapter-3-crossheading-arrangements-for-provision-of-services",
+          "href" : "part/1A/chapter/3/crossheading/arrangements-for-provision-of-services",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "3R",
             "title" : "Arrangements for provision of services",
             "ref" : "section-3R",
+            "id" : "section-3R",
+            "href" : "section/3R",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -10679,36 +10927,48 @@
           "number" : null,
           "title" : "Rules",
           "ref" : "chapter-3-crossheading-rules",
+          "id" : "chapter-3-crossheading-rules",
+          "href" : "chapter/3/crossheading/rules",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "3RA",
             "title" : "Duty of FCA and PRA to review rules",
             "ref" : "section-3RA",
+            "id" : "section-3RA",
+            "href" : "section/3RA",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "3RB",
             "title" : "Statement of policy relating to review of rules",
             "ref" : "section-3RB",
+            "id" : "section-3RB",
+            "href" : "section/3RB",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "3RC",
             "title" : "Requirement to review specified rules",
             "ref" : "section-3RC",
+            "id" : "section-3RC",
+            "href" : "section/3RC",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "3RD",
             "title" : "Report on certain reviews",
             "ref" : "section-3RD",
+            "id" : "section-3RD",
+            "href" : "section/3RD",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "3RE",
             "title" : "Power of Treasury to require making of rules by regulations",
             "ref" : "section-3RE",
+            "id" : "section-3RE",
+            "href" : "section/3RE",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -10716,12 +10976,16 @@
           "number" : null,
           "title" : "Enhancing public understanding of financial matters etc.",
           "ref" : "part-1A-chapter-3-crossheading-enhancing-public-understanding-of-financial-matters-etc",
+          "id" : "part-1A-chapter-3-crossheading-enhancing-public-understanding-of-financial-matters-etc",
+          "href" : "part/1A/chapter/3/crossheading/enhancing-public-understanding-of-financial-matters-etc",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "3S",
             "title" : "The consumer financial education body",
             "ref" : "section-3S",
+            "id" : "section-3S",
+            "href" : "section/3S",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -10729,12 +10993,16 @@
           "number" : null,
           "title" : "Interpretation",
           "ref" : "chapter-3-crossheading-interpretation",
+          "id" : "chapter-3-crossheading-interpretation",
+          "href" : "chapter/3/crossheading/interpretation",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "3T",
             "title" : "Interpretation",
             "ref" : "section-3T",
+            "id" : "section-3T",
+            "href" : "section/3T",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -10744,18 +11012,24 @@
       "number" : "Part II",
       "title" : " Regulated And Prohibited Activities",
       "ref" : "part-II",
+      "id" : "part-II",
+      "href" : "part/II",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : " The general prohibition",
         "ref" : "part-II-crossheading-the-general-prohibition",
+        "id" : "part-II-crossheading-the-general-prohibition",
+        "href" : "part/II/crossheading/the-general-prohibition",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "19",
           "title" : " The general prohibition.",
           "ref" : "section-19",
+          "id" : "section-19",
+          "href" : "section/19",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -10763,12 +11037,16 @@
         "number" : null,
         "title" : " Requirement for permission",
         "ref" : "part-II-crossheading-requirement-for-permission",
+        "id" : "part-II-crossheading-requirement-for-permission",
+        "href" : "part/II/crossheading/requirement-for-permission",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "20",
           "title" : " Authorised persons acting without permission.",
           "ref" : "section-20",
+          "id" : "section-20",
+          "href" : "section/20",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -10776,12 +11054,16 @@
         "number" : null,
         "title" : " Financial promotion",
         "ref" : "part-II-crossheading-financial-promotion",
+        "id" : "part-II-crossheading-financial-promotion",
+        "href" : "part/II/crossheading/financial-promotion",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "21",
           "title" : "Restrictions on financial promotion.",
           "ref" : "section-21",
+          "id" : "section-21",
+          "href" : "section/21",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -10789,24 +11071,32 @@
         "number" : null,
         "title" : " Regulated activities",
         "ref" : "part-II-crossheading-regulated-activities",
+        "id" : "part-II-crossheading-regulated-activities",
+        "href" : "part/II/crossheading/regulated-activities",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "22",
           "title" : "Regulated activities",
           "ref" : "section-22",
+          "id" : "section-22",
+          "href" : "section/22",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "22A",
           "title" : "Designation of activities requiring prudential regulation by PRA",
           "ref" : "section-22A",
+          "id" : "section-22A",
+          "href" : "section/22A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "22B",
           "title" : "Parliamentary control in relation to certain orders under section 22A",
           "ref" : "section-22B",
+          "id" : "section-22B",
+          "href" : "section/22B",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -10814,30 +11104,40 @@
         "number" : null,
         "title" : " Offences",
         "ref" : "part-II-crossheading-offences",
+        "id" : "part-II-crossheading-offences",
+        "href" : "part/II/crossheading/offences",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "23",
           "title" : "Contravention of the general prohibition or section 20(1) or (1A).",
           "ref" : "section-23",
+          "id" : "section-23",
+          "href" : "section/23",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "23A",
           "title" : "Parliamentary control in relation to certain orders under section 23",
           "ref" : "section-23A",
+          "id" : "section-23A",
+          "href" : "section/23A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "24",
           "title" : " False claims to be authorised or exempt.",
           "ref" : "section-24",
+          "id" : "section-24",
+          "href" : "section/24",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "25",
           "title" : "Contravention of section 21.",
           "ref" : "section-25",
+          "id" : "section-25",
+          "href" : "section/25",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -10845,54 +11145,72 @@
         "number" : null,
         "title" : " Enforceability of agreements",
         "ref" : "part-II-crossheading-enforceability-of-agreements",
+        "id" : "part-II-crossheading-enforceability-of-agreements",
+        "href" : "part/II/crossheading/enforceability-of-agreements",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "26",
           "title" : " Agreements made by unauthorised persons.",
           "ref" : "section-26",
+          "id" : "section-26",
+          "href" : "section/26",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "26A",
           "title" : "Agreements relating to credit",
           "ref" : "section-26A",
+          "id" : "section-26A",
+          "href" : "section/26A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "27",
           "title" : " Agreements made through unauthorised persons.",
           "ref" : "section-27",
+          "id" : "section-27",
+          "href" : "section/27",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "28",
           "title" : " Agreements made unenforceable by section 26 or 27: general cases.",
           "ref" : "section-28",
+          "id" : "section-28",
+          "href" : "section/28",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "28A",
           "title" : "Credit-related agreements made unenforceable by section 26, 26A or 27",
           "ref" : "section-28A",
+          "id" : "section-28A",
+          "href" : "section/28A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "28B",
           "title" : "Decisions under section 28A: procedure",
           "ref" : "section-28B",
+          "id" : "section-28B",
+          "href" : "section/28B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "29",
           "title" : " Accepting deposits in breach of general prohibition.",
           "ref" : "section-29",
+          "id" : "section-29",
+          "href" : "section/29",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "30",
           "title" : " Enforceability of agreements resulting from unlawful communications.",
           "ref" : "section-30",
+          "id" : "section-30",
+          "href" : "section/30",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -10901,24 +11219,32 @@
       "number" : "Part III",
       "title" : " Authorisation and Exemption",
       "ref" : "part-III",
+      "id" : "part-III",
+      "href" : "part/III",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : " Authorisation",
         "ref" : "part-III-crossheading-authorisation",
+        "id" : "part-III-crossheading-authorisation",
+        "href" : "part/III/crossheading/authorisation",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "31",
           "title" : " Authorised persons.",
           "ref" : "section-31",
+          "id" : "section-31",
+          "href" : "section/31",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "32",
           "title" : " Partnerships and unincorporated associations.",
           "ref" : "section-32",
+          "id" : "section-32",
+          "href" : "section/32",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -10926,30 +11252,40 @@
         "number" : null,
         "title" : " Ending of authorisation",
         "ref" : "part-III-crossheading-ending-of-authorisation",
+        "id" : "part-III-crossheading-ending-of-authorisation",
+        "href" : "part/III/crossheading/ending-of-authorisation",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "33",
           "title" : " Withdrawal of authorisation ....",
           "ref" : "section-33",
+          "id" : "section-33",
+          "href" : "section/33",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "34",
           "title" : " EEA firms.",
           "ref" : "section-34",
+          "id" : "section-34",
+          "href" : "section/34",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "35",
           "title" : " Treaty firms.",
           "ref" : "section-35",
+          "id" : "section-35",
+          "href" : "section/35",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "36",
           "title" : "Authorised open-ended investment companies",
           "ref" : "section-36",
+          "id" : "section-36",
+          "href" : "section/36",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -10957,12 +11293,16 @@
         "number" : null,
         "title" : " Exercise of EEA rights by UK firms",
         "ref" : "part-III-crossheading-exercise-of-eea-rights-by-uk-firms",
+        "id" : "part-III-crossheading-exercise-of-eea-rights-by-uk-firms",
+        "href" : "part/III/crossheading/exercise-of-eea-rights-by-uk-firms",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "37",
           "title" : " Exercise of EEA rights by UK firms.",
           "ref" : "section-37",
+          "id" : "section-37",
+          "href" : "section/37",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -10970,24 +11310,32 @@
         "number" : null,
         "title" : " Exemption",
         "ref" : "part-III-crossheading-exemption",
+        "id" : "part-III-crossheading-exemption",
+        "href" : "part/III/crossheading/exemption",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "38",
           "title" : " Exemption orders.",
           "ref" : "section-38",
+          "id" : "section-38",
+          "href" : "section/38",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "39",
           "title" : "Exemption of appointed representatives.",
           "ref" : "section-39",
+          "id" : "section-39",
+          "href" : "section/39",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "39A",
           "title" : "Certain tied agents operating outside United Kingdom",
           "ref" : "section-39A",
+          "id" : "section-39A",
+          "href" : "section/39A",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -10996,24 +11344,32 @@
       "number" : "Part IV",
       "title" : " Permission to Carry on Regulated Activities",
       "ref" : "part-IV",
+      "id" : "part-IV",
+      "href" : "part/IV",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : " Application for permission",
         "ref" : "part-IV-crossheading-application-for-permission",
+        "id" : "part-IV-crossheading-application-for-permission",
+        "href" : "part/IV/crossheading/application-for-permission",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "40",
           "title" : " Application for permission.",
           "ref" : "section-40",
+          "id" : "section-40",
+          "href" : "section/40",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "41",
           "title" : " The threshold conditions.",
           "ref" : "section-41",
+          "id" : "section-41",
+          "href" : "section/41",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -11021,18 +11377,24 @@
         "number" : null,
         "title" : " Permission",
         "ref" : "part-IV-crossheading-permission",
+        "id" : "part-IV-crossheading-permission",
+        "href" : "part/IV/crossheading/permission",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "42",
           "title" : " Giving permission.",
           "ref" : "section-42",
+          "id" : "section-42",
+          "href" : "section/42",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "43",
           "title" : " Imposition of requirements.",
           "ref" : "section-43",
+          "id" : "section-43",
+          "href" : "section/43",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -11040,36 +11402,48 @@
         "number" : null,
         "title" : " Variation and cancellation of Part IV permission",
         "ref" : "part-IV-crossheading-variation-and-cancellation-of-part-iv-permission",
+        "id" : "part-IV-crossheading-variation-and-cancellation-of-part-iv-permission",
+        "href" : "part/IV/crossheading/variation-and-cancellation-of-part-iv-permission",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "44",
           "title" : " Variation etc. at request of authorised person.",
           "ref" : "section-44",
+          "id" : "section-44",
+          "href" : "section/44",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "45",
           "title" : " Variation etc. on the Authority’s own initiative.",
           "ref" : "section-45",
+          "id" : "section-45",
+          "href" : "section/45",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "46",
           "title" : " Variation of permission on acquisition of control.",
           "ref" : "section-46",
+          "id" : "section-46",
+          "href" : "section/46",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "47",
           "title" : " Exercise of power in support of overseas regulator.",
           "ref" : "section-47",
+          "id" : "section-47",
+          "href" : "section/47",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "48",
           "title" : " Prohibitions and restrictions.",
           "ref" : "section-48",
+          "id" : "section-48",
+          "href" : "section/48",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -11077,12 +11451,16 @@
         "number" : null,
         "title" : " Connected persons",
         "ref" : "part-IV-crossheading-connected-persons",
+        "id" : "part-IV-crossheading-connected-persons",
+        "href" : "part/IV/crossheading/connected-persons",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "49",
           "title" : " Persons connected with an applicant.",
           "ref" : "section-49",
+          "id" : "section-49",
+          "href" : "section/49",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -11090,12 +11468,16 @@
         "number" : null,
         "title" : " Additional permissions",
         "ref" : "part-IV-crossheading-additional-permissions",
+        "id" : "part-IV-crossheading-additional-permissions",
+        "href" : "part/IV/crossheading/additional-permissions",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "50",
           "title" : " Authority’s duty to consider other permissions etc.",
           "ref" : "section-50",
+          "id" : "section-50",
+          "href" : "section/50",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -11103,30 +11485,40 @@
         "number" : null,
         "title" : " Procedure",
         "ref" : "part-IV-crossheading-procedure",
+        "id" : "part-IV-crossheading-procedure",
+        "href" : "part/IV/crossheading/procedure",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "51",
           "title" : " Applications under this Part.",
           "ref" : "section-51",
+          "id" : "section-51",
+          "href" : "section/51",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "52",
           "title" : " Determination of applications.",
           "ref" : "section-52",
+          "id" : "section-52",
+          "href" : "section/52",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "53",
           "title" : " Exercise of own-initiative power: procedure.",
           "ref" : "section-53",
+          "id" : "section-53",
+          "href" : "section/53",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "54",
           "title" : " Cancellation of Part IV permission: procedure.",
           "ref" : "section-54",
+          "id" : "section-54",
+          "href" : "section/54",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -11134,18 +11526,24 @@
         "number" : null,
         "title" : "Notification",
         "ref" : "part-IV-crossheading-notification",
+        "id" : "part-IV-crossheading-notification",
+        "href" : "part/IV/crossheading/notification",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "54A",
           "title" : "Notification of ESMA",
           "ref" : "section-54A",
+          "id" : "section-54A",
+          "href" : "section/54A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "54B",
           "title" : "Notification of EBA",
           "ref" : "section-54B",
+          "id" : "section-54B",
+          "href" : "section/54B",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -11153,12 +11551,16 @@
         "number" : null,
         "title" : " References to the Tribunal",
         "ref" : "part-IV-crossheading-references-to-the-tribunal",
+        "id" : "part-IV-crossheading-references-to-the-tribunal",
+        "href" : "part/IV/crossheading/references-to-the-tribunal",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "55",
           "title" : " Right to refer matters to the Tribunal.",
           "ref" : "section-55",
+          "id" : "section-55",
+          "href" : "section/55",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -11167,54 +11569,72 @@
       "number" : "PART 4A",
       "title" : "Permission to carry on regulated activities",
       "ref" : "part-4A",
+      "id" : "part-4A",
+      "href" : "part/4A",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : "Application for permission",
         "ref" : "part-4A-crossheading-application-for-permission",
+        "id" : "part-4A-crossheading-application-for-permission",
+        "href" : "part/4A/crossheading/application-for-permission",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "55A",
           "title" : "Application for permission",
           "ref" : "section-55A",
+          "id" : "section-55A",
+          "href" : "section/55A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "55B",
           "title" : "The threshold conditions",
           "ref" : "section-55B",
+          "id" : "section-55B",
+          "href" : "section/55B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "55C",
           "title" : "Power to amend Schedule 6",
           "ref" : "section-55C",
+          "id" : "section-55C",
+          "href" : "section/55C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "55D",
           "title" : "Firms based outside  the United Kingdom ",
           "ref" : "section-55D",
+          "id" : "section-55D",
+          "href" : "section/55D",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "55E",
           "title" : "Giving permission: the FCA",
           "ref" : "section-55E",
+          "id" : "section-55E",
+          "href" : "section/55E",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "55F",
           "title" : "Giving permission: the PRA",
           "ref" : "section-55F",
+          "id" : "section-55F",
+          "href" : "section/55F",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "55G",
           "title" : "Giving permission: special cases",
           "ref" : "section-55G",
+          "id" : "section-55G",
+          "href" : "section/55G",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -11222,42 +11642,56 @@
         "number" : null,
         "title" : "Variation and cancellation of Part 4A permission",
         "ref" : "part-4A-crossheading-variation-and-cancellation-of-part-4a-permission",
+        "id" : "part-4A-crossheading-variation-and-cancellation-of-part-4a-permission",
+        "href" : "part/4A/crossheading/variation-and-cancellation-of-part-4a-permission",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "55H",
           "title" : "Variation by FCA at request of authorised person",
           "ref" : "section-55H",
+          "id" : "section-55H",
+          "href" : "section/55H",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "55I",
           "title" : "Variation by PRA at request of authorised person",
           "ref" : "section-55I",
+          "id" : "section-55I",
+          "href" : "section/55I",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "55J",
           "title" : "Variation or cancellation on initiative of regulator",
           "ref" : "section-55J",
+          "id" : "section-55J",
+          "href" : "section/55J",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "55JA",
           "title" : "Variation or cancellation on initiative of FCA: additional power",
           "ref" : "section-55JA",
+          "id" : "section-55JA",
+          "href" : "section/55JA",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "55K",
           "title" : "Investment firms: particular conditions that enable cancellation",
           "ref" : "section-55K",
+          "id" : "section-55K",
+          "href" : "section/55K",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "55KA",
           "title" : "Insurance undertakings, reinsurance undertakings and third-country insurance undertakings: particular conditions that enable cancellation",
           "ref" : "section-55KA",
+          "id" : "section-55KA",
+          "href" : "section/55KA",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -11265,60 +11699,80 @@
         "number" : null,
         "title" : "Imposition and variation of requirements",
         "ref" : "part-4A-crossheading-imposition-and-variation-of-requirements",
+        "id" : "part-4A-crossheading-imposition-and-variation-of-requirements",
+        "href" : "part/4A/crossheading/imposition-and-variation-of-requirements",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "55L",
           "title" : "Imposition of requirements by FCA",
           "ref" : "section-55L",
+          "id" : "section-55L",
+          "href" : "section/55L",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "55M",
           "title" : "Imposition of requirements by PRA",
           "ref" : "section-55M",
+          "id" : "section-55M",
+          "href" : "section/55M",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "55N",
           "title" : "Requirements under section 55L or 55M: further provisions",
           "ref" : "section-55N",
+          "id" : "section-55N",
+          "href" : "section/55N",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "55NA",
           "title" : "General requirement relating to financial promotion approval",
           "ref" : "section-55NA",
+          "id" : "section-55NA",
+          "href" : "section/55NA",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "55NB",
           "title" : "Section 55NA: power to provide for exemptions",
           "ref" : "section-55NB",
+          "id" : "section-55NB",
+          "href" : "section/55NB",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "55O",
           "title" : "Imposition of requirements on acquisition of control",
           "ref" : "section-55O",
+          "id" : "section-55O",
+          "href" : "section/55O",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "55P",
           "title" : "Prohibitions and restrictions",
           "ref" : "section-55P",
+          "id" : "section-55P",
+          "href" : "section/55P",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "55PA",
           "title" : "Assets requirements imposed on insurance undertakings or reinsurance undertakings",
           "ref" : "section-55PA",
+          "id" : "section-55PA",
+          "href" : "section/55PA",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "55PB",
           "title" : "Requirements relating to general meetings",
           "ref" : "section-55PB",
+          "id" : "section-55PB",
+          "href" : "section/55PB",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -11326,12 +11780,16 @@
         "number" : null,
         "title" : "Exercise of power in support of overseas regulator",
         "ref" : "part-4A-crossheading-exercise-of-power-in-support-of-overseas-regulator",
+        "id" : "part-4A-crossheading-exercise-of-power-in-support-of-overseas-regulator",
+        "href" : "part/4A/crossheading/exercise-of-power-in-support-of-overseas-regulator",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "55Q",
           "title" : "Exercise of power in support of overseas regulator",
           "ref" : "section-55Q",
+          "id" : "section-55Q",
+          "href" : "section/55Q",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -11339,12 +11797,16 @@
         "number" : null,
         "title" : "Connected persons",
         "ref" : "part-4A-crossheading-connected-persons",
+        "id" : "part-4A-crossheading-connected-persons",
+        "href" : "part/4A/crossheading/connected-persons",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "55R",
           "title" : "Persons connected with an applicant",
           "ref" : "section-55R",
+          "id" : "section-55R",
+          "href" : "section/55R",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -11352,12 +11814,16 @@
         "number" : null,
         "title" : "Additional permissions",
         "ref" : "part-4A-crossheading-additional-permissions",
+        "id" : "part-4A-crossheading-additional-permissions",
+        "href" : "part/4A/crossheading/additional-permissions",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "55S",
           "title" : "Duty of FCA or PRA to consider other permissions",
           "ref" : "section-55S",
+          "id" : "section-55S",
+          "href" : "section/55S",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -11365,12 +11831,16 @@
         "number" : null,
         "title" : "Persons whose interests are protected",
         "ref" : "part-4A-crossheading-persons-whose-interests-are-protected",
+        "id" : "part-4A-crossheading-persons-whose-interests-are-protected",
+        "href" : "part/4A/crossheading/persons-whose-interests-are-protected",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "55T",
           "title" : "Persons whose interests are protected",
           "ref" : "section-55T",
+          "id" : "section-55T",
+          "href" : "section/55T",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -11378,48 +11848,64 @@
         "number" : null,
         "title" : "Procedure",
         "ref" : "part-4A-crossheading-procedure",
+        "id" : "part-4A-crossheading-procedure",
+        "href" : "part/4A/crossheading/procedure",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "55U",
           "title" : "Applications under this Part",
           "ref" : "section-55U",
+          "id" : "section-55U",
+          "href" : "section/55U",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "55V",
           "title" : "Determination of applications",
           "ref" : "section-55V",
+          "id" : "section-55V",
+          "href" : "section/55V",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "55W",
           "title" : "Applications under this Part: communications between regulators",
           "ref" : "section-55W",
+          "id" : "section-55W",
+          "href" : "section/55W",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "55X",
           "title" : "Determination of applications: warning notices and decision notices",
           "ref" : "section-55X",
+          "id" : "section-55X",
+          "href" : "section/55X",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "55XA",
           "title" : "Applications relating to administering a benchmark",
           "ref" : "section-55XA",
+          "id" : "section-55XA",
+          "href" : "section/55XA",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "55Y",
           "title" : "Exercise of own-initiative power: procedure",
           "ref" : "section-55Y",
+          "id" : "section-55Y",
+          "href" : "section/55Y",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "55Z",
           "title" : "Cancellation of Part 4A permission or permission under section 55NA: procedure",
           "ref" : "section-55Z",
+          "id" : "section-55Z",
+          "href" : "section/55Z",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -11427,24 +11913,32 @@
         "number" : null,
         "title" : "Notification",
         "ref" : "part-4A-crossheading-notification",
+        "id" : "part-4A-crossheading-notification",
+        "href" : "part/4A/crossheading/notification",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "55Z1",
           "title" : "Notification of ESMA",
           "ref" : "section-55Z1",
+          "id" : "section-55Z1",
+          "href" : "section/55Z1",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "55Z2",
           "title" : "Notification of EBA",
           "ref" : "section-55Z2",
+          "id" : "section-55Z2",
+          "href" : "section/55Z2",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "55Z2A",
           "title" : "Notification of the European bodies",
           "ref" : "section-55Z2A",
+          "id" : "section-55Z2A",
+          "href" : "section/55Z2A",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -11452,12 +11946,16 @@
         "number" : null,
         "title" : "References to the Tribunal",
         "ref" : "part-4A-crossheading-references-to-the-tribunal",
+        "id" : "part-4A-crossheading-references-to-the-tribunal",
+        "href" : "part/4A/crossheading/references-to-the-tribunal",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "55Z3",
           "title" : "Right to refer matters to the Tribunal",
           "ref" : "section-55Z3",
+          "id" : "section-55Z3",
+          "href" : "section/55Z3",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -11465,12 +11963,16 @@
         "number" : null,
         "title" : "Interpretation",
         "ref" : "part-4A-crossheading-interpretation",
+        "id" : "part-4A-crossheading-interpretation",
+        "href" : "part/4A/crossheading/interpretation",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "55Z4",
           "title" : "Interpretation of Part 4A",
           "ref" : "section-55Z4",
+          "id" : "section-55Z4",
+          "href" : "section/55Z4",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -11479,30 +11981,40 @@
       "number" : "Part V",
       "title" : " Performance of Regulated Activities",
       "ref" : "part-V",
+      "id" : "part-V",
+      "href" : "part/V",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : " Prohibition orders",
         "ref" : "part-V-crossheading-prohibition-orders",
+        "id" : "part-V-crossheading-prohibition-orders",
+        "href" : "part/V/crossheading/prohibition-orders",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "56",
           "title" : "Prohibition orders.",
           "ref" : "section-56",
+          "id" : "section-56",
+          "href" : "section/56",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "57",
           "title" : "Prohibition orders: procedure and right to refer to Tribunal.",
           "ref" : "section-57",
+          "id" : "section-57",
+          "href" : "section/57",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "58",
           "title" : " Applications relating to prohibitions: procedure and right to refer to Tribunal.",
           "ref" : "section-58",
+          "id" : "section-58",
+          "href" : "section/58",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -11510,108 +12022,144 @@
         "number" : null,
         "title" : " Approval",
         "ref" : "part-V-crossheading-approval",
+        "id" : "part-V-crossheading-approval",
+        "href" : "part/V/crossheading/approval",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "59",
           "title" : " Approval for particular arrangements.",
           "ref" : "section-59",
+          "id" : "section-59",
+          "href" : "section/59",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "59ZA",
           "title" : "Senior management functions",
           "ref" : "section-59ZA",
+          "id" : "section-59ZA",
+          "href" : "section/59ZA",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "59ZB",
           "title" : "Designated senior management functions",
           "ref" : "section-59ZB",
+          "id" : "section-59ZB",
+          "href" : "section/59ZB",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "59A",
           "title" : "Specifying functions as controlled functions: supplementary",
           "ref" : "section-59A",
+          "id" : "section-59A",
+          "href" : "section/59A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "59AB",
           "title" : "Specifying functions as controlled functions: transitional provision",
           "ref" : "section-59AB",
+          "id" : "section-59AB",
+          "href" : "section/59AB",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "59B",
           "title" : "Role of FCA in relation to PRA decisions",
           "ref" : "section-59B",
+          "id" : "section-59B",
+          "href" : "section/59B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "60",
           "title" : " Applications for approval.",
           "ref" : "section-60",
+          "id" : "section-60",
+          "href" : "section/60",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "60A",
           "title" : "Vetting of candidates by relevant authorised persons",
           "ref" : "section-60A",
+          "id" : "section-60A",
+          "href" : "section/60A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "61",
           "title" : " Determination of applications.",
           "ref" : "section-61",
+          "id" : "section-61",
+          "href" : "section/61",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "62",
           "title" : " Applications for approval: procedure and right to refer to Tribunal.",
           "ref" : "section-62",
+          "id" : "section-62",
+          "href" : "section/62",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "62A",
           "title" : "Changes in responsibilities of senior managers",
           "ref" : "section-62A",
+          "id" : "section-62A",
+          "href" : "section/62A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "63",
           "title" : " Withdrawal of approval.",
           "ref" : "section-63",
+          "id" : "section-63",
+          "href" : "section/63",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "63ZA",
           "title" : "Variation of senior manager's approval at request of relevant authorised person",
           "ref" : "section-63ZA",
+          "id" : "section-63ZA",
+          "href" : "section/63ZA",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "63ZB",
           "title" : "Variation of senior manager's approval on initiative of regulator",
           "ref" : "section-63ZB",
+          "id" : "section-63ZB",
+          "href" : "section/63ZB",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "63ZC",
           "title" : "Exercise of power under section 63ZB: procedure",
           "ref" : "section-63ZC",
+          "id" : "section-63ZC",
+          "href" : "section/63ZC",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "63ZD",
           "title" : "Statement of policy relating to conditional approval and variation",
           "ref" : "section-63ZD",
+          "id" : "section-63ZD",
+          "href" : "section/63ZD",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "63ZE",
           "title" : "Statement of policy: procedure",
           "ref" : "section-63ZE",
+          "id" : "section-63ZE",
+          "href" : "section/63ZE",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -11619,30 +12167,40 @@
         "number" : null,
         "title" : "Performance of controlled functions without approval",
         "ref" : "part-V-crossheading-performance-of-controlled-functions-without-approval",
+        "id" : "part-V-crossheading-performance-of-controlled-functions-without-approval",
+        "href" : "part/V/crossheading/performance-of-controlled-functions-without-approval",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "63A",
           "title" : "Power to impose penalties",
           "ref" : "section-63A",
+          "id" : "section-63A",
+          "href" : "section/63A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "63B",
           "title" : "Procedure and right to refer to Tribunal",
           "ref" : "section-63B",
+          "id" : "section-63B",
+          "href" : "section/63B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "63C",
           "title" : "Statement of policy",
           "ref" : "section-63C",
+          "id" : "section-63C",
+          "href" : "section/63C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "63D",
           "title" : "Statement of policy: procedure",
           "ref" : "section-63D",
+          "id" : "section-63D",
+          "href" : "section/63D",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -11650,18 +12208,24 @@
         "number" : null,
         "title" : "Certification of employees",
         "ref" : "part-V-crossheading-certification-of-employees",
+        "id" : "part-V-crossheading-certification-of-employees",
+        "href" : "part/V/crossheading/certification-of-employees",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "63E",
           "title" : "Certification of employees by ... authorised persons",
           "ref" : "section-63E",
+          "id" : "section-63E",
+          "href" : "section/63E",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "63F",
           "title" : "Issuing of certificates",
           "ref" : "section-63F",
+          "id" : "section-63F",
+          "href" : "section/63F",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -11669,18 +12233,24 @@
         "number" : null,
         "title" : " ...",
         "ref" : "part-V-crossheading-conduct",
+        "id" : "part-V-crossheading-conduct",
+        "href" : "part/V/crossheading/conduct",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "64",
           "title" : " Conduct: statements and codes.",
           "ref" : "section-64",
+          "id" : "section-64",
+          "href" : "section/64",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "65",
           "title" : " Statements and codes: procedure.",
           "ref" : "section-65",
+          "id" : "section-65",
+          "href" : "section/65",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -11688,66 +12258,88 @@
         "number" : null,
         "title" : "Conduct of approved persons and others",
         "ref" : "part-V-crossheading-conduct-of-approved-persons-and-others",
+        "id" : "part-V-crossheading-conduct-of-approved-persons-and-others",
+        "href" : "part/V/crossheading/conduct-of-approved-persons-and-others",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "64A",
           "title" : "Rules of conduct",
           "ref" : "section-64A",
+          "id" : "section-64A",
+          "href" : "section/64A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "64B",
           "title" : "Rules of conduct: responsibilities of ... authorised persons",
           "ref" : "section-64B",
+          "id" : "section-64B",
+          "href" : "section/64B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "64C",
           "title" : "Requirement for ... authorised persons to notify regulator of disciplinary action",
           "ref" : "section-64C",
+          "id" : "section-64C",
+          "href" : "section/64C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "66",
           "title" : "Disciplinary powers.",
           "ref" : "section-66",
+          "id" : "section-66",
+          "href" : "section/66",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "66A",
           "title" : "Misconduct: action by the FCA",
           "ref" : "section-66A",
+          "id" : "section-66A",
+          "href" : "section/66A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "66B",
           "title" : "Misconduct: action by the PRA",
           "ref" : "section-66B",
+          "id" : "section-66B",
+          "href" : "section/66B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "67",
           "title" : "Disciplinary measures: procedure and right to refer to Tribunal.",
           "ref" : "section-67",
+          "id" : "section-67",
+          "href" : "section/67",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "68",
           "title" : "Publication.",
           "ref" : "section-68",
+          "id" : "section-68",
+          "href" : "section/68",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "69",
           "title" : "Statement of policy.",
           "ref" : "section-69",
+          "id" : "section-69",
+          "href" : "section/69",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "70",
           "title" : "Statements of policy: procedure.",
           "ref" : "section-70",
+          "id" : "section-70",
+          "href" : "section/70",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -11755,12 +12347,16 @@
         "number" : null,
         "title" : " Breach of statutory duty",
         "ref" : "part-V-crossheading-breach-of-statutory-duty",
+        "id" : "part-V-crossheading-breach-of-statutory-duty",
+        "href" : "part/V/crossheading/breach-of-statutory-duty",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "71",
           "title" : " Actions for damages.",
           "ref" : "section-71",
+          "id" : "section-71",
+          "href" : "section/71",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -11768,12 +12364,16 @@
         "number" : null,
         "title" : "\n                        “Relevant authorised person”\n                      ",
         "ref" : "part-V-crossheading-relevant-authorised-person",
+        "id" : "part-V-crossheading-relevant-authorised-person",
+        "href" : "part/V/crossheading/relevant-authorised-person",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "71A",
           "title" : "Meaning of  “relevant authorised person”",
           "ref" : "section-71A",
+          "id" : "section-71A",
+          "href" : "section/71A",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -11781,54 +12381,72 @@
         "number" : null,
         "title" : "Removal of directors and senior executives and appointment of temporary manager",
         "ref" : "part-V-crossheading-removal-of-directors-and-senior-executives-and-appointment-of-temporary-manager",
+        "id" : "part-V-crossheading-removal-of-directors-and-senior-executives-and-appointment-of-temporary-manager",
+        "href" : "part/V/crossheading/removal-of-directors-and-senior-executives-and-appointment-of-temporary-manager",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "71B",
           "title" : "Removal of directors and senior executives",
           "ref" : "section-71B",
+          "id" : "section-71B",
+          "href" : "section/71B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "71C",
           "title" : "Temporary manager",
           "ref" : "section-71C",
+          "id" : "section-71C",
+          "href" : "section/71C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "71D",
           "title" : "Sections 71B and 71C: conditions",
           "ref" : "section-71D",
+          "id" : "section-71D",
+          "href" : "section/71D",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "71E",
           "title" : "Temporary manager: further provisions in relation to the appointment",
           "ref" : "section-71E",
+          "id" : "section-71E",
+          "href" : "section/71E",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "71F",
           "title" : "Temporary manager: instrument of appointment",
           "ref" : "section-71F",
+          "id" : "section-71F",
+          "href" : "section/71F",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "71G",
           "title" : "Right to refer matters to the Tribunal",
           "ref" : "section-71G",
+          "id" : "section-71G",
+          "href" : "section/71G",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "71H",
           "title" : "Removal of directors and senior executives and appointment of temporary manager: procedure",
           "ref" : "section-71H",
+          "id" : "section-71H",
+          "href" : "section/71H",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "71I",
           "title" : "Sections 71B to 71H: interpretation",
           "ref" : "section-71I",
+          "id" : "section-71I",
+          "href" : "section/71I",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -11837,60 +12455,80 @@
       "number" : "PART 5A",
       "title" : "Designated activities",
       "ref" : "part-5A",
+      "id" : "part-5A",
+      "href" : "part/5A",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "71K",
         "title" : "Designated activities",
         "ref" : "section-71K",
+        "id" : "section-71K",
+        "href" : "section/71K",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "71L",
         "title" : "Restrictions on carrying on of designated activities",
         "ref" : "section-71L",
+        "id" : "section-71L",
+        "href" : "section/71L",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "71M",
         "title" : "Designated activity regulations: general",
         "ref" : "section-71M",
+        "id" : "section-71M",
+        "href" : "section/71M",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "71N",
         "title" : "Designated activities: rules",
         "ref" : "section-71N",
+        "id" : "section-71N",
+        "href" : "section/71N",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "71O",
         "title" : "Designated activities: directions",
         "ref" : "section-71O",
+        "id" : "section-71O",
+        "href" : "section/71O",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "71P",
         "title" : "Designated activities: liability",
         "ref" : "section-71P",
+        "id" : "section-71P",
+        "href" : "section/71P",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "71Q",
         "title" : "Designated activities: enforcement",
         "ref" : "section-71Q",
+        "id" : "section-71Q",
+        "href" : "section/71Q",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "71R",
         "title" : "Designated activities and rules: connected amendments",
         "ref" : "section-71R",
+        "id" : "section-71R",
+        "href" : "section/71R",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "71S",
         "title" : "Designated activities regulations: Parliamentary control",
         "ref" : "section-71S",
+        "id" : "section-71S",
+        "href" : "section/71S",
         "extent" : [ "E", "W", "S", "NI" ]
       } ]
     }, {
@@ -11898,24 +12536,32 @@
       "number" : "Part VI",
       "title" : "Official Listing",
       "ref" : "part-VI",
+      "id" : "part-VI",
+      "href" : "part/VI",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : "...",
         "ref" : "part-VI-crossheading-the-competent-authority",
+        "id" : "part-VI-crossheading-the-competent-authority",
+        "href" : "part/VI/crossheading/the-competent-authority",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "72",
           "title" : "The competent authority.",
           "ref" : "section-72",
+          "id" : "section-72",
+          "href" : "section/72",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "73",
           "title" : "General duty of the competent authority.",
           "ref" : "section-73",
+          "id" : "section-73",
+          "href" : "section/73",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -11923,12 +12569,16 @@
         "number" : null,
         "title" : "Rules",
         "ref" : "part-VI-crossheading-rules",
+        "id" : "part-VI-crossheading-rules",
+        "href" : "part/VI/crossheading/rules",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "73A",
           "title" : "Part 6 Rules",
           "ref" : "section-73A",
+          "id" : "section-73A",
+          "href" : "section/73A",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -11936,12 +12586,16 @@
         "number" : null,
         "title" : "The official list",
         "ref" : "part-VI-crossheading-the-official-list",
+        "id" : "part-VI-crossheading-the-official-list",
+        "href" : "part/VI/crossheading/the-official-list",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "74",
           "title" : "The official list.",
           "ref" : "section-74",
+          "id" : "section-74",
+          "href" : "section/74",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -11949,36 +12603,48 @@
         "number" : null,
         "title" : "Listing",
         "ref" : "part-VI-crossheading-listing",
+        "id" : "part-VI-crossheading-listing",
+        "href" : "part/VI/crossheading/listing",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "75",
           "title" : "Applications for listing.",
           "ref" : "section-75",
+          "id" : "section-75",
+          "href" : "section/75",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "76",
           "title" : "Decision on application.",
           "ref" : "section-76",
+          "id" : "section-76",
+          "href" : "section/76",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "77",
           "title" : "Discontinuance and suspension of listing.",
           "ref" : "section-77",
+          "id" : "section-77",
+          "href" : "section/77",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "78",
           "title" : "Discontinuance or suspension: procedure.",
           "ref" : "section-78",
+          "id" : "section-78",
+          "href" : "section/78",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "78A",
           "title" : "Discontinuance or suspension at the request of the issuer: procedure",
           "ref" : "section-78A",
+          "id" : "section-78A",
+          "href" : "section/78A",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -11986,36 +12652,48 @@
         "number" : null,
         "title" : "Listing particulars",
         "ref" : "part-VI-crossheading-listing-particulars",
+        "id" : "part-VI-crossheading-listing-particulars",
+        "href" : "part/VI/crossheading/listing-particulars",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "79",
           "title" : "Listing particulars and other documents.",
           "ref" : "section-79",
+          "id" : "section-79",
+          "href" : "section/79",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "80",
           "title" : "General duty of disclosure in listing particulars.",
           "ref" : "section-80",
+          "id" : "section-80",
+          "href" : "section/80",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "81",
           "title" : "Supplementary listing particulars.",
           "ref" : "section-81",
+          "id" : "section-81",
+          "href" : "section/81",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "82",
           "title" : "Exemptions from disclosure.",
           "ref" : "section-82",
+          "id" : "section-82",
+          "href" : "section/82",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "83",
           "title" : "Registration of listing particulars.",
           "ref" : "section-83",
+          "id" : "section-83",
+          "href" : "section/83",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -12023,30 +12701,40 @@
         "number" : null,
         "title" : "Contravention of prohibition relating to public offer of securities",
         "ref" : "part-VI-crossheading-prospectuses",
+        "id" : "part-VI-crossheading-prospectuses",
+        "href" : "part/VI/crossheading/prospectuses",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "84",
           "title" : "Matters which may be dealt with by prospectus rules",
           "ref" : "section-84",
+          "id" : "section-84",
+          "href" : "section/84",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "85",
           "title" : "Contravention of prohibition relating to public offer of securities",
           "ref" : "section-85",
+          "id" : "section-85",
+          "href" : "section/85",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "86",
           "title" : "Exempt offers to the public and admissions to trading",
           "ref" : "section-86",
+          "id" : "section-86",
+          "href" : "section/86",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "87",
           "title" : "Election to have prospectus",
           "ref" : "section-87",
+          "id" : "section-87",
+          "href" : "section/87",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -12054,30 +12742,40 @@
         "number" : null,
         "title" : "Approval of prospectus",
         "ref" : "part-VI-crossheading-approval-of-prospectus",
+        "id" : "part-VI-crossheading-approval-of-prospectus",
+        "href" : "part/VI/crossheading/approval-of-prospectus",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "87A",
           "title" : "Criteria for approval of prospectus by FCA",
           "ref" : "section-87A",
+          "id" : "section-87A",
+          "href" : "section/87A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "87B",
           "title" : "Exemptions from disclosure",
           "ref" : "section-87B",
+          "id" : "section-87B",
+          "href" : "section/87B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "87C",
           "title" : "Consideration of application for approval",
           "ref" : "section-87C",
+          "id" : "section-87C",
+          "href" : "section/87C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "87D",
           "title" : "Procedure for decision to refuse an application for approval",
           "ref" : "section-87D",
+          "id" : "section-87D",
+          "href" : "section/87D",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -12085,18 +12783,24 @@
         "number" : null,
         "title" : "Transfer of application for approval of a prospectus",
         "ref" : "part-VI-crossheading-transfer-of-application-for-approval-of-a-prospectus",
+        "id" : "part-VI-crossheading-transfer-of-application-for-approval-of-a-prospectus",
+        "href" : "part/VI/crossheading/transfer-of-application-for-approval-of-a-prospectus",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "87E",
           "title" : "Transfer by FCA of application for approval",
           "ref" : "section-87E",
+          "id" : "section-87E",
+          "href" : "section/87E",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "87F",
           "title" : "Transfer to FCA of application for approval",
           "ref" : "section-87F",
+          "id" : "section-87F",
+          "href" : "section/87F",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -12104,18 +12808,24 @@
         "number" : null,
         "title" : "Final terms",
         "ref" : "part-VI-crossheading-final-terms",
+        "id" : "part-VI-crossheading-final-terms",
+        "href" : "part/VI/crossheading/final-terms",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "87FA",
           "title" : "Final terms",
           "ref" : "section-87FA",
+          "id" : "section-87FA",
+          "href" : "section/87FA",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "87FB",
           "title" : "Communication of final terms by FCA",
           "ref" : "section-87FB",
+          "id" : "section-87FB",
+          "href" : "section/87FB",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -12123,12 +12833,16 @@
         "number" : null,
         "title" : "Supplementary prospectus",
         "ref" : "part-VI-crossheading-supplementary-prospectus",
+        "id" : "part-VI-crossheading-supplementary-prospectus",
+        "href" : "part/VI/crossheading/supplementary-prospectus",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "87G",
           "title" : "Supplementary prospectus",
           "ref" : "section-87G",
+          "id" : "section-87G",
+          "href" : "section/87G",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -12136,18 +12850,24 @@
         "number" : null,
         "title" : "Passporting",
         "ref" : "part-VI-crossheading-passporting",
+        "id" : "part-VI-crossheading-passporting",
+        "href" : "part/VI/crossheading/passporting",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "87H",
           "title" : "Prospectus approved in another EEA State",
           "ref" : "section-87H",
+          "id" : "section-87H",
+          "href" : "section/87H",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "87I",
           "title" : "Provision of information to host Member State",
           "ref" : "section-87I",
+          "id" : "section-87I",
+          "href" : "section/87I",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -12155,66 +12875,88 @@
         "number" : null,
         "title" : "Transferable securities: powers of FCA",
         "ref" : "part-VI-crossheading-transferable-securities-powers-of-competent-authority",
+        "id" : "part-VI-crossheading-transferable-securities-powers-of-competent-authority",
+        "href" : "part/VI/crossheading/transferable-securities-powers-of-competent-authority",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "87J",
           "title" : "Requirements imposed as condition of approval",
           "ref" : "section-87J",
+          "id" : "section-87J",
+          "href" : "section/87J",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "87JA",
           "title" : "Power to suspend scrutiny of prospectus",
           "ref" : "section-87JA",
+          "id" : "section-87JA",
+          "href" : "section/87JA",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "87JB",
           "title" : "Power to refuse approval of a prospectus",
           "ref" : "section-87JB",
+          "id" : "section-87JB",
+          "href" : "section/87JB",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "87K",
           "title" : "Power to suspend , restrict or prohibit offer to the public",
           "ref" : "section-87K",
+          "id" : "section-87K",
+          "href" : "section/87K",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "87L",
           "title" : "Power to suspend , restrict or prohibit admission to trading on a regulated market",
           "ref" : "section-87L",
+          "id" : "section-87L",
+          "href" : "section/87L",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "87LA",
           "title" : "Power of FCA to suspend or prohibit trading on a trading facility",
           "ref" : "section-87LA",
+          "id" : "section-87LA",
+          "href" : "section/87LA",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "87M",
           "title" : "Public censure of issuer",
           "ref" : "section-87M",
+          "id" : "section-87M",
+          "href" : "section/87M",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "87N",
           "title" : "Right to refer matters to the Tribunal",
           "ref" : "section-87N",
+          "id" : "section-87N",
+          "href" : "section/87N",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "87O",
           "title" : "Procedure under sections 87JA, 87K, 87L and 87LA",
           "ref" : "section-87O",
+          "id" : "section-87O",
+          "href" : "section/87O",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "87P",
           "title" : "Exercise of powers at request of competent authority of another EEA State",
           "ref" : "section-87P",
+          "id" : "section-87P",
+          "href" : "section/87P",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -12222,12 +12964,16 @@
         "number" : null,
         "title" : "Rights of investors",
         "ref" : "part-VI-crossheading-rights-of-investors",
+        "id" : "part-VI-crossheading-rights-of-investors",
+        "href" : "part/VI/crossheading/rights-of-investors",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "87Q",
           "title" : "Right of investor to withdraw",
           "ref" : "section-87Q",
+          "id" : "section-87Q",
+          "href" : "section/87Q",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -12235,12 +12981,16 @@
         "number" : null,
         "title" : "Registered investors",
         "ref" : "part-VI-crossheading-registered-investors",
+        "id" : "part-VI-crossheading-registered-investors",
+        "href" : "part/VI/crossheading/registered-investors",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "87R",
           "title" : "Register of investors",
           "ref" : "section-87R",
+          "id" : "section-87R",
+          "href" : "section/87R",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -12248,54 +12998,72 @@
         "number" : null,
         "title" : "Sponsors",
         "ref" : "part-VI-crossheading-sponsors",
+        "id" : "part-VI-crossheading-sponsors",
+        "href" : "part/VI/crossheading/sponsors",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "88",
           "title" : "Sponsors.",
           "ref" : "section-88",
+          "id" : "section-88",
+          "href" : "section/88",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "89",
           "title" : "Public censure of sponsor.",
           "ref" : "section-89",
+          "id" : "section-89",
+          "href" : "section/89",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "88A",
           "title" : "Disciplinary powers: contravention of s.88(3)(c) or (e)",
           "ref" : "section-88A",
+          "id" : "section-88A",
+          "href" : "section/88A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "88B",
           "title" : "Action under s.88A: procedure and right to refer to Tribunal",
           "ref" : "section-88B",
+          "id" : "section-88B",
+          "href" : "section/88B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "88C",
           "title" : "Action under s.88A: statement of policy",
           "ref" : "section-88C",
+          "id" : "section-88C",
+          "href" : "section/88C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "88D",
           "title" : "Statement of policy under s.88C: procedure",
           "ref" : "section-88D",
+          "id" : "section-88D",
+          "href" : "section/88D",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "88E",
           "title" : "Powers exercisable to advance operational objectives",
           "ref" : "section-88E",
+          "id" : "section-88E",
+          "href" : "section/88E",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "88F",
           "title" : "Action under s.88E: procedure",
           "ref" : "section-88F",
+          "id" : "section-88F",
+          "href" : "section/88F",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -12303,48 +13071,64 @@
         "number" : null,
         "title" : "Transparency obligations",
         "ref" : "part-VI-crossheading-transparency-obligations",
+        "id" : "part-VI-crossheading-transparency-obligations",
+        "href" : "part/VI/crossheading/transparency-obligations",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "89A",
           "title" : "Transparency rules",
           "ref" : "section-89A",
+          "id" : "section-89A",
+          "href" : "section/89A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "89B",
           "title" : "Provision of voteholder information",
           "ref" : "section-89B",
+          "id" : "section-89B",
+          "href" : "section/89B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "89C",
           "title" : "Provision of information by issuers of transferable securities",
           "ref" : "section-89C",
+          "id" : "section-89C",
+          "href" : "section/89C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "89D",
           "title" : "Notification of voting rights held by issuer",
           "ref" : "section-89D",
+          "id" : "section-89D",
+          "href" : "section/89D",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "89E",
           "title" : "Notification of proposed amendment of issuer's constitution",
           "ref" : "section-89E",
+          "id" : "section-89E",
+          "href" : "section/89E",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "89F",
           "title" : "Transparency rules: interpretation etc",
           "ref" : "section-89F",
+          "id" : "section-89F",
+          "href" : "section/89F",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "89G",
           "title" : "Transparency rules: other supplementary provisions",
           "ref" : "section-89G",
+          "id" : "section-89G",
+          "href" : "section/89G",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -12352,24 +13136,32 @@
         "number" : null,
         "title" : "Power of FCA to call for information",
         "ref" : "part-VI-crossheading-power-of-competent-authority-to-call-for-information",
+        "id" : "part-VI-crossheading-power-of-competent-authority-to-call-for-information",
+        "href" : "part/VI/crossheading/power-of-competent-authority-to-call-for-information",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "89H",
           "title" : "FCA's power to call for information",
           "ref" : "section-89H",
+          "id" : "section-89H",
+          "href" : "section/89H",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "89I",
           "title" : "Requirements in connection with call for information",
           "ref" : "section-89I",
+          "id" : "section-89I",
+          "href" : "section/89I",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "89J",
           "title" : "Power to call for information: supplementary provisions",
           "ref" : "section-89J",
+          "id" : "section-89J",
+          "href" : "section/89J",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -12377,36 +13169,48 @@
         "number" : null,
         "title" : "Powers exercisable in case of infringement of transparency obligation",
         "ref" : "part-VI-crossheading-powers-exercisable-in-case-of-infringement-of-transparency-obligation",
+        "id" : "part-VI-crossheading-powers-exercisable-in-case-of-infringement-of-transparency-obligation",
+        "href" : "part/VI/crossheading/powers-exercisable-in-case-of-infringement-of-transparency-obligation",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "89K",
           "title" : "Public censure of issuer",
           "ref" : "section-89K",
+          "id" : "section-89K",
+          "href" : "section/89K",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "89L",
           "title" : "Power to suspend or prohibit trading of securities",
           "ref" : "section-89L",
+          "id" : "section-89L",
+          "href" : "section/89L",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "89M",
           "title" : "Procedure under section 89L",
           "ref" : "section-89M",
+          "id" : "section-89M",
+          "href" : "section/89M",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "89N",
           "title" : "Right to refer matters to the Tribunal",
           "ref" : "section-89N",
+          "id" : "section-89N",
+          "href" : "section/89N",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "89NA",
           "title" : "Voting rights suspension orders",
           "ref" : "section-89NA",
+          "id" : "section-89NA",
+          "href" : "section/89NA",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -12414,12 +13218,16 @@
         "number" : null,
         "title" : "Corporate governance",
         "ref" : "part-VI-crossheading-corporate-governance",
+        "id" : "part-VI-crossheading-corporate-governance",
+        "href" : "part/VI/crossheading/corporate-governance",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "89O",
           "title" : "Corporate governance rules",
           "ref" : "section-89O",
+          "id" : "section-89O",
+          "href" : "section/89O",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -12427,54 +13235,72 @@
         "number" : null,
         "title" : "Primary information providers",
         "ref" : "part-VI-crossheading-primary-information-providers",
+        "id" : "part-VI-crossheading-primary-information-providers",
+        "href" : "part/VI/crossheading/primary-information-providers",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "89P",
           "title" : "Primary information providers",
           "ref" : "section-89P",
+          "id" : "section-89P",
+          "href" : "section/89P",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "89Q",
           "title" : "Disciplinary powers: contravention of s.89P(4)(b) or (d)",
           "ref" : "section-89Q",
+          "id" : "section-89Q",
+          "href" : "section/89Q",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "89R",
           "title" : "Action under s.89Q: procedure and right to refer to Tribunal",
           "ref" : "section-89R",
+          "id" : "section-89R",
+          "href" : "section/89R",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "89S",
           "title" : "Action under s.89Q: statement of policy",
           "ref" : "section-89S",
+          "id" : "section-89S",
+          "href" : "section/89S",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "89T",
           "title" : "Statement of policy under s.89S: procedure",
           "ref" : "section-89T",
+          "id" : "section-89T",
+          "href" : "section/89T",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "89U",
           "title" : "Powers exercisable to advance operational objectives",
           "ref" : "section-89U",
+          "id" : "section-89U",
+          "href" : "section/89U",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "89V",
           "title" : "Action under s.89U: procedure",
           "ref" : "section-89V",
+          "id" : "section-89V",
+          "href" : "section/89V",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "89W",
           "title" : "Storage of regulated information",
           "ref" : "section-89W",
+          "id" : "section-89W",
+          "href" : "section/89W",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -12482,30 +13308,40 @@
         "number" : null,
         "title" : "Compensation for false or misleading statements etc",
         "ref" : "part-VI-crossheading-compensation",
+        "id" : "part-VI-crossheading-compensation",
+        "href" : "part/VI/crossheading/compensation",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "90",
           "title" : "Compensation for statements in listing particulars or prospectus",
           "ref" : "section-90",
+          "id" : "section-90",
+          "href" : "section/90",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "90ZA",
           "title" : "Liability for key investor information",
           "ref" : "section-90ZA",
+          "id" : "section-90ZA",
+          "href" : "section/90ZA",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "90A",
           "title" : "Liability of issuers in connection with published information",
           "ref" : "section-90A",
+          "id" : "section-90A",
+          "href" : "section/90A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "90B",
           "title" : "Power to make further provision about liability for published information",
           "ref" : "section-90B",
+          "id" : "section-90B",
+          "href" : "section/90B",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -12513,30 +13349,40 @@
         "number" : null,
         "title" : "Penalties",
         "ref" : "part-VI-crossheading-penalties",
+        "id" : "part-VI-crossheading-penalties",
+        "href" : "part/VI/crossheading/penalties",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "91",
           "title" : "Penalties for breach of Part 6 rules",
           "ref" : "section-91",
+          "id" : "section-91",
+          "href" : "section/91",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "92",
           "title" : "Procedure.",
           "ref" : "section-92",
+          "id" : "section-92",
+          "href" : "section/92",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "93",
           "title" : "Statement of policy.",
           "ref" : "section-93",
+          "id" : "section-93",
+          "href" : "section/93",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "94",
           "title" : "Statements of policy: procedure.",
           "ref" : "section-94",
+          "id" : "section-94",
+          "href" : "section/94",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -12544,12 +13390,16 @@
         "number" : null,
         "title" : "Competition",
         "ref" : "part-VI-crossheading-competition",
+        "id" : "part-VI-crossheading-competition",
+        "href" : "part/VI/crossheading/competition",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "95",
           "title" : "Competition scrutiny.",
           "ref" : "section-95",
+          "id" : "section-95",
+          "href" : "section/95",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -12557,78 +13407,104 @@
         "number" : null,
         "title" : "Miscellaneous",
         "ref" : "part-VI-crossheading-miscellaneous",
+        "id" : "part-VI-crossheading-miscellaneous",
+        "href" : "part/VI/crossheading/miscellaneous",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "96",
           "title" : "Obligations of issuers of listed securities.",
           "ref" : "section-96",
+          "id" : "section-96",
+          "href" : "section/96",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "96A",
           "title" : "Disclosure of information requirements",
           "ref" : "section-96A",
+          "id" : "section-96A",
+          "href" : "section/96A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "96B",
           "title" : "Disclosure rules: persons responsible for compliance",
           "ref" : "section-96B",
+          "id" : "section-96B",
+          "href" : "section/96B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "96C",
           "title" : "Suspension of trading",
           "ref" : "section-96C",
+          "id" : "section-96C",
+          "href" : "section/96C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "97",
           "title" : "Appointment by FCA of persons to carry out investigations.",
           "ref" : "section-97",
+          "id" : "section-97",
+          "href" : "section/97",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "97A",
           "title" : "Reporting of infringements",
           "ref" : "section-97A",
+          "id" : "section-97A",
+          "href" : "section/97A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "98",
           "title" : "Advertisements etc. in connection with listing applications.",
           "ref" : "section-98",
+          "id" : "section-98",
+          "href" : "section/98",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "99",
           "title" : "Fees.",
           "ref" : "section-99",
+          "id" : "section-99",
+          "href" : "section/99",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "100",
           "title" : "Penalties.",
           "ref" : "section-100",
+          "id" : "section-100",
+          "href" : "section/100",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "100A",
           "title" : "Exercise of powers where UK is host member state",
           "ref" : "section-100A",
+          "id" : "section-100A",
+          "href" : "section/100A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "101",
           "title" : "Listing rules: general provisions.",
           "ref" : "section-101",
+          "id" : "section-101",
+          "href" : "section/101",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "102",
           "title" : "Exemption from liability in damages.",
           "ref" : "section-102",
+          "id" : "section-102",
+          "href" : "section/102",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -12636,30 +13512,40 @@
         "number" : null,
         "title" : "Interpretative provisions",
         "ref" : "part-VI-crossheading-interpretative-provisions",
+        "id" : "part-VI-crossheading-interpretative-provisions",
+        "href" : "part/VI/crossheading/interpretative-provisions",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "102A",
           "title" : "Meaning of “securities” etc.",
           "ref" : "section-102A",
+          "id" : "section-102A",
+          "href" : "section/102A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "102B",
           "title" : "Meaning of “offer of transferable securities to the public” etc.",
           "ref" : "section-102B",
+          "id" : "section-102B",
+          "href" : "section/102B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "102C",
           "title" : "Meaning of “home State” in relation to transferable securities",
           "ref" : "section-102C",
+          "id" : "section-102C",
+          "href" : "section/102C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "103",
           "title" : "Interpretation of this Part",
           "ref" : "section-103",
+          "id" : "section-103",
+          "href" : "section/103",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -12668,132 +13554,176 @@
       "number" : "Part VII",
       "title" : " Control of Business Transfers",
       "ref" : "part-VII",
+      "id" : "part-VII",
+      "href" : "part/VII",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "103A",
         "title" : "Meaning of  “the appropriate regulator”",
         "ref" : "section-103A",
+        "id" : "section-103A",
+        "href" : "section/103A",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "104",
         "title" : " Control of business transfers.",
         "ref" : "section-104",
+        "id" : "section-104",
+        "href" : "section/104",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "105",
         "title" : " Insurance business transfer schemes.",
         "ref" : "section-105",
+        "id" : "section-105",
+        "href" : "section/105",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "106",
         "title" : " Banking business transfer schemes.",
         "ref" : "section-106",
+        "id" : "section-106",
+        "href" : "section/106",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "106A",
         "title" : "Reclaim fund business transfer scheme",
         "ref" : "section-106A",
+        "id" : "section-106A",
+        "href" : "section/106A",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "106B",
         "title" : "Ring-fencing transfer scheme",
         "ref" : "section-106B",
+        "id" : "section-106B",
+        "href" : "section/106B",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "107",
         "title" : " Application for order sanctioning transfer scheme.",
         "ref" : "section-107",
+        "id" : "section-107",
+        "href" : "section/107",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "108",
         "title" : " Requirements on applicants.",
         "ref" : "section-108",
+        "id" : "section-108",
+        "href" : "section/108",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "109",
         "title" : "Scheme reports: insurance business transfer schemes",
         "ref" : "section-109",
+        "id" : "section-109",
+        "href" : "section/109",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "109A",
         "title" : "Scheme reports: ring-fencing transfer schemes",
         "ref" : "section-109A",
+        "id" : "section-109A",
+        "href" : "section/109A",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "110",
         "title" : " Right to participate in proceedings.",
         "ref" : "section-110",
+        "id" : "section-110",
+        "href" : "section/110",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "111",
         "title" : " Sanction of the court for business transfer schemes.",
         "ref" : "section-111",
+        "id" : "section-111",
+        "href" : "section/111",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "112",
         "title" : " Effect of order sanctioning business transfer scheme.",
         "ref" : "section-112",
+        "id" : "section-112",
+        "href" : "section/112",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "112ZA",
         "title" : "Duty of regulator to provide copy of order",
         "ref" : "section-112ZA",
+        "id" : "section-112ZA",
+        "href" : "section/112ZA",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "112A",
         "title" : "Rights to terminate etc.",
         "ref" : "section-112A",
+        "id" : "section-112A",
+        "href" : "section/112A",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "113",
         "title" : " Appointment of actuary in relation to reduction of benefits.",
         "ref" : "section-113",
+        "id" : "section-113",
+        "href" : "section/113",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "114",
         "title" : " Rights of certain policyholders.",
         "ref" : "section-114",
+        "id" : "section-114",
+        "href" : "section/114",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "114A",
         "title" : "Notice of transfer of reinsurance contracts",
         "ref" : "section-114A",
+        "id" : "section-114A",
+        "href" : "section/114A",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "pblock",
         "number" : null,
         "title" : " Business transfers outside the United Kingdom",
         "ref" : "part-VII-crossheading-business-transfers-outside-the-united-kingdom",
+        "id" : "part-VII-crossheading-business-transfers-outside-the-united-kingdom",
+        "href" : "part/VII/crossheading/business-transfers-outside-the-united-kingdom",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "115",
           "title" : " Certificates for purposes of insurance business transfers overseas.",
           "ref" : "section-115",
+          "id" : "section-115",
+          "href" : "section/115",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "116",
           "title" : " Effect of insurance business transfers authorised in other EEA States.",
           "ref" : "section-116",
+          "id" : "section-116",
+          "href" : "section/116",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -12801,12 +13731,16 @@
         "number" : null,
         "title" : " Modifications",
         "ref" : "part-VII-crossheading-modifications",
+        "id" : "part-VII-crossheading-modifications",
+        "href" : "part/VII/crossheading/modifications",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "117",
           "title" : " Power to modify this Part.",
           "ref" : "section-117",
+          "id" : "section-117",
+          "href" : "section/117",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -12815,36 +13749,48 @@
       "number" : "Part VIII",
       "title" : " Provisions relating to market abuse",
       "ref" : "part-VIII",
+      "id" : "part-VIII",
+      "href" : "part/VIII",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : "...",
         "ref" : "part-VIII-crossheading-market-abuse",
+        "id" : "part-VIII-crossheading-market-abuse",
+        "href" : "part/VIII/crossheading/market-abuse",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "118",
           "title" : " Market abuse.",
           "ref" : "section-118",
+          "id" : "section-118",
+          "href" : "section/118",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "118A",
           "title" : "Supplementary provision about certain behaviour",
           "ref" : "section-118A",
+          "id" : "section-118A",
+          "href" : "section/118A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "118B",
           "title" : "Insiders",
           "ref" : "section-118B",
+          "id" : "section-118B",
+          "href" : "section/118B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "118C",
           "title" : "Inside information",
           "ref" : "section-118C",
+          "id" : "section-118C",
+          "href" : "section/118C",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -12852,30 +13798,40 @@
         "number" : null,
         "title" : "...",
         "ref" : "part-VIII-crossheading-the-code",
+        "id" : "part-VIII-crossheading-the-code",
+        "href" : "part/VIII/crossheading/the-code",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "119",
           "title" : " The code.",
           "ref" : "section-119",
+          "id" : "section-119",
+          "href" : "section/119",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "120",
           "title" : " Provisions included in the FCA's code by reference to the City Code.",
           "ref" : "section-120",
+          "id" : "section-120",
+          "href" : "section/120",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "121",
           "title" : " Codes: procedure.",
           "ref" : "section-121",
+          "id" : "section-121",
+          "href" : "section/121",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "122",
           "title" : " Effect of the code.",
           "ref" : "section-122",
+          "id" : "section-122",
+          "href" : "section/122",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -12883,42 +13839,56 @@
         "number" : null,
         "title" : "Powers to require information and supplemental provisions",
         "ref" : "part-VIII-crossheading-powers-to-require-information-and-supplemental-provisions",
+        "id" : "part-VIII-crossheading-powers-to-require-information-and-supplemental-provisions",
+        "href" : "part/VIII/crossheading/powers-to-require-information-and-supplemental-provisions",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "122A",
           "title" : "Power to require information from issuers",
           "ref" : "section-122A",
+          "id" : "section-122A",
+          "href" : "section/122A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "122B",
           "title" : "General power to require information",
           "ref" : "section-122B",
+          "id" : "section-122B",
+          "href" : "section/122B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "122C",
           "title" : "Power to require information: supplementary",
           "ref" : "section-122C",
+          "id" : "section-122C",
+          "href" : "section/122C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "122D",
           "title" : "Entry of premises under warrant",
           "ref" : "section-122D",
+          "id" : "section-122D",
+          "href" : "section/122D",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "122E",
           "title" : "Retention of documents taken under section 122D",
           "ref" : "section-122E",
+          "id" : "section-122E",
+          "href" : "section/122E",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "122F",
           "title" : "Offences",
           "ref" : "section-122F",
+          "id" : "section-122F",
+          "href" : "section/122F",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -12926,36 +13896,48 @@
         "number" : null,
         "title" : "Other administrative powers",
         "ref" : "part-VIII-crossheading-other-administrative-powers",
+        "id" : "part-VIII-crossheading-other-administrative-powers",
+        "href" : "part/VIII/crossheading/other-administrative-powers",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "122G",
           "title" : "Publication of information and corrective statements by issuers",
           "ref" : "section-122G",
+          "id" : "section-122G",
+          "href" : "section/122G",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "122H",
           "title" : "Publication of corrective statements generally",
           "ref" : "section-122H",
+          "id" : "section-122H",
+          "href" : "section/122H",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "122HA",
           "title" : "Publication of corrective statements relating to benchmarks",
           "ref" : "section-122HA",
+          "id" : "section-122HA",
+          "href" : "section/122HA",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "122I",
           "title" : "Power to suspend trading in financial instruments",
           "ref" : "section-122I",
+          "id" : "section-122I",
+          "href" : "section/122I",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "122IA",
           "title" : "Power to suspend auctioning of auctioned products on a recognised auction platform",
           "ref" : "section-122IA",
+          "id" : "section-122IA",
+          "href" : "section/122IA",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -12963,30 +13945,40 @@
         "number" : null,
         "title" : " Administrative sanctions",
         "ref" : "part-VIII-crossheading-power-to-impose-penalties",
+        "id" : "part-VIII-crossheading-power-to-impose-penalties",
+        "href" : "part/VIII/crossheading/power-to-impose-penalties",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "123",
           "title" : " Power to impose penalties or issue censure",
           "ref" : "section-123",
+          "id" : "section-123",
+          "href" : "section/123",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "123A",
           "title" : "Power to prohibit individuals from managing or dealing",
           "ref" : "section-123A",
+          "id" : "section-123A",
+          "href" : "section/123A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "123B",
           "title" : "Suspending permission to carry on regulated activities etc",
           "ref" : "section-123B",
+          "id" : "section-123B",
+          "href" : "section/123B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "123C",
           "title" : "Exercise of administrative sanctions",
           "ref" : "section-123C",
+          "id" : "section-123C",
+          "href" : "section/123C",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -12994,18 +13986,24 @@
         "number" : null,
         "title" : " Statement of policy",
         "ref" : "part-VIII-crossheading-statement-of-policy",
+        "id" : "part-VIII-crossheading-statement-of-policy",
+        "href" : "part/VIII/crossheading/statement-of-policy",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "124",
           "title" : " Statement of policy.",
           "ref" : "section-124",
+          "id" : "section-124",
+          "href" : "section/124",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "125",
           "title" : " Statement of policy: procedure.",
           "ref" : "section-125",
+          "id" : "section-125",
+          "href" : "section/125",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -13013,24 +14011,32 @@
         "number" : null,
         "title" : " Procedure",
         "ref" : "part-VIII-crossheading-procedure",
+        "id" : "part-VIII-crossheading-procedure",
+        "href" : "part/VIII/crossheading/procedure",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "126",
           "title" : " Warning notices.",
           "ref" : "section-126",
+          "id" : "section-126",
+          "href" : "section/126",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "127",
           "title" : " Decision notices and right to refer to Tribunal.",
           "ref" : "section-127",
+          "id" : "section-127",
+          "href" : "section/127",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "127A",
           "title" : "Consultation with the PRA in relation to administrative sanctions",
           "ref" : "section-127A",
+          "id" : "section-127A",
+          "href" : "section/127A",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -13038,72 +14044,96 @@
         "number" : null,
         "title" : " Miscellaneous",
         "ref" : "part-VIII-crossheading-miscellaneous",
+        "id" : "part-VIII-crossheading-miscellaneous",
+        "href" : "part/VIII/crossheading/miscellaneous",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "128",
           "title" : " Suspension of investigations.",
           "ref" : "section-128",
+          "id" : "section-128",
+          "href" : "section/128",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "129",
           "title" : " Power of court to impose administrative sanctions in cases of market abuse",
           "ref" : "section-129",
+          "id" : "section-129",
+          "href" : "section/129",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "130",
           "title" : " Guidance.",
           "ref" : "section-130",
+          "id" : "section-130",
+          "href" : "section/130",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "130A",
           "title" : "Interpretation and supplementary provision",
           "ref" : "section-130A",
+          "id" : "section-130A",
+          "href" : "section/130A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "131",
           "title" : " Effect on transactions.",
           "ref" : "section-131",
+          "id" : "section-131",
+          "href" : "section/131",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "131A",
           "title" : "Protected Disclosures",
           "ref" : "section-131A",
+          "id" : "section-131A",
+          "href" : "section/131A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "131AA",
           "title" : "Reporting of infringements",
           "ref" : "section-131AA",
+          "id" : "section-131AA",
+          "href" : "section/131AA",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "131AB",
           "title" : "Interpretation",
           "ref" : "section-131AB",
+          "id" : "section-131AB",
+          "href" : "section/131AB",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "131AC",
           "title" : "Meaning of “persons closely associated” in the market abuse regulation",
           "ref" : "section-131AC",
+          "id" : "section-131AC",
+          "href" : "section/131AC",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "131AD",
           "title" : "Individual liability in respect of legal persons under Articles 8 and 12 of the market abuse regulation",
           "ref" : "section-131AD",
+          "id" : "section-131AD",
+          "href" : "section/131AD",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "131AE",
           "title" : "Liability for contraventions of Article 14 or 15 of the market abuse regulation",
           "ref" : "section-131AE",
+          "id" : "section-131AE",
+          "href" : "section/131AE",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -13112,30 +14142,40 @@
       "number" : "Part 8A",
       "title" : "Short selling",
       "ref" : "part-8A",
+      "id" : "part-8A",
+      "href" : "part/8A",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : "Short selling rules",
         "ref" : "part-8A-crossheading-short-selling-rules",
+        "id" : "part-8A-crossheading-short-selling-rules",
+        "href" : "part/8A/crossheading/short-selling-rules",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "131B",
           "title" : "Short selling rules",
           "ref" : "section-131B",
+          "id" : "section-131B",
+          "href" : "section/131B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "131C",
           "title" : "\nShort selling rules: definitions \netc\n",
           "ref" : "section-131C",
+          "id" : "section-131C",
+          "href" : "section/131C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "131D",
           "title" : "Short selling rules: procedure in urgent cases",
           "ref" : "section-131D",
+          "id" : "section-131D",
+          "href" : "section/131D",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -13143,36 +14183,48 @@
         "number" : null,
         "title" : "Power to require information",
         "ref" : "part-8A-crossheading-power-to-require-information",
+        "id" : "part-8A-crossheading-power-to-require-information",
+        "href" : "part/8A/crossheading/power-to-require-information",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "131E",
           "title" : "Power to require information",
           "ref" : "section-131E",
+          "id" : "section-131E",
+          "href" : "section/131E",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "131F",
           "title" : "Power to require information: supplementary",
           "ref" : "section-131F",
+          "id" : "section-131F",
+          "href" : "section/131F",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "131FA",
           "title" : "Investigations in support of overseas  regulator",
           "ref" : "section-131FA",
+          "id" : "section-131FA",
+          "href" : "section/131FA",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "131FB",
           "title" : "Entry of premises under warrant",
           "ref" : "section-131FB",
+          "id" : "section-131FB",
+          "href" : "section/131FB",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "131FC",
           "title" : "Retention of documents taken under section 131FB",
           "ref" : "section-131FC",
+          "id" : "section-131FC",
+          "href" : "section/131FC",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -13180,42 +14232,56 @@
         "number" : null,
         "title" : "\n\nBreach of short selling regulation \netc\n",
         "ref" : "part-8A-crossheading-breach-of-short-selling-rules-etc",
+        "id" : "part-8A-crossheading-breach-of-short-selling-rules-etc",
+        "href" : "part/8A/crossheading/breach-of-short-selling-rules-etc",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "131G",
           "title" : "Power to impose penalty or issue censure",
           "ref" : "section-131G",
+          "id" : "section-131G",
+          "href" : "section/131G",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "131H",
           "title" : "Procedure and right to refer to Tribunal",
           "ref" : "section-131H",
+          "id" : "section-131H",
+          "href" : "section/131H",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "131I",
           "title" : "Duty on publication of statement",
           "ref" : "section-131I",
+          "id" : "section-131I",
+          "href" : "section/131I",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "131J",
           "title" : "Imposition of penalties under section 131G: statement of policy",
           "ref" : "section-131J",
+          "id" : "section-131J",
+          "href" : "section/131J",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "131K",
           "title" : "Statement of policy: procedure",
           "ref" : "section-131K",
+          "id" : "section-131K",
+          "href" : "section/131K",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "131L",
           "title" : "Offences",
           "ref" : "section-131L",
+          "id" : "section-131L",
+          "href" : "section/131L",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -13224,30 +14290,40 @@
       "number" : "PART 8B",
       "title" : "Cash access services",
       "ref" : "part-8B",
+      "id" : "part-8B",
+      "href" : "part/8B",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : "Introductory",
         "ref" : "part-8B-crossheading-introductory",
+        "id" : "part-8B-crossheading-introductory",
+        "href" : "part/8B/crossheading/introductory",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "131M",
           "title" : "Overview",
           "ref" : "section-131M",
+          "id" : "section-131M",
+          "href" : "section/131M",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "131N",
           "title" : "Cash access services and coordination arrangements",
           "ref" : "section-131N",
+          "id" : "section-131N",
+          "href" : "section/131N",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "131O",
           "title" : "Current accounts and relevant current account providers",
           "ref" : "section-131O",
+          "id" : "section-131O",
+          "href" : "section/131O",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -13255,18 +14331,24 @@
         "number" : null,
         "title" : "Cash access policy statement",
         "ref" : "part-8B-crossheading-cash-access-policy-statement",
+        "id" : "part-8B-crossheading-cash-access-policy-statement",
+        "href" : "part/8B/crossheading/cash-access-policy-statement",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "131P",
           "title" : "Cash access policy statement",
           "ref" : "section-131P",
+          "id" : "section-131P",
+          "href" : "section/131P",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "131Q",
           "title" : "Provision of reports to assist the Treasury",
           "ref" : "section-131Q",
+          "id" : "section-131Q",
+          "href" : "section/131Q",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -13274,24 +14356,32 @@
         "number" : null,
         "title" : "Designation",
         "ref" : "part-8B-crossheading-designation",
+        "id" : "part-8B-crossheading-designation",
+        "href" : "part/8B/crossheading/designation",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "131R",
           "title" : "Designation",
           "ref" : "section-131R",
+          "id" : "section-131R",
+          "href" : "section/131R",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "131S",
           "title" : "Designation criteria",
           "ref" : "section-131S",
+          "id" : "section-131S",
+          "href" : "section/131S",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "131T",
           "title" : "Cancellation or variation of a designation notice",
           "ref" : "section-131T",
+          "id" : "section-131T",
+          "href" : "section/131T",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -13299,54 +14389,72 @@
         "number" : null,
         "title" : "Supervision of designated persons",
         "ref" : "part-8B-crossheading-supervision-of-designated-persons",
+        "id" : "part-8B-crossheading-supervision-of-designated-persons",
+        "href" : "part/8B/crossheading/supervision-of-designated-persons",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "131U",
           "title" : "Purpose for which FCA must exercise functions under this Part",
           "ref" : "section-131U",
+          "id" : "section-131U",
+          "href" : "section/131U",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "131V",
           "title" : "FCA rules",
           "ref" : "section-131V",
+          "id" : "section-131V",
+          "href" : "section/131V",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "131W",
           "title" : "Power to direct designated persons",
           "ref" : "section-131W",
+          "id" : "section-131W",
+          "href" : "section/131W",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "131X",
           "title" : "Procedure for directions",
           "ref" : "section-131X",
+          "id" : "section-131X",
+          "href" : "section/131X",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "131Y",
           "title" : "Information gathering and investigations",
           "ref" : "section-131Y",
+          "id" : "section-131Y",
+          "href" : "section/131Y",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "131Z",
           "title" : "Disciplinary measures",
           "ref" : "section-131Z",
+          "id" : "section-131Z",
+          "href" : "section/131Z",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "131Z1",
           "title" : "Costs of supervision",
           "ref" : "section-131Z1",
+          "id" : "section-131Z1",
+          "href" : "section/131Z1",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "131Z2",
           "title" : "Exclusion and modification of other FCA duties",
           "ref" : "section-131Z2",
+          "id" : "section-131Z2",
+          "href" : "section/131Z2",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -13355,54 +14463,72 @@
       "number" : "Part IX",
       "title" : " Hearings and Appeals",
       "ref" : "part-IX",
+      "id" : "part-IX",
+      "href" : "part/IX",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "132",
         "title" : " The Financial Services and Markets Tribunal.",
         "ref" : "section-132",
+        "id" : "section-132",
+        "href" : "section/132",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "133",
         "title" : "Proceedings before Tribunal: general provision",
         "ref" : "section-133",
+        "id" : "section-133",
+        "href" : "section/133",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "133A",
         "title" : " Proceedings before Tribunal: decision and supervisory notices, etc.",
         "ref" : "section-133A",
+        "id" : "section-133A",
+        "href" : "section/133A",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "133B",
         "title" : "Offences",
         "ref" : "section-133B",
+        "id" : "section-133B",
+        "href" : "section/133B",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "pblock",
         "number" : null,
         "title" : " Legal assistance before the Tribunal",
         "ref" : "part-IX-crossheading-legal-assistance-before-the-tribunal",
+        "id" : "part-IX-crossheading-legal-assistance-before-the-tribunal",
+        "href" : "part/IX/crossheading/legal-assistance-before-the-tribunal",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "134",
           "title" : " Legal assistance scheme.",
           "ref" : "section-134",
+          "id" : "section-134",
+          "href" : "section/134",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "135",
           "title" : " Provisions of the legal assistance scheme.",
           "ref" : "section-135",
+          "id" : "section-135",
+          "href" : "section/135",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "136",
           "title" : " Funding of the legal assistance scheme.",
           "ref" : "section-136",
+          "id" : "section-136",
+          "href" : "section/136",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -13411,168 +14537,224 @@
       "number" : "PART 9A",
       "title" : "Rules and Guidance",
       "ref" : "part-9A",
+      "id" : "part-9A",
+      "href" : "part/9A",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "chapter",
         "number" : "CHAPTER 1",
         "title" : "Rule-making powers",
         "ref" : "part-9A-chapter-1",
+        "id" : "part-9A-chapter-1",
+        "href" : "part/9A/chapter/1",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "General rule-making powers of the FCA and the PRA",
           "ref" : "part-9A-chapter-1-crossheading-general-rulemaking-powers-of-the-fca-and-the-pra",
+          "id" : "part-9A-chapter-1-crossheading-general-rulemaking-powers-of-the-fca-and-the-pra",
+          "href" : "part/9A/chapter/1/crossheading/general-rulemaking-powers-of-the-fca-and-the-pra",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "137A",
             "title" : "The FCA's general rules",
             "ref" : "section-137A",
+            "id" : "section-137A",
+            "href" : "section/137A",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "137AA",
             "title" : "The FCA's general rules: Gibraltar",
             "ref" : "section-137AA",
+            "id" : "section-137AA",
+            "href" : "section/137AA",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "137B",
             "title" : "FCA general rules: clients' money, right to rescind etc.",
             "ref" : "section-137B",
+            "id" : "section-137B",
+            "href" : "section/137B",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "137C",
             "title" : "FCA general rules: cost of credit and duration of credit agreements",
             "ref" : "section-137C",
+            "id" : "section-137C",
+            "href" : "section/137C",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "137D",
             "title" : "FCA general rules: product intervention",
             "ref" : "section-137D",
+            "id" : "section-137D",
+            "href" : "section/137D",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "137E",
             "title" : "Orders under s.137D(1)(b)",
             "ref" : "section-137E",
+            "id" : "section-137E",
+            "href" : "section/137E",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "137F",
             "title" : "Rules requiring participation in benchmark",
             "ref" : "section-137F",
+            "id" : "section-137F",
+            "href" : "section/137F",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "137FA",
             "title" : "FCA general rules: disclosure of information about pension scheme transaction costs etc",
             "ref" : "section-137FA",
+            "id" : "section-137FA",
+            "href" : "section/137FA",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "137FAA",
             "title" : "FCA general rules: pensions dashboards",
             "ref" : "section-137FAA",
+            "id" : "section-137FAA",
+            "href" : "section/137FAA",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "137FAB",
             "title" : "Pensions dashboards: further provision",
             "ref" : "section-137FAB",
+            "id" : "section-137FAB",
+            "href" : "section/137FAB",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "137FAC",
             "title" : "Sections 137FAA and 137FAB: supplementary",
             "ref" : "section-137FAC",
+            "id" : "section-137FAC",
+            "href" : "section/137FAC",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "137FB",
             "title" : "FCA general rules: disclosure of information about the availability of pensions guidance",
             "ref" : "section-137FB",
+            "id" : "section-137FB",
+            "href" : "section/137FB",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "137FBA",
             "title" : "FCA general rules: advice about transferring or otherwise dealing with annuity payments",
             "ref" : "section-137FBA",
+            "id" : "section-137FBA",
+            "href" : "section/137FBA",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "137FBB",
             "title" : "FCA general rules: early exit pension charges",
             "ref" : "section-137FBB",
+            "id" : "section-137FBB",
+            "href" : "section/137FBB",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "137FC",
             "title" : "FCA rules: disclosure of information about the availability of financial guidance",
             "ref" : "section-137FC",
+            "id" : "section-137FC",
+            "href" : "section/137FC",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "137FD",
             "title" : "FCA general rules: charges for claims management services",
             "ref" : "section-137FD",
+            "id" : "section-137FD",
+            "href" : "section/137FD",
             "extent" : [ "E", "W", "S" ]
           }, {
             "name" : "item",
             "number" : "137G",
             "title" : "The PRA's general rules",
             "ref" : "section-137G",
+            "id" : "section-137G",
+            "href" : "section/137G",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "137GA",
             "title" : "The PRA's general rules: Gibraltar",
             "ref" : "section-137GA",
+            "id" : "section-137GA",
+            "href" : "section/137GA",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "137H",
             "title" : "General rules about remuneration",
             "ref" : "section-137H",
+            "id" : "section-137H",
+            "href" : "section/137H",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "137I",
             "title" : "Remuneration policies: Treasury direction to consider compliance",
             "ref" : "section-137I",
+            "id" : "section-137I",
+            "href" : "section/137I",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "137J",
             "title" : "Rules about recovery plans: duty to consult",
             "ref" : "section-137J",
+            "id" : "section-137J",
+            "href" : "section/137J",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "137K",
             "title" : "Rules about resolution packs: duty to consult",
             "ref" : "section-137K",
+            "id" : "section-137K",
+            "href" : "section/137K",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "137L",
             "title" : "Interpretation of sections 137J and 137K",
             "ref" : "section-137L",
+            "id" : "section-137L",
+            "href" : "section/137L",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "137M",
             "title" : "Special provision relating to adequacy of resolution plans",
             "ref" : "section-137M",
+            "id" : "section-137M",
+            "href" : "section/137M",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "137N",
             "title" : "Recovery plans and resolution packs: restriction on duty of confidence",
             "ref" : "section-137N",
+            "id" : "section-137N",
+            "href" : "section/137N",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -13580,48 +14762,64 @@
           "number" : null,
           "title" : "Specific rule-making powers",
           "ref" : "part-9A-chapter-1-crossheading-specific-rulemaking-powers",
+          "id" : "part-9A-chapter-1-crossheading-specific-rulemaking-powers",
+          "href" : "part/9A/chapter/1/crossheading/specific-rulemaking-powers",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "137O",
             "title" : "Threshold condition code",
             "ref" : "section-137O",
+            "id" : "section-137O",
+            "href" : "section/137O",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "137P",
             "title" : "Control of information rules",
             "ref" : "section-137P",
+            "id" : "section-137P",
+            "href" : "section/137P",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "137Q",
             "title" : "Price stabilising rules",
             "ref" : "section-137Q",
+            "id" : "section-137Q",
+            "href" : "section/137Q",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "137R",
             "title" : "Financial promotion rules",
             "ref" : "section-137R",
+            "id" : "section-137R",
+            "href" : "section/137R",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "137S",
             "title" : "Financial promotion rules: directions given by FCA",
             "ref" : "section-137S",
+            "id" : "section-137S",
+            "href" : "section/137S",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "137SA",
             "title" : "Rules to recover expenses relating to the  Money and Pensions Service ",
             "ref" : "section-137SA",
+            "id" : "section-137SA",
+            "href" : "section/137SA",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "137SB",
             "title" : "Rules to recover debt advice expenses incurred by the devolved authorities",
             "ref" : "section-137SB",
+            "id" : "section-137SB",
+            "href" : "section/137SB",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -13629,12 +14827,16 @@
           "number" : null,
           "title" : "Supplementary powers",
           "ref" : "part-9A-chapter-1-crossheading-supplementary-powers",
+          "id" : "part-9A-chapter-1-crossheading-supplementary-powers",
+          "href" : "part/9A/chapter/1/crossheading/supplementary-powers",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "137T",
             "title" : "General supplementary powers",
             "ref" : "section-137T",
+            "id" : "section-137T",
+            "href" : "section/137T",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -13643,30 +14845,40 @@
         "number" : "CHAPTER 2",
         "title" : "Rules: modification, waiver, contravention and procedural provisions",
         "ref" : "part-9A-chapter-2",
+        "id" : "part-9A-chapter-2",
+        "href" : "part/9A/chapter/2",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Modification or waiver of rules",
           "ref" : "part-9A-chapter-2-crossheading-modification-or-waiver-of-rules",
+          "id" : "part-9A-chapter-2-crossheading-modification-or-waiver-of-rules",
+          "href" : "part/9A/chapter/2/crossheading/modification-or-waiver-of-rules",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "138A",
             "title" : "Modification or waiver of rules",
             "ref" : "section-138A",
+            "id" : "section-138A",
+            "href" : "section/138A",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "138B",
             "title" : "Publication of directions under section 138A",
             "ref" : "section-138B",
+            "id" : "section-138B",
+            "href" : "section/138B",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "138BA",
             "title" : "Disapplication or modification of rules in individual cases",
             "ref" : "section-138BA",
+            "id" : "section-138BA",
+            "href" : "section/138BA",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -13674,24 +14886,32 @@
           "number" : null,
           "title" : "Contravention of rules",
           "ref" : "part-9A-chapter-2-crossheading-contravention-of-rules",
+          "id" : "part-9A-chapter-2-crossheading-contravention-of-rules",
+          "href" : "part/9A/chapter/2/crossheading/contravention-of-rules",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "138C",
             "title" : "Evidential provisions",
             "ref" : "section-138C",
+            "id" : "section-138C",
+            "href" : "section/138C",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "138D",
             "title" : "Actions for damages",
             "ref" : "section-138D",
+            "id" : "section-138D",
+            "href" : "section/138D",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "138E",
             "title" : "Limits on effect of contravening rules",
             "ref" : "section-138E",
+            "id" : "section-138E",
+            "href" : "section/138E",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -13699,96 +14919,128 @@
           "number" : null,
           "title" : "Procedural provisions",
           "ref" : "part-9A-chapter-2-crossheading-procedural-provisions",
+          "id" : "part-9A-chapter-2-crossheading-procedural-provisions",
+          "href" : "part/9A/chapter/2/crossheading/procedural-provisions",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "138EA",
             "title" : "Matters to consider when making rules",
             "ref" : "section-138EA",
+            "id" : "section-138EA",
+            "href" : "section/138EA",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "138F",
             "title" : "Notification of rules",
             "ref" : "section-138F",
+            "id" : "section-138F",
+            "href" : "section/138F",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "138G",
             "title" : "Rule-making instruments",
             "ref" : "section-138G",
+            "id" : "section-138G",
+            "href" : "section/138G",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "138H",
             "title" : "Verification of rules",
             "ref" : "section-138H",
+            "id" : "section-138H",
+            "href" : "section/138H",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "138I",
             "title" : "Consultation by the FCA",
             "ref" : "section-138I",
+            "id" : "section-138I",
+            "href" : "section/138I",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "138IA",
             "title" : "FCA Cost Benefit Analysis Panel",
             "ref" : "section-138IA",
+            "id" : "section-138IA",
+            "href" : "section/138IA",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "138IB",
             "title" : "Statement of policy in relation to cost benefit analyses",
             "ref" : "section-138IB",
+            "id" : "section-138IB",
+            "href" : "section/138IB",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "138J",
             "title" : "Consultation by the PRA",
             "ref" : "section-138J",
+            "id" : "section-138J",
+            "href" : "section/138J",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "138JA",
             "title" : "PRA Cost Benefit Analysis Panel",
             "ref" : "section-138JA",
+            "id" : "section-138JA",
+            "href" : "section/138JA",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "138JB",
             "title" : "Statement of policy in relation to cost benefit analyses",
             "ref" : "section-138JB",
+            "id" : "section-138JB",
+            "href" : "section/138JB",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "138K",
             "title" : "Consultation: mutual societies",
             "ref" : "section-138K",
+            "id" : "section-138K",
+            "href" : "section/138K",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "138L",
             "title" : "Consultation: general exemptions",
             "ref" : "section-138L",
+            "id" : "section-138L",
+            "href" : "section/138L",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "138M",
             "title" : "Consultation: exemptions for temporary product intervention rules",
             "ref" : "section-138M",
+            "id" : "section-138M",
+            "href" : "section/138M",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "138N",
             "title" : "Temporary product intervention rules: statement of policy",
             "ref" : "section-138N",
+            "id" : "section-138N",
+            "href" : "section/138N",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "138O",
             "title" : "Statement of policy under section 138N: procedure",
             "ref" : "section-138O",
+            "id" : "section-138O",
+            "href" : "section/138O",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -13797,30 +15049,40 @@
         "number" : "CHAPTER 2A",
         "title" : "Technical  Standards",
         "ref" : "part-9A-chapter-2A",
+        "id" : "part-9A-chapter-2A",
+        "href" : "part/9A/chapter/2A",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "138P",
           "title" : "Technical standards",
           "ref" : "section-138P",
+          "id" : "section-138P",
+          "href" : "section/138P",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "138Q",
           "title" : "Standards instruments",
           "ref" : "section-138Q",
+          "id" : "section-138Q",
+          "href" : "section/138Q",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "138R",
           "title" : "Treasury approval",
           "ref" : "section-138R",
+          "id" : "section-138R",
+          "href" : "section/138R",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "138S",
           "title" : "Application of Chapters 1 and 2",
           "ref" : "section-138S",
+          "id" : "section-138S",
+          "href" : "section/138S",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -13828,18 +15090,24 @@
         "number" : "CHAPTER 3",
         "title" : "Guidance",
         "ref" : "part-9A-chapter-3",
+        "id" : "part-9A-chapter-3",
+        "href" : "part/9A/chapter/3",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "139A",
           "title" : "Power of the FCA to give guidance",
           "ref" : "section-139A",
+          "id" : "section-139A",
+          "href" : "section/139A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "139B",
           "title" : "Notification of FCA guidance to the Treasury",
           "ref" : "section-139B",
+          "id" : "section-139B",
+          "href" : "section/139B",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -13847,54 +15115,72 @@
         "number" : "CHAPTER 4",
         "title" : "Competition scrutiny",
         "ref" : "part-9A-chapter-4",
+        "id" : "part-9A-chapter-4",
+        "href" : "part/9A/chapter/4",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "140A",
           "title" : "Interpretation",
           "ref" : "section-140A",
+          "id" : "section-140A",
+          "href" : "section/140A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "140B",
           "title" : "Advice about effect of regulating provision or practice",
           "ref" : "section-140B",
+          "id" : "section-140B",
+          "href" : "section/140B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "140C",
           "title" : "Consultation with regulator",
           "ref" : "section-140C",
+          "id" : "section-140C",
+          "href" : "section/140C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "140D",
           "title" : "Investigation powers of  CMA ",
           "ref" : "section-140D",
+          "id" : "section-140D",
+          "href" : "section/140D",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "140E",
           "title" : "Publication by CMA of section 140B advice",
           "ref" : "section-140E",
+          "id" : "section-140E",
+          "href" : "section/140E",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "140F",
           "title" : "Duty of  CMA  to send report to regulator",
           "ref" : "section-140F",
+          "id" : "section-140F",
+          "href" : "section/140F",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "140G",
           "title" : "Duty of regulator to publish response",
           "ref" : "section-140G",
+          "id" : "section-140G",
+          "href" : "section/140G",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "140H",
           "title" : "Role of the Treasury",
           "ref" : "section-140H",
+          "id" : "section-140H",
+          "href" : "section/140H",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -13902,18 +15188,24 @@
         "number" : "CHAPTER 5",
         "title" : "Power to make consequential amendments",
         "ref" : "part-9A-chapter-5",
+        "id" : "part-9A-chapter-5",
+        "href" : "part/9A/chapter/5",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "141A",
           "title" : "Power to make consequential amendments of references to rules etc.",
           "ref" : "section-141A",
+          "id" : "section-141A",
+          "href" : "section/141A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "141B",
           "title" : "Power to consequentially amend enactments",
           "ref" : "section-141B",
+          "id" : "section-141B",
+          "href" : "section/141B",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -13922,48 +15214,64 @@
       "number" : "PART 9B",
       "title" : "Ring-fencing",
       "ref" : "part-9B",
+      "id" : "part-9B",
+      "href" : "part/9B",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : "Introductory",
         "ref" : "part-9B-crossheading-introductory",
+        "id" : "part-9B-crossheading-introductory",
+        "href" : "part/9B/crossheading/introductory",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "142A",
           "title" : "“Ring-fenced body”",
           "ref" : "section-142A",
+          "id" : "section-142A",
+          "href" : "section/142A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "142B",
           "title" : "Core activities",
           "ref" : "section-142B",
+          "id" : "section-142B",
+          "href" : "section/142B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "142C",
           "title" : "Core services",
           "ref" : "section-142C",
+          "id" : "section-142C",
+          "href" : "section/142C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "142D",
           "title" : "Excluded activities",
           "ref" : "section-142D",
+          "id" : "section-142D",
+          "href" : "section/142D",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "142E",
           "title" : "Power of Treasury to impose prohibitions",
           "ref" : "section-142E",
+          "id" : "section-142E",
+          "href" : "section/142E",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "142F",
           "title" : "Orders under section 142A, 142B, 142D or 142E",
           "ref" : "section-142F",
+          "id" : "section-142F",
+          "href" : "section/142F",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -13971,12 +15279,16 @@
         "number" : null,
         "title" : "Ring-fenced bodies not to carry on excluded activities or contravene prohibitions",
         "ref" : "part-9B-crossheading-ringfenced-bodies-not-to-carry-on-excluded-activities-or-contravene-prohibitions",
+        "id" : "part-9B-crossheading-ringfenced-bodies-not-to-carry-on-excluded-activities-or-contravene-prohibitions",
+        "href" : "part/9B/crossheading/ringfenced-bodies-not-to-carry-on-excluded-activities-or-contravene-prohibitions",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "142G",
           "title" : "Ring-fenced bodies not to carry on excluded activities or contravene prohibitions",
           "ref" : "section-142G",
+          "id" : "section-142G",
+          "href" : "section/142G",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -13984,24 +15296,32 @@
         "number" : null,
         "title" : "Ring-fencing rules",
         "ref" : "part-9B-crossheading-ringfencing-rules",
+        "id" : "part-9B-crossheading-ringfencing-rules",
+        "href" : "part/9B/crossheading/ringfencing-rules",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "142H",
           "title" : "Ring-fencing rules",
           "ref" : "section-142H",
+          "id" : "section-142H",
+          "href" : "section/142H",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "142I",
           "title" : "Powers of Treasury in relation to ring-fencing rules",
           "ref" : "section-142I",
+          "id" : "section-142I",
+          "href" : "section/142I",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "142J",
           "title" : "Review of ring-fencing rules etc",
           "ref" : "section-142J",
+          "id" : "section-142J",
+          "href" : "section/142J",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -14009,54 +15329,72 @@
         "number" : null,
         "title" : "Group restructuring powers",
         "ref" : "part-9B-crossheading-group-restructuring-powers",
+        "id" : "part-9B-crossheading-group-restructuring-powers",
+        "href" : "part/9B/crossheading/group-restructuring-powers",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "142K",
           "title" : "Cases in which group restructuring powers become exercisable",
           "ref" : "section-142K",
+          "id" : "section-142K",
+          "href" : "section/142K",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "142L",
           "title" : "Group restructuring powers",
           "ref" : "section-142L",
+          "id" : "section-142L",
+          "href" : "section/142L",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "142M",
           "title" : "Procedure: preliminary notices",
           "ref" : "section-142M",
+          "id" : "section-142M",
+          "href" : "section/142M",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "142N",
           "title" : "Procedure: warning notice and decision notice",
           "ref" : "section-142N",
+          "id" : "section-142N",
+          "href" : "section/142N",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "142O",
           "title" : "References to Tribunal",
           "ref" : "section-142O",
+          "id" : "section-142O",
+          "href" : "section/142O",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "142P",
           "title" : "Subsequent variation of requirement or direction",
           "ref" : "section-142P",
+          "id" : "section-142P",
+          "href" : "section/142P",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "142Q",
           "title" : "Consultation etc. between regulators",
           "ref" : "section-142Q",
+          "id" : "section-142Q",
+          "href" : "section/142Q",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "142R",
           "title" : "Relationship with regulators' powers under Parts 4A and 12A",
           "ref" : "section-142R",
+          "id" : "section-142R",
+          "href" : "section/142R",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -14064,30 +15402,40 @@
         "number" : null,
         "title" : "Failure of parent undertaking to comply with direction",
         "ref" : "part-9B-crossheading-failure-of-parent-undertaking-to-comply-with-direction",
+        "id" : "part-9B-crossheading-failure-of-parent-undertaking-to-comply-with-direction",
+        "href" : "part/9B/crossheading/failure-of-parent-undertaking-to-comply-with-direction",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "142S",
           "title" : "Power to impose penalty or issue censure",
           "ref" : "section-142S",
+          "id" : "section-142S",
+          "href" : "section/142S",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "142T",
           "title" : "Procedure and right to refer to Tribunal",
           "ref" : "section-142T",
+          "id" : "section-142T",
+          "href" : "section/142T",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "142U",
           "title" : "Duty on publication of statement",
           "ref" : "section-142U",
+          "id" : "section-142U",
+          "href" : "section/142U",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "142V",
           "title" : "Imposition of penalties under section 142S: statement of policy",
           "ref" : "section-142V",
+          "id" : "section-142V",
+          "href" : "section/142V",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -14095,18 +15443,24 @@
         "number" : null,
         "title" : "Pension liabilities",
         "ref" : "part-9B-crossheading-pension-liabilities",
+        "id" : "part-9B-crossheading-pension-liabilities",
+        "href" : "part/9B/crossheading/pension-liabilities",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "142W",
           "title" : "Pension liabilities",
           "ref" : "section-142W",
+          "id" : "section-142W",
+          "href" : "section/142W",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "142X",
           "title" : "Further interpretative provisions for section 142W",
           "ref" : "section-142X",
+          "id" : "section-142X",
+          "href" : "section/142X",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -14114,12 +15468,16 @@
         "number" : null,
         "title" : "Loss-absorbency requirements",
         "ref" : "part-9B-crossheading-lossabsorbency-requirements",
+        "id" : "part-9B-crossheading-lossabsorbency-requirements",
+        "href" : "part/9B/crossheading/lossabsorbency-requirements",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "142Y",
           "title" : "Power of Treasury in relation to loss-absorbency requirements",
           "ref" : "section-142Y",
+          "id" : "section-142Y",
+          "href" : "section/142Y",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -14127,18 +15485,24 @@
         "number" : null,
         "title" : "General",
         "ref" : "part-9B-crossheading-general",
+        "id" : "part-9B-crossheading-general",
+        "href" : "part/9B/crossheading/general",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "142Z",
           "title" : "Affirmative procedure in relation to certain orders under Part 9B",
           "ref" : "section-142Z",
+          "id" : "section-142Z",
+          "href" : "section/142Z",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "142Z1",
           "title" : "Interpretation of Part 9B",
           "ref" : "section-142Z1",
+          "id" : "section-142Z1",
+          "href" : "section/142Z1",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -14147,24 +15511,32 @@
       "number" : "PART 9C",
       "title" : "Prudential regulation of FCA investment firms",
       "ref" : "part-9C",
+      "id" : "part-9C",
+      "href" : "part/9C",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : "Interpretation",
         "ref" : "part-9C-crossheading-interpretation",
+        "id" : "part-9C-crossheading-interpretation",
+        "href" : "part/9C/crossheading/interpretation",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "143A",
           "title" : "FCA investment firms",
           "ref" : "section-143A",
+          "id" : "section-143A",
+          "href" : "section/143A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "143B",
           "title" : "Other terms used in this Part",
           "ref" : "section-143B",
+          "id" : "section-143B",
+          "href" : "section/143B",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -14172,48 +15544,64 @@
         "number" : null,
         "title" : "Rules",
         "ref" : "part-9C-crossheading-rules",
+        "id" : "part-9C-crossheading-rules",
+        "href" : "part/9C/crossheading/rules",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "143C",
           "title" : "Duty to make rules applying to FCA investment firms",
           "ref" : "section-143C",
+          "id" : "section-143C",
+          "href" : "section/143C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "143D",
           "title" : "Duty to make rules applying to parent undertakings",
           "ref" : "section-143D",
+          "id" : "section-143D",
+          "href" : "section/143D",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "143E",
           "title" : "Powers to make rules applying to parent undertakings",
           "ref" : "section-143E",
+          "id" : "section-143E",
+          "href" : "section/143E",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "143F",
           "title" : "Part 9C rules",
           "ref" : "section-143F",
+          "id" : "section-143F",
+          "href" : "section/143F",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "143G",
           "title" : "Matters to consider when making Part 9C rules",
           "ref" : "section-143G",
+          "id" : "section-143G",
+          "href" : "section/143G",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "143H",
           "title" : "Explanation to accompany consultation on rules",
           "ref" : "section-143H",
+          "id" : "section-143H",
+          "href" : "section/143H",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "143I",
           "title" : "Exceptions from sections 143G and 143H",
           "ref" : "section-143I",
+          "id" : "section-143I",
+          "href" : "section/143I",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -14221,12 +15609,16 @@
         "number" : null,
         "title" : "Requirement to have UK parent undertaking",
         "ref" : "part-9C-crossheading-requirement-to-have-uk-parent-undertaking",
+        "id" : "part-9C-crossheading-requirement-to-have-uk-parent-undertaking",
+        "href" : "part/9C/crossheading/requirement-to-have-uk-parent-undertaking",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "143J",
           "title" : "Requirement to have UK parent undertaking",
           "ref" : "section-143J",
+          "id" : "section-143J",
+          "href" : "section/143J",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -14234,48 +15626,64 @@
         "number" : null,
         "title" : "Imposition of requirements on non-authorised parent undertakings",
         "ref" : "part-9C-crossheading-imposition-of-requirements-on-nonauthorised-parent-undertakings",
+        "id" : "part-9C-crossheading-imposition-of-requirements-on-nonauthorised-parent-undertakings",
+        "href" : "part/9C/crossheading/imposition-of-requirements-on-nonauthorised-parent-undertakings",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "143K",
           "title" : "Imposition of requirements on non-authorised parent undertakings",
           "ref" : "section-143K",
+          "id" : "section-143K",
+          "href" : "section/143K",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "143L",
           "title" : "Applications under section 143K",
           "ref" : "section-143L",
+          "id" : "section-143L",
+          "href" : "section/143L",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "143M",
           "title" : "Determination of applications under section 143K",
           "ref" : "section-143M",
+          "id" : "section-143M",
+          "href" : "section/143M",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "143N",
           "title" : "Refusal of applications under section 143K",
           "ref" : "section-143N",
+          "id" : "section-143N",
+          "href" : "section/143N",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "143O",
           "title" : "Exercise of own-initiative power under section 143K",
           "ref" : "section-143O",
+          "id" : "section-143O",
+          "href" : "section/143O",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "143P",
           "title" : "Right to refer matters to the Tribunal",
           "ref" : "section-143P",
+          "id" : "section-143P",
+          "href" : "section/143P",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "143Q",
           "title" : "Assets requirements",
           "ref" : "section-143Q",
+          "id" : "section-143Q",
+          "href" : "section/143Q",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -14283,36 +15691,48 @@
         "number" : null,
         "title" : "Control of managers etc of non-authorised parent undertakings",
         "ref" : "part-9C-crossheading-control-of-managers-etc-of-nonauthorised-parent-undertakings",
+        "id" : "part-9C-crossheading-control-of-managers-etc-of-nonauthorised-parent-undertakings",
+        "href" : "part/9C/crossheading/control-of-managers-etc-of-nonauthorised-parent-undertakings",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "143R",
           "title" : "Managers of non-authorised parent undertakings",
           "ref" : "section-143R",
+          "id" : "section-143R",
+          "href" : "section/143R",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "143S",
           "title" : "Part 9C prohibition orders",
           "ref" : "section-143S",
+          "id" : "section-143S",
+          "href" : "section/143S",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "143T",
           "title" : "Procedure for making a Part 9C prohibition order",
           "ref" : "section-143T",
+          "id" : "section-143T",
+          "href" : "section/143T",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "143U",
           "title" : "Varying and withdrawing a Part 9C prohibition order",
           "ref" : "section-143U",
+          "id" : "section-143U",
+          "href" : "section/143U",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "143V",
           "title" : "Offence of breaching a Part 9C prohibition order",
           "ref" : "section-143V",
+          "id" : "section-143V",
+          "href" : "section/143V",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -14320,30 +15740,40 @@
         "number" : null,
         "title" : "Disciplinary measures for non-authorised parent undertakings",
         "ref" : "part-9C-crossheading-disciplinary-measures-for-nonauthorised-parent-undertakings",
+        "id" : "part-9C-crossheading-disciplinary-measures-for-nonauthorised-parent-undertakings",
+        "href" : "part/9C/crossheading/disciplinary-measures-for-nonauthorised-parent-undertakings",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "143W",
           "title" : "Disciplinary measures",
           "ref" : "section-143W",
+          "id" : "section-143W",
+          "href" : "section/143W",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "143X",
           "title" : "Procedure for disciplinary measures",
           "ref" : "section-143X",
+          "id" : "section-143X",
+          "href" : "section/143X",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "143Y",
           "title" : "Statement of policy for penalties under section 143W",
           "ref" : "section-143Y",
+          "id" : "section-143Y",
+          "href" : "section/143Y",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "143Z",
           "title" : "Procedure for statement of policy",
           "ref" : "section-143Z",
+          "id" : "section-143Z",
+          "href" : "section/143Z",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -14352,24 +15782,32 @@
       "number" : "PART 9D",
       "title" : "Prudential regulation of credit institutions etc",
       "ref" : "part-9D",
+      "id" : "part-9D",
+      "href" : "part/9D",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : "Interpretation",
         "ref" : "part-9D-crossheading-interpretation",
+        "id" : "part-9D-crossheading-interpretation",
+        "href" : "part/9D/crossheading/interpretation",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "144A",
           "title" : "CRR rules",
           "ref" : "section-144A",
+          "id" : "section-144A",
+          "href" : "section/144A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "144B",
           "title" : "Terms used in this Part",
           "ref" : "section-144B",
+          "id" : "section-144B",
+          "href" : "section/144B",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -14377,30 +15815,40 @@
         "number" : null,
         "title" : "Making CRR rules",
         "ref" : "part-9D-crossheading-making-crr-rules",
+        "id" : "part-9D-crossheading-making-crr-rules",
+        "href" : "part/9D/crossheading/making-crr-rules",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "144C",
           "title" : "Matters to consider when making CRR rules",
           "ref" : "section-144C",
+          "id" : "section-144C",
+          "href" : "section/144C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "144D",
           "title" : "Explanation to accompany consultation on CRR rules",
           "ref" : "section-144D",
+          "id" : "section-144D",
+          "href" : "section/144D",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "144E",
           "title" : "Exceptions from sections 144C and 144D etc",
           "ref" : "section-144E",
+          "id" : "section-144E",
+          "href" : "section/144E",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "144F",
           "title" : "Power to consequentially amend enactments",
           "ref" : "section-144F",
+          "id" : "section-144F",
+          "href" : "section/144F",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -14408,18 +15856,24 @@
         "number" : null,
         "title" : "Content of CRR rules",
         "ref" : "part-9D-crossheading-content-of-crr-rules",
+        "id" : "part-9D-crossheading-content-of-crr-rules",
+        "href" : "part/9D/crossheading/content-of-crr-rules",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "144G",
           "title" : "Disapplication or modification of CRR rules in individual cases",
           "ref" : "section-144G",
+          "id" : "section-144G",
+          "href" : "section/144G",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "144H",
           "title" : "Relationship with the capital requirements regulation",
           "ref" : "section-144H",
+          "id" : "section-144H",
+          "href" : "section/144H",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -14428,114 +15882,152 @@
       "number" : "Part X",
       "title" : " Rules and Guidance",
       "ref" : "part-X",
+      "id" : "part-X",
+      "href" : "part/X",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "chapter",
         "number" : "Chapter I",
         "title" : " Rule-making Powers",
         "ref" : "part-X-chapter-I",
+        "id" : "part-X-chapter-I",
+        "href" : "part/X/chapter/I",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "138",
           "title" : " General rule-making power.",
           "ref" : "section-138",
+          "id" : "section-138",
+          "href" : "section/138",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "139",
           "title" : " Miscellaneous ancillary matters.",
           "ref" : "section-139",
+          "id" : "section-139",
+          "href" : "section/139",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "139A",
           "title" : "General rules about remuneration",
           "ref" : "section-139An1",
+          "id" : "section-139An1",
+          "href" : "section/139An1",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "139B",
           "title" : "Rules about recovery plans",
           "ref" : "section-139Bn1",
+          "id" : "section-139Bn1",
+          "href" : "section/139Bn1",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "139C",
           "title" : "Rules about resolution plans",
           "ref" : "section-139C",
+          "id" : "section-139C",
+          "href" : "section/139C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "139D",
           "title" : "Sections 139B and 139C: interpretation",
           "ref" : "section-139D",
+          "id" : "section-139D",
+          "href" : "section/139D",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "139E",
           "title" : "Rules about recovery and resolution plans: supplementary provision",
           "ref" : "section-139E",
+          "id" : "section-139E",
+          "href" : "section/139E",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "139F",
           "title" : "Special provision in relation to resolution plans",
           "ref" : "section-139F",
+          "id" : "section-139F",
+          "href" : "section/139F",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "140",
           "title" : " Restriction on managers of  certain collective investment schemes.",
           "ref" : "section-140",
+          "id" : "section-140",
+          "href" : "section/140",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "141",
           "title" : " Insurance business rules.",
           "ref" : "section-141",
+          "id" : "section-141",
+          "href" : "section/141",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "142",
           "title" : " Insurance business: regulations supplementing Authority’s rules.",
           "ref" : "section-142",
+          "id" : "section-142",
+          "href" : "section/142",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "143",
           "title" : " Endorsement of codes etc.",
           "ref" : "section-143",
+          "id" : "section-143",
+          "href" : "section/143",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "pblock",
           "number" : null,
           "title" : " Specific rules",
           "ref" : "part-X-chapter-I-crossheading-specific-rules",
+          "id" : "part-X-chapter-I-crossheading-specific-rules",
+          "href" : "part/X/chapter/I/crossheading/specific-rules",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "144",
             "title" : " Price stabilising rules.",
             "ref" : "section-144",
+            "id" : "section-144",
+            "href" : "section/144",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "145",
             "title" : " Financial promotion rules.",
             "ref" : "section-145",
+            "id" : "section-145",
+            "href" : "section/145",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "146",
             "title" : " Money laundering rules.",
             "ref" : "section-146",
+            "id" : "section-146",
+            "href" : "section/146",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "147",
             "title" : " Control of information rules.",
             "ref" : "section-147",
+            "id" : "section-147",
+            "href" : "section/147",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -14543,12 +16035,16 @@
           "number" : null,
           "title" : " Modification or waiver",
           "ref" : "part-X-chapter-I-crossheading-modification-or-waiver",
+          "id" : "part-X-chapter-I-crossheading-modification-or-waiver",
+          "href" : "part/X/chapter/I/crossheading/modification-or-waiver",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "148",
             "title" : " Modification or waiver of rules.",
             "ref" : "section-148",
+            "id" : "section-148",
+            "href" : "section/148",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -14556,24 +16052,32 @@
           "number" : null,
           "title" : " Contravention of rules",
           "ref" : "part-X-chapter-I-crossheading-contravention-of-rules",
+          "id" : "part-X-chapter-I-crossheading-contravention-of-rules",
+          "href" : "part/X/chapter/I/crossheading/contravention-of-rules",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "149",
             "title" : " Evidential provisions.",
             "ref" : "section-149",
+            "id" : "section-149",
+            "href" : "section/149",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "150",
             "title" : " Actions for damages.",
             "ref" : "section-150",
+            "id" : "section-150",
+            "href" : "section/150",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "151",
             "title" : " Limits on effect of contravening rules.",
             "ref" : "section-151",
+            "id" : "section-151",
+            "href" : "section/151",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -14581,36 +16085,48 @@
           "number" : null,
           "title" : " Procedural provisions",
           "ref" : "part-X-chapter-I-crossheading-procedural-provisions",
+          "id" : "part-X-chapter-I-crossheading-procedural-provisions",
+          "href" : "part/X/chapter/I/crossheading/procedural-provisions",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "152",
             "title" : " Notification of rules to the Treasury.",
             "ref" : "section-152",
+            "id" : "section-152",
+            "href" : "section/152",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "153",
             "title" : " Rule-making instruments.",
             "ref" : "section-153",
+            "id" : "section-153",
+            "href" : "section/153",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "154",
             "title" : " Verification of rules.",
             "ref" : "section-154",
+            "id" : "section-154",
+            "href" : "section/154",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "155",
             "title" : " Consultation.",
             "ref" : "section-155",
+            "id" : "section-155",
+            "href" : "section/155",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "156",
             "title" : " General supplementary powers.",
             "ref" : "section-156",
+            "id" : "section-156",
+            "href" : "section/156",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -14619,24 +16135,32 @@
         "number" : "Chapter II",
         "title" : " Guidance",
         "ref" : "part-X-chapter-II",
+        "id" : "part-X-chapter-II",
+        "href" : "part/X/chapter/II",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "157",
           "title" : " Guidance.",
           "ref" : "section-157",
+          "id" : "section-157",
+          "href" : "section/157",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "158",
           "title" : " Notification of guidance to the Treasury.",
           "ref" : "section-158",
+          "id" : "section-158",
+          "href" : "section/158",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "158A",
           "title" : "Guidance on outsourcing by investment firms and credit institutions",
           "ref" : "section-158A",
+          "id" : "section-158A",
+          "href" : "section/158A",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -14644,42 +16168,56 @@
         "number" : "Chapter III",
         "title" : " Competition Scrutiny",
         "ref" : "part-X-chapter-III",
+        "id" : "part-X-chapter-III",
+        "href" : "part/X/chapter/III",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "159",
           "title" : " Interpretation.",
           "ref" : "section-159",
+          "id" : "section-159",
+          "href" : "section/159",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "160",
           "title" : " Reports by  OFT.",
           "ref" : "section-160",
+          "id" : "section-160",
+          "href" : "section/160",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "161",
           "title" : " Power of  OFT to request information.",
           "ref" : "section-161",
+          "id" : "section-161",
+          "href" : "section/161",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "162",
           "title" : " Consideration by Competition Commission.",
           "ref" : "section-162",
+          "id" : "section-162",
+          "href" : "section/162",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "163",
           "title" : " Role of the Treasury.",
           "ref" : "section-163",
+          "id" : "section-163",
+          "href" : "section/163",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "164",
           "title" : " The Competition Act 1998.",
           "ref" : "section-164",
+          "id" : "section-164",
+          "href" : "section/164",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -14688,48 +16226,64 @@
       "number" : "Part XI",
       "title" : "Information Gathering and Investigations",
       "ref" : "part-XI",
+      "id" : "part-XI",
+      "href" : "part/XI",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : "Powers to gather information",
         "ref" : "part-XI-crossheading-powers-to-gather-information",
+        "id" : "part-XI-crossheading-powers-to-gather-information",
+        "href" : "part/XI/crossheading/powers-to-gather-information",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "165",
           "title" : "Regulators power to require information : authorised persons etc.",
           "ref" : "section-165",
+          "id" : "section-165",
+          "href" : "section/165",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "165A",
           "title" : "PRA's power to require information: financial stability",
           "ref" : "section-165A",
+          "id" : "section-165A",
+          "href" : "section/165A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "165B",
           "title" : "Safeguards etc in relation to exercise of power under section 165A",
           "ref" : "section-165B",
+          "id" : "section-165B",
+          "href" : "section/165B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "165C",
           "title" : "Orders under section 165A(2)(d)",
           "ref" : "section-165C",
+          "id" : "section-165C",
+          "href" : "section/165C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "166",
           "title" : "Reports by skilled persons.",
           "ref" : "section-166",
+          "id" : "section-166",
+          "href" : "section/166",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "166A",
           "title" : "Appointment of skilled person to collect and update information",
           "ref" : "section-166A",
+          "id" : "section-166A",
+          "href" : "section/166A",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -14737,18 +16291,24 @@
         "number" : null,
         "title" : "Appointment of investigators",
         "ref" : "part-XI-crossheading-appointment-of-investigators",
+        "id" : "part-XI-crossheading-appointment-of-investigators",
+        "href" : "part/XI/crossheading/appointment-of-investigators",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "167",
           "title" : "Appointment of persons to carry out general investigations.",
           "ref" : "section-167",
+          "id" : "section-167",
+          "href" : "section/167",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "168",
           "title" : "Appointment of persons to carry out investigations in particular cases.",
           "ref" : "section-168",
+          "id" : "section-168",
+          "href" : "section/168",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -14756,18 +16316,24 @@
         "number" : null,
         "title" : "Assistance to overseas regulators",
         "ref" : "part-XI-crossheading-assistance-to-overseas-regulators",
+        "id" : "part-XI-crossheading-assistance-to-overseas-regulators",
+        "href" : "part/XI/crossheading/assistance-to-overseas-regulators",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "169",
           "title" : "Investigations etc. in support of overseas regulator.",
           "ref" : "section-169",
+          "id" : "section-169",
+          "href" : "section/169",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "169A",
           "title" : "Support of overseas regulator with respect to financial stability",
           "ref" : "section-169A",
+          "id" : "section-169A",
+          "href" : "section/169A",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -14775,54 +16341,72 @@
         "number" : null,
         "title" : "Conduct of investigations",
         "ref" : "part-XI-crossheading-conduct-of-investigations",
+        "id" : "part-XI-crossheading-conduct-of-investigations",
+        "href" : "part/XI/crossheading/conduct-of-investigations",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "170",
           "title" : "Investigations: general.",
           "ref" : "section-170",
+          "id" : "section-170",
+          "href" : "section/170",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "171",
           "title" : "Powers of persons appointed under section 167.",
           "ref" : "section-171",
+          "id" : "section-171",
+          "href" : "section/171",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "172",
           "title" : "Additional power of persons appointed as a result of section 168(1) or (4).",
           "ref" : "section-172",
+          "id" : "section-172",
+          "href" : "section/172",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "173",
           "title" : "Powers of persons appointed as a result of section 168(2).",
           "ref" : "section-173",
+          "id" : "section-173",
+          "href" : "section/173",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "174",
           "title" : "Admissibility of statements made to investigators.",
           "ref" : "section-174",
+          "id" : "section-174",
+          "href" : "section/174",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "175",
           "title" : "Information and documents: supplemental provisions.",
           "ref" : "section-175",
+          "id" : "section-175",
+          "href" : "section/175",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "176",
           "title" : "Entry of premises under warrant.",
           "ref" : "section-176",
+          "id" : "section-176",
+          "href" : "section/176",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "176A",
           "title" : "Retention of documents taken under section 176",
           "ref" : "section-176A",
+          "id" : "section-176A",
+          "href" : "section/176A",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -14830,12 +16414,16 @@
         "number" : null,
         "title" : "Offences",
         "ref" : "part-XI-crossheading-offences",
+        "id" : "part-XI-crossheading-offences",
+        "href" : "part/XI/crossheading/offences",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "177",
           "title" : "Offences.",
           "ref" : "section-177",
+          "id" : "section-177",
+          "href" : "section/177",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -14843,12 +16431,16 @@
         "number" : null,
         "title" : "Interpretation",
         "ref" : "part-XI-crossheading-interpretation",
+        "id" : "part-XI-crossheading-interpretation",
+        "href" : "part/XI/crossheading/interpretation",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "177A",
           "title" : "Interpretation of Part 11",
           "ref" : "section-177A",
+          "id" : "section-177A",
+          "href" : "section/177A",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -14857,30 +16449,40 @@
       "number" : "Part XII",
       "title" : " Control Over Authorised Persons",
       "ref" : "part-XII",
+      "id" : "part-XII",
+      "href" : "part/XII",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : "Notices of acquisitions of control over UK authorised persons",
         "ref" : "part-XII-crossheading-notices-of-acquisitions-of-control-over-uk-authorised-persons",
+        "id" : "part-XII-crossheading-notices-of-acquisitions-of-control-over-uk-authorised-persons",
+        "href" : "part/XII/crossheading/notices-of-acquisitions-of-control-over-uk-authorised-persons",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "178",
           "title" : "Obligation to notify the  appropriate regulator: acquisitions of control",
           "ref" : "section-178",
+          "id" : "section-178",
+          "href" : "section/178",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "179",
           "title" : "Requirements for section 178 notices",
           "ref" : "section-179",
+          "id" : "section-179",
+          "href" : "section/179",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "180",
           "title" : "Acknowledgment of receipt",
           "ref" : "section-180",
+          "id" : "section-180",
+          "href" : "section/180",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -14888,30 +16490,40 @@
         "number" : null,
         "title" : "Acquiring control and other changes of holding",
         "ref" : "part-XII-crossheading-acquiring-control-and-other-changes-of-holding",
+        "id" : "part-XII-crossheading-acquiring-control-and-other-changes-of-holding",
+        "href" : "part/XII/crossheading/acquiring-control-and-other-changes-of-holding",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "181",
           "title" : "Acquiring control",
           "ref" : "section-181",
+          "id" : "section-181",
+          "href" : "section/181",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "182",
           "title" : "Increasing control",
           "ref" : "section-182",
+          "id" : "section-182",
+          "href" : "section/182",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "183",
           "title" : "Reducing or ceasing to have control",
           "ref" : "section-183",
+          "id" : "section-183",
+          "href" : "section/183",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "184",
           "title" : "Disregarded holdings",
           "ref" : "section-184",
+          "id" : "section-184",
+          "href" : "section/184",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -14919,72 +16531,96 @@
         "number" : null,
         "title" : "Assessment procedure",
         "ref" : "part-XII-crossheading-assessment-procedure",
+        "id" : "part-XII-crossheading-assessment-procedure",
+        "href" : "part/XII/crossheading/assessment-procedure",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "185",
           "title" : "Assessment: general",
           "ref" : "section-185",
+          "id" : "section-185",
+          "href" : "section/185",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "186",
           "title" : "Assessment criteria",
           "ref" : "section-186",
+          "id" : "section-186",
+          "href" : "section/186",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "187",
           "title" : "Approval with conditions",
           "ref" : "section-187",
+          "id" : "section-187",
+          "href" : "section/187",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "187A",
           "title" : "Assessment: consultation by PRA with FCA",
           "ref" : "section-187A",
+          "id" : "section-187A",
+          "href" : "section/187A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "187B",
           "title" : "Assessment: consultation by FCA with PRA",
           "ref" : "section-187B",
+          "id" : "section-187B",
+          "href" : "section/187B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "187C",
           "title" : "Variation etc of conditions",
           "ref" : "section-187C",
+          "id" : "section-187C",
+          "href" : "section/187C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "188",
           "title" : "Assessment: consultation with EC competent authorities",
           "ref" : "section-188",
+          "id" : "section-188",
+          "href" : "section/188",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "189",
           "title" : "Assessment: Procedure",
           "ref" : "section-189",
+          "id" : "section-189",
+          "href" : "section/189",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "190",
           "title" : "Requests for further information",
           "ref" : "section-190",
+          "id" : "section-190",
+          "href" : "section/190",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "190A",
           "title" : "Assessment and resolution",
           "ref" : "section-190A",
+          "id" : "section-190A",
+          "href" : "section/190A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "191",
           "title" : "Duration of approval",
           "ref" : "section-191",
+          "id" : "section-191",
+          "href" : "section/191",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -14992,24 +16628,32 @@
         "number" : null,
         "title" : "Enforcement procedures",
         "ref" : "part-XII-crossheading-enforcement-procedures",
+        "id" : "part-XII-crossheading-enforcement-procedures",
+        "href" : "part/XII/crossheading/enforcement-procedures",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "191A",
           "title" : "Objection by the appropriate regulator",
           "ref" : "section-191A",
+          "id" : "section-191A",
+          "href" : "section/191A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "191B",
           "title" : "Restriction notices",
           "ref" : "section-191B",
+          "id" : "section-191B",
+          "href" : "section/191B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "191C",
           "title" : "Orders for sale of shares",
           "ref" : "section-191C",
+          "id" : "section-191C",
+          "href" : "section/191C",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -15017,18 +16661,24 @@
         "number" : null,
         "title" : "Notice of reductions of control of UK authorised persons",
         "ref" : "part-XII-crossheading-notice-of-reductions-of-control-of-uk-authorised-persons",
+        "id" : "part-XII-crossheading-notice-of-reductions-of-control-of-uk-authorised-persons",
+        "href" : "part/XII/crossheading/notice-of-reductions-of-control-of-uk-authorised-persons",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "191D",
           "title" : "Obligation to notify the appropriate regulator: dispositions of control",
           "ref" : "section-191D",
+          "id" : "section-191D",
+          "href" : "section/191D",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "191E",
           "title" : "Requirements for notices under section 191D",
           "ref" : "section-191E",
+          "id" : "section-191E",
+          "href" : "section/191E",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -15036,12 +16686,16 @@
         "number" : null,
         "title" : "Offences",
         "ref" : "part-XII-crossheading-offences",
+        "id" : "part-XII-crossheading-offences",
+        "href" : "part/XII/crossheading/offences",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "191F",
           "title" : "Offences under this Part",
           "ref" : "section-191F",
+          "id" : "section-191F",
+          "href" : "section/191F",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -15049,12 +16703,16 @@
         "number" : null,
         "title" : "Interpretation",
         "ref" : "part-XII-crossheading-interpretation",
+        "id" : "part-XII-crossheading-interpretation",
+        "href" : "part/XII/crossheading/interpretation",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "191G",
           "title" : "Interpretation",
           "ref" : "section-191G",
+          "id" : "section-191G",
+          "href" : "section/191G",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -15062,12 +16720,16 @@
         "number" : null,
         "title" : " Miscellaneous",
         "ref" : "part-XII-crossheading-miscellaneous",
+        "id" : "part-XII-crossheading-miscellaneous",
+        "href" : "part/XII/crossheading/miscellaneous",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "192",
           "title" : " Power to change definitions of control etc.",
           "ref" : "section-192",
+          "id" : "section-192",
+          "href" : "section/192",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -15076,24 +16738,32 @@
       "number" : "PART 12A",
       "title" : "Powers exercisable in relation to parent undertakings",
       "ref" : "part-12A",
+      "id" : "part-12A",
+      "href" : "part/12A",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : "Introductory",
         "ref" : "part-12A-crossheading-introductory",
+        "id" : "part-12A-crossheading-introductory",
+        "href" : "part/12A/crossheading/introductory",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "192A",
           "title" : "Meaning of  “qualifying authorised person”",
           "ref" : "section-192A",
+          "id" : "section-192A",
+          "href" : "section/192A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "192B",
           "title" : "Meaning of  “qualifying parent undertaking”",
           "ref" : "section-192B",
+          "id" : "section-192B",
+          "href" : "section/192B",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -15101,48 +16771,64 @@
         "number" : null,
         "title" : "Power of direction",
         "ref" : "part-12A-crossheading-power-of-direction",
+        "id" : "part-12A-crossheading-power-of-direction",
+        "href" : "part/12A/crossheading/power-of-direction",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "192C",
           "title" : "Power to direct qualifying parent undertaking",
           "ref" : "section-192C",
+          "id" : "section-192C",
+          "href" : "section/192C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "192D",
           "title" : "Requirements that may be imposed",
           "ref" : "section-192D",
+          "id" : "section-192D",
+          "href" : "section/192D",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "192E",
           "title" : "Direction: procedure",
           "ref" : "section-192E",
+          "id" : "section-192E",
+          "href" : "section/192E",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "192F",
           "title" : "Consultation between regulators",
           "ref" : "section-192F",
+          "id" : "section-192F",
+          "href" : "section/192F",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "192G",
           "title" : "References to Tribunal",
           "ref" : "section-192G",
+          "id" : "section-192G",
+          "href" : "section/192G",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "192H",
           "title" : "Statement of policy: directions under section 192C",
           "ref" : "section-192H",
+          "id" : "section-192H",
+          "href" : "section/192H",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "192I",
           "title" : "Statement of policy relating to directions: procedure",
           "ref" : "section-192I",
+          "id" : "section-192I",
+          "href" : "section/192I",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -15150,12 +16836,16 @@
         "number" : null,
         "title" : "Rules requiring provision of information by parent undertakings",
         "ref" : "part-12A-crossheading-rules-requiring-provision-of-information-by-parent-undertakings",
+        "id" : "part-12A-crossheading-rules-requiring-provision-of-information-by-parent-undertakings",
+        "href" : "part/12A/crossheading/rules-requiring-provision-of-information-by-parent-undertakings",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "192J",
           "title" : "Rules requiring provision of information by parent undertakings",
           "ref" : "section-192J",
+          "id" : "section-192J",
+          "href" : "section/192J",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -15163,12 +16853,16 @@
         "number" : null,
         "title" : "Rules applying to parent undertakings of ring-fenced bodies",
         "ref" : "part-12A-crossheading-rules-applying-to-parent-undertakings-of-ringfenced-bodies",
+        "id" : "part-12A-crossheading-rules-applying-to-parent-undertakings-of-ringfenced-bodies",
+        "href" : "part/12A/crossheading/rules-applying-to-parent-undertakings-of-ringfenced-bodies",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "192JA",
           "title" : "Rules applying to parent undertakings of ring-fenced bodies",
           "ref" : "section-192JA",
+          "id" : "section-192JA",
+          "href" : "section/192JA",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -15176,12 +16870,16 @@
         "number" : null,
         "title" : "Rules requiring parent undertakings to facilitate resolution",
         "ref" : "part-12A-crossheading-rules-requiring-parent-undertakings-to-facilitate-resolution",
+        "id" : "part-12A-crossheading-rules-requiring-parent-undertakings-to-facilitate-resolution",
+        "href" : "part/12A/crossheading/rules-requiring-parent-undertakings-to-facilitate-resolution",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "192JB",
           "title" : "Rules requiring parent undertakings to facilitate resolution",
           "ref" : "section-192JB",
+          "id" : "section-192JB",
+          "href" : "section/192JB",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -15189,30 +16887,40 @@
         "number" : null,
         "title" : "Failure to comply with direction or breach of rules",
         "ref" : "part-12A-crossheading-failure-to-comply-with-direction-or-breach-of-rules",
+        "id" : "part-12A-crossheading-failure-to-comply-with-direction-or-breach-of-rules",
+        "href" : "part/12A/crossheading/failure-to-comply-with-direction-or-breach-of-rules",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "192K",
           "title" : "Power to impose penalty or issue censure",
           "ref" : "section-192K",
+          "id" : "section-192K",
+          "href" : "section/192K",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "192L",
           "title" : "Procedure and right to refer to Tribunal",
           "ref" : "section-192L",
+          "id" : "section-192L",
+          "href" : "section/192L",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "192M",
           "title" : "Duty on publication of statement",
           "ref" : "section-192M",
+          "id" : "section-192M",
+          "href" : "section/192M",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "192N",
           "title" : "Imposition of penalties under section 192K: statement of policy",
           "ref" : "section-192N",
+          "id" : "section-192N",
+          "href" : "section/192N",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -15221,18 +16929,24 @@
       "number" : "PART 12B",
       "title" : "Approval of certain holding companies",
       "ref" : "part-12B",
+      "id" : "part-12B",
+      "href" : "part/12B",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : "Interpretation",
         "ref" : "part-12B-crossheading-interpretation",
+        "id" : "part-12B-crossheading-interpretation",
+        "href" : "part/12B/crossheading/interpretation",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "192O",
           "title" : "Interpretation",
           "ref" : "section-192O",
+          "id" : "section-192O",
+          "href" : "section/192O",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -15240,60 +16954,80 @@
         "number" : null,
         "title" : "Approval ",
         "ref" : "part-12B-crossheading-approval",
+        "id" : "part-12B-crossheading-approval",
+        "href" : "part/12B/crossheading/approval",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "192P",
           "title" : "Requirement for approval",
           "ref" : "section-192P",
+          "id" : "section-192P",
+          "href" : "section/192P",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "192Q",
           "title" : "Application for approval or exemption",
           "ref" : "section-192Q",
+          "id" : "section-192Q",
+          "href" : "section/192Q",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "192R",
           "title" : "Grant of approval",
           "ref" : "section-192R",
+          "id" : "section-192R",
+          "href" : "section/192R",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "192S",
           "title" : "Regulator’s duty to monitor",
           "ref" : "section-192S",
+          "id" : "section-192S",
+          "href" : "section/192S",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "192T",
           "title" : "Measures",
           "ref" : "section-192T",
+          "id" : "section-192T",
+          "href" : "section/192T",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "192U",
           "title" : "Directions: procedure",
           "ref" : "section-192U",
+          "id" : "section-192U",
+          "href" : "section/192U",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "192V",
           "title" : "Rules imposing consolidated or sub-consolidated requirements",
           "ref" : "section-192V",
+          "id" : "section-192V",
+          "href" : "section/192V",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "192W",
           "title" : "Consultation between regulators",
           "ref" : "section-192W",
+          "id" : "section-192W",
+          "href" : "section/192W",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "192X",
           "title" : "References to Tribunal",
           "ref" : "section-192X",
+          "id" : "section-192X",
+          "href" : "section/192X",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -15301,24 +17035,32 @@
         "number" : null,
         "title" : "Rules",
         "ref" : "part-12B-crossheading-rules",
+        "id" : "part-12B-crossheading-rules",
+        "href" : "part/12B/crossheading/rules",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "192XA",
           "title" : "Rules applying to holding companies",
           "ref" : "section-192XA",
+          "id" : "section-192XA",
+          "href" : "section/192XA",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "192XB",
           "title" : "Procedural provision",
           "ref" : "section-192XB",
+          "id" : "section-192XB",
+          "href" : "section/192XB",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "192XC",
           "title" : "Disapplication or modification of rules in individual cases",
           "ref" : "section-192XC",
+          "id" : "section-192XC",
+          "href" : "section/192XC",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -15326,30 +17068,40 @@
         "number" : "192Y",
         "title" : "Power to impose penalty or issue censure",
         "ref" : "section-192Y",
+        "id" : "section-192Y",
+        "href" : "section/192Y",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "192Z",
         "title" : "Procedure and right to refer to Tribunal",
         "ref" : "section-192Z",
+        "id" : "section-192Z",
+        "href" : "section/192Z",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "192Z1",
         "title" : "Duty on publication of statement",
         "ref" : "section-192Z1",
+        "id" : "section-192Z1",
+        "href" : "section/192Z1",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "192Z2",
         "title" : "Directions and penalties: statement of policy",
         "ref" : "section-192Z2",
+        "id" : "section-192Z2",
+        "href" : "section/192Z2",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "192Z3",
         "title" : "Statement of policy relating to directions: procedure",
         "ref" : "section-192Z3",
+        "id" : "section-192Z3",
+        "href" : "section/192Z3",
         "extent" : [ "E", "W", "S", "NI" ]
       } ]
     }, {
@@ -15357,78 +17109,104 @@
       "number" : "Part XIII",
       "title" : " Incoming Firms: Intervention by  FCA or PRA ",
       "ref" : "part-XIII",
+      "id" : "part-XIII",
+      "href" : "part/XIII",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : " Interpretation",
         "ref" : "part-XIII-crossheading-interpretation",
+        "id" : "part-XIII-crossheading-interpretation",
+        "href" : "part/XIII/crossheading/interpretation",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "193",
           "title" : " Interpretation of this Part.",
           "ref" : "section-193",
+          "id" : "section-193",
+          "href" : "section/193",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "194",
           "title" : " General grounds on which power of intervention is exercisable.",
           "ref" : "section-194",
+          "id" : "section-194",
+          "href" : "section/194",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "194A",
           "title" : "\n\nContravention by relevant \nEEA\n firm with \nUK\n branch of requirement under markets in financial instruments directive:  appropriate regulator  primarily responsible for securing compliance\n",
           "ref" : "section-194A",
+          "id" : "section-194A",
+          "href" : "section/194A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "194B",
           "title" : "Contravention by relevant EEA firm of requirement in capital requirements directive or capital requirements regulation",
           "ref" : "section-194B",
+          "id" : "section-194B",
+          "href" : "section/194B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "194C",
           "title" : "Contravention by relevant EEA firm with UK branch of requirement in mortgages directive: appropriate regulator primarily responsible for securing compliance",
           "ref" : "section-194C",
+          "id" : "section-194C",
+          "href" : "section/194C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "194D",
           "title" : "Contravention by relevant EEA firm of requirement in insurance distribution directive: appropriate regulator primarily responsible for securing compliance",
           "ref" : "section-194D",
+          "id" : "section-194D",
+          "href" : "section/194D",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "195",
           "title" : " Exercise of power in support of overseas regulator.",
           "ref" : "section-195",
+          "id" : "section-195",
+          "href" : "section/195",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "195A",
           "title" : "Contravention by relevant EEA firm  , EEAUCITS or EEAAIFM  of directive requirements: home state regulator primarily responsible for securing compliance",
           "ref" : "section-195A",
+          "id" : "section-195A",
+          "href" : "section/195A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "195B",
           "title" : "Contravention by relevant EEA firm of requirement in mortgages directive: home state regulator primarily responsible for securing compliance",
           "ref" : "section-195B",
+          "id" : "section-195B",
+          "href" : "section/195B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "195C",
           "title" : "Contravention by relevant EEA firm of requirement in insurance distribution directive: home state regulator primarily responsible for securing compliance",
           "ref" : "section-195C",
+          "id" : "section-195C",
+          "href" : "section/195C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "196",
           "title" : " The power of intervention.",
           "ref" : "section-196",
+          "id" : "section-196",
+          "href" : "section/196",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -15436,30 +17214,40 @@
         "number" : null,
         "title" : " Exercise of power of intervention",
         "ref" : "part-XIII-crossheading-exercise-of-power-of-intervention",
+        "id" : "part-XIII-crossheading-exercise-of-power-of-intervention",
+        "href" : "part/XIII/crossheading/exercise-of-power-of-intervention",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "197",
           "title" : " Procedure on exercise of power of intervention.",
           "ref" : "section-197",
+          "id" : "section-197",
+          "href" : "section/197",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "198",
           "title" : " Power to apply to court for injunction in respect of certain overseas insurance companies.",
           "ref" : "section-198",
+          "id" : "section-198",
+          "href" : "section/198",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "199",
           "title" : " Additional procedure for EEA firms in certain cases.",
           "ref" : "section-199",
+          "id" : "section-199",
+          "href" : "section/199",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "199A",
           "title" : "Management companies: loss of authorisation",
           "ref" : "section-199A",
+          "id" : "section-199A",
+          "href" : "section/199A",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -15467,24 +17255,32 @@
         "number" : null,
         "title" : " Supplemental",
         "ref" : "part-XIII-crossheading-supplemental",
+        "id" : "part-XIII-crossheading-supplemental",
+        "href" : "part/XIII/crossheading/supplemental",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "200",
           "title" : " Rescission and variation of requirements.",
           "ref" : "section-200",
+          "id" : "section-200",
+          "href" : "section/200",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "201",
           "title" : "Effect of certain requirements on other persons",
           "ref" : "section-201",
+          "id" : "section-201",
+          "href" : "section/201",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "202",
           "title" : " Contravention of requirement imposed under this Part.",
           "ref" : "section-202",
+          "id" : "section-202",
+          "href" : "section/202",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -15492,18 +17288,24 @@
         "number" : null,
         "title" : " Powers of   Office of Fair Trading\n            ",
         "ref" : "part-XIII-crossheading-powers-of-director-general-of-fair-trading",
+        "id" : "part-XIII-crossheading-powers-of-director-general-of-fair-trading",
+        "href" : "part/XIII/crossheading/powers-of-director-general-of-fair-trading",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "203",
           "title" : " Power to prohibit the carrying on of Consumer Credit Act business.",
           "ref" : "section-203",
+          "id" : "section-203",
+          "href" : "section/203",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "204",
           "title" : " Power to restrict the carrying on of Consumer Credit Act business.",
           "ref" : "section-204",
+          "id" : "section-204",
+          "href" : "section/204",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -15512,30 +17314,40 @@
       "number" : "PART 13A",
       "title" : "Enhanced supervision of firms exercising rights under the Insurance Distribution Directive",
       "ref" : "part-13A",
+      "id" : "part-13A",
+      "href" : "part/13A",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "203A",
         "title" : "Insurance distribution directive: enhanced supervision of EEA firms by UK regulators",
         "ref" : "section-203A",
+        "id" : "section-203A",
+        "href" : "section/203A",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "203B",
         "title" : "Insurance distribution directive: enhanced supervision of UK firms by an EEA regulator",
         "ref" : "section-203B",
+        "id" : "section-203B",
+        "href" : "section/203B",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "203C",
         "title" : "Modification or waiver of rules where firm subject to enhanced supervision",
         "ref" : "section-203C",
+        "id" : "section-203C",
+        "href" : "section/203C",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "203D",
         "title" : "Publication of directions under section 203C",
         "ref" : "section-203D",
+        "id" : "section-203D",
+        "href" : "section/203D",
         "extent" : [ "E", "W", "S", "NI" ]
       } ]
     }, {
@@ -15543,60 +17355,80 @@
       "number" : "Part XIV",
       "title" : " Disciplinary Measures",
       "ref" : "part-XIV",
+      "id" : "part-XIV",
+      "href" : "part/XIV",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "204A",
         "title" : "Meaning of “relevant requirement” and “appropriate regulator”",
         "ref" : "section-204A",
+        "id" : "section-204A",
+        "href" : "section/204A",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "205",
         "title" : " Public censure.",
         "ref" : "section-205",
+        "id" : "section-205",
+        "href" : "section/205",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "206",
         "title" : " Financial penalties.",
         "ref" : "section-206",
+        "id" : "section-206",
+        "href" : "section/206",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "206A",
         "title" : "\n\nSuspending permission to carry on regulated activities \netc\n",
         "ref" : "section-206A",
+        "id" : "section-206A",
+        "href" : "section/206A",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "207",
         "title" : " Proposal to take disciplinary measures.",
         "ref" : "section-207",
+        "id" : "section-207",
+        "href" : "section/207",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "208",
         "title" : " Decision notice.",
         "ref" : "section-208",
+        "id" : "section-208",
+        "href" : "section/208",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "209",
         "title" : " Publication.",
         "ref" : "section-209",
+        "id" : "section-209",
+        "href" : "section/209",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "210",
         "title" : " Statements of policy.",
         "ref" : "section-210",
+        "id" : "section-210",
+        "href" : "section/210",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "211",
         "title" : " Statements of policy: procedure.",
         "ref" : "section-211",
+        "id" : "section-211",
+        "href" : "section/211",
         "extent" : [ "E", "W", "S", "NI" ]
       } ]
     }, {
@@ -15604,18 +17436,24 @@
       "number" : "Part XV",
       "title" : " The Financial Services Compensation Scheme",
       "ref" : "part-XV",
+      "id" : "part-XV",
+      "href" : "part/XV",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : " The scheme manager",
         "ref" : "part-XV-crossheading-the-scheme-manager",
+        "id" : "part-XV-crossheading-the-scheme-manager",
+        "href" : "part/XV/crossheading/the-scheme-manager",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "212",
           "title" : "The scheme manager.",
           "ref" : "section-212",
+          "id" : "section-212",
+          "href" : "section/212",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -15623,12 +17461,16 @@
         "number" : null,
         "title" : " The scheme",
         "ref" : "part-XV-crossheading-the-scheme",
+        "id" : "part-XV-crossheading-the-scheme",
+        "href" : "part/XV/crossheading/the-scheme",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "213",
           "title" : "The compensation scheme.",
           "ref" : "section-213",
+          "id" : "section-213",
+          "href" : "section/213",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -15636,78 +17478,104 @@
         "number" : null,
         "title" : "Provisions of the scheme",
         "ref" : "part-XV-crossheading-provisions-of-the-scheme",
+        "id" : "part-XV-crossheading-provisions-of-the-scheme",
+        "href" : "part/XV/crossheading/provisions-of-the-scheme",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "214",
           "title" : "General.",
           "ref" : "section-214",
+          "id" : "section-214",
+          "href" : "section/214",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "214A",
           "title" : "Contingency funding",
           "ref" : "section-214A",
+          "id" : "section-214A",
+          "href" : "section/214A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "214B",
           "title" : "Contribution to costs of special resolution regime",
           "ref" : "section-214B",
+          "id" : "section-214B",
+          "href" : "section/214B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "214C",
           "title" : "Limit on amount of special resolution regime payments",
           "ref" : "section-214C",
+          "id" : "section-214C",
+          "href" : "section/214C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "214D",
           "title" : "Contributions under section 214B: supplementary",
           "ref" : "section-214D",
+          "id" : "section-214D",
+          "href" : "section/214D",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "215",
           "title" : "Rights of the scheme in insolvency",
           "ref" : "section-215",
+          "id" : "section-215",
+          "href" : "section/215",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "215A",
           "title" : "Continuity etc. of funeral plan contracts",
           "ref" : "section-215A",
+          "id" : "section-215A",
+          "href" : "section/215A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "215B",
           "title" : "Scheme manager’s power to require assistance from liquidator etc. in relation to funeral plan contracts",
           "ref" : "section-215B",
+          "id" : "section-215B",
+          "href" : "section/215B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "216",
           "title" : "Continuity of long-term insurance policies.",
           "ref" : "section-216",
+          "id" : "section-216",
+          "href" : "section/216",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "217",
           "title" : "Insurers in financial difficulties.",
           "ref" : "section-217",
+          "id" : "section-217",
+          "href" : "section/217",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "217ZA",
           "title" : "Insurers subject to write-down orders",
           "ref" : "section-217ZA",
+          "id" : "section-217ZA",
+          "href" : "section/217ZA",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "217ZB",
           "title" : "Recovery of financial assistance under section 217ZA",
           "ref" : "section-217ZB",
+          "id" : "section-217ZB",
+          "href" : "section/217ZB",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -15715,12 +17583,16 @@
         "number" : null,
         "title" : "Relationship with the regulators",
         "ref" : "part-XV-crossheading-relationship-with-the-regulators",
+        "id" : "part-XV-crossheading-relationship-with-the-regulators",
+        "href" : "part/XV/crossheading/relationship-with-the-regulators",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "217A",
           "title" : "Co-operation",
           "ref" : "section-217A",
+          "id" : "section-217A",
+          "href" : "section/217A",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -15728,24 +17600,32 @@
         "number" : null,
         "title" : " Annual plan and report",
         "ref" : "part-XV-crossheading-annual-report",
+        "id" : "part-XV-crossheading-annual-report",
+        "href" : "part/XV/crossheading/annual-report",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "217B",
           "title" : "Annual plan",
           "ref" : "section-217B",
+          "id" : "section-217B",
+          "href" : "section/217B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "218",
           "title" : " Annual report.",
           "ref" : "section-218",
+          "id" : "section-218",
+          "href" : "section/218",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "218ZA",
           "title" : "Audit of accounts",
           "ref" : "section-218ZA",
+          "id" : "section-218ZA",
+          "href" : "section/218ZA",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -15753,42 +17633,56 @@
         "number" : null,
         "title" : "Information and documents",
         "ref" : "part-XV-crossheading-information-and-documents",
+        "id" : "part-XV-crossheading-information-and-documents",
+        "href" : "part/XV/crossheading/information-and-documents",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "218A",
           "title" : "Regulators' power to require information",
           "ref" : "section-218A",
+          "id" : "section-218A",
+          "href" : "section/218A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "218B",
           "title" : "Treasury's power to require information from scheme manager",
           "ref" : "section-218B",
+          "id" : "section-218B",
+          "href" : "section/218B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "219",
           "title" : "Scheme manager’s power to require information.",
           "ref" : "section-219",
+          "id" : "section-219",
+          "href" : "section/219",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "220",
           "title" : "Scheme manager’s power to inspect information held by liquidator etc.",
           "ref" : "section-220",
+          "id" : "section-220",
+          "href" : "section/220",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "220A",
           "title" : "Power to inspect information held by write-down manager",
           "ref" : "section-220A",
+          "id" : "section-220A",
+          "href" : "section/220A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "221",
           "title" : "Powers of court where information required.",
           "ref" : "section-221",
+          "id" : "section-221",
+          "href" : "section/221",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -15796,60 +17690,80 @@
         "number" : null,
         "title" : " Miscellaneous",
         "ref" : "part-XV-crossheading-miscellaneous",
+        "id" : "part-XV-crossheading-miscellaneous",
+        "href" : "part/XV/crossheading/miscellaneous",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "221A",
           "title" : "Delegation of functions",
           "ref" : "section-221A",
+          "id" : "section-221A",
+          "href" : "section/221A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "222",
           "title" : " Statutory immunity.",
           "ref" : "section-222",
+          "id" : "section-222",
+          "href" : "section/222",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "223",
           "title" : " Management expenses.",
           "ref" : "section-223",
+          "id" : "section-223",
+          "href" : "section/223",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "223A",
           "title" : "Investing in National Loans Fund",
           "ref" : "section-223A",
+          "id" : "section-223A",
+          "href" : "section/223A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "223B",
           "title" : "Borrowing from National Loans Fund",
           "ref" : "section-223B",
+          "id" : "section-223B",
+          "href" : "section/223B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "223C",
           "title" : "Payments in error",
           "ref" : "section-223C",
+          "id" : "section-223C",
+          "href" : "section/223C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "224",
           "title" : "Scheme manager’s power to inspect documents held by Official Receiver etc.",
           "ref" : "section-224",
+          "id" : "section-224",
+          "href" : "section/224",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "224ZA",
           "title" : "Discharge of functions",
           "ref" : "section-224ZA",
+          "id" : "section-224ZA",
+          "href" : "section/224ZA",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "224A",
           "title" : "Functions under the Banking Act 2009",
           "ref" : "section-224A",
+          "id" : "section-224A",
+          "href" : "section/224A",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -15858,18 +17772,24 @@
       "number" : "Part 15A",
       "title" : "Power to require FSCS manager to act in relation to other schemes",
       "ref" : "part-15A",
+      "id" : "part-15A",
+      "href" : "part/15A",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : "Introduction",
         "ref" : "part-15A-crossheading-introduction",
+        "id" : "part-15A-crossheading-introduction",
+        "href" : "part/15A/crossheading/introduction",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "224B",
           "title" : "Meaning of  “relevant scheme” etc",
           "ref" : "section-224B",
+          "id" : "section-224B",
+          "href" : "section/224B",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -15877,24 +17797,32 @@
         "number" : null,
         "title" : "Power to require FSCS manager to act",
         "ref" : "part-15A-crossheading-power-to-require-fscs-manager-to-act",
+        "id" : "part-15A-crossheading-power-to-require-fscs-manager-to-act",
+        "href" : "part/15A/crossheading/power-to-require-fscs-manager-to-act",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "224C",
           "title" : "Power to require FSCS manager to act on behalf of manager of relevant scheme",
           "ref" : "section-224C",
+          "id" : "section-224C",
+          "href" : "section/224C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "224D",
           "title" : "Cases where FSCS manager may decline to act",
           "ref" : "section-224D",
+          "id" : "section-224D",
+          "href" : "section/224D",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "224E",
           "title" : "Grounds for declining to act",
           "ref" : "section-224E",
+          "id" : "section-224E",
+          "href" : "section/224E",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -15902,12 +17830,16 @@
         "number" : null,
         "title" : "Rules",
         "ref" : "part-15A-crossheading-rules",
+        "id" : "part-15A-crossheading-rules",
+        "href" : "part/15A/crossheading/rules",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "224F",
           "title" : "Rules about relevant schemes",
           "ref" : "section-224F",
+          "id" : "section-224F",
+          "href" : "section/224F",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -15916,36 +17848,48 @@
       "number" : "Part XVI",
       "title" : " The Ombudsman Scheme",
       "ref" : "part-XVI",
+      "id" : "part-XVI",
+      "href" : "part/XVI",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : " The scheme",
         "ref" : "part-XVI-crossheading-the-scheme",
+        "id" : "part-XVI-crossheading-the-scheme",
+        "href" : "part/XVI/crossheading/the-scheme",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "225",
           "title" : " The scheme and the scheme operator.",
           "ref" : "section-225",
+          "id" : "section-225",
+          "href" : "section/225",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "226",
           "title" : " Compulsory jurisdiction.",
           "ref" : "section-226",
+          "id" : "section-226",
+          "href" : "section/226",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "226A",
           "title" : "Consumer credit jurisdiction",
           "ref" : "section-226A",
+          "id" : "section-226A",
+          "href" : "section/226A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "227",
           "title" : " Voluntary jurisdiction.",
           "ref" : "section-227",
+          "id" : "section-227",
+          "href" : "section/227",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -15953,30 +17897,40 @@
         "number" : null,
         "title" : " Determination of complaints",
         "ref" : "part-XVI-crossheading-determination-of-complaints",
+        "id" : "part-XVI-crossheading-determination-of-complaints",
+        "href" : "part/XVI/crossheading/determination-of-complaints",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "228",
           "title" : " Determination under the compulsory jurisdiction.",
           "ref" : "section-228",
+          "id" : "section-228",
+          "href" : "section/228",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "229",
           "title" : " Awards.",
           "ref" : "section-229",
+          "id" : "section-229",
+          "href" : "section/229",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "230",
           "title" : " Costs.",
           "ref" : "section-230",
+          "id" : "section-230",
+          "href" : "section/230",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "230A",
           "title" : "Reports of determinations",
           "ref" : "section-230A",
+          "id" : "section-230A",
+          "href" : "section/230A",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -15984,30 +17938,40 @@
         "number" : null,
         "title" : " Information",
         "ref" : "part-XVI-crossheading-information",
+        "id" : "part-XVI-crossheading-information",
+        "href" : "part/XVI/crossheading/information",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "231",
           "title" : " Ombudsman’s power to require information.",
           "ref" : "section-231",
+          "id" : "section-231",
+          "href" : "section/231",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "232",
           "title" : " Powers of court where information required.",
           "ref" : "section-232",
+          "id" : "section-232",
+          "href" : "section/232",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "232A",
           "title" : "Scheme operator's duty to provide information to FCA",
           "ref" : "section-232A",
+          "id" : "section-232A",
+          "href" : "section/232A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "233",
           "title" : " Data protection.",
           "ref" : "section-233",
+          "id" : "section-233",
+          "href" : "section/233",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -16015,18 +17979,24 @@
         "number" : null,
         "title" : " Funding",
         "ref" : "part-XVI-crossheading-funding",
+        "id" : "part-XVI-crossheading-funding",
+        "href" : "part/XVI/crossheading/funding",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "234",
           "title" : " Industry funding.",
           "ref" : "section-234",
+          "id" : "section-234",
+          "href" : "section/234",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "234A",
           "title" : "Funding by consumer credit licensees etc.",
           "ref" : "section-234A",
+          "id" : "section-234A",
+          "href" : "section/234A",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -16034,12 +18004,16 @@
         "number" : null,
         "title" : "Successors to businesses",
         "ref" : "part-XVI-crossheading-successors-to-businesses",
+        "id" : "part-XVI-crossheading-successors-to-businesses",
+        "href" : "part/XVI/crossheading/successors-to-businesses",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "234B",
           "title" : "Transfers of liability",
           "ref" : "section-234B",
+          "id" : "section-234B",
+          "href" : "section/234B",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -16048,42 +18022,56 @@
       "number" : "PART 16A",
       "title" : "Consumer protection and competition",
       "ref" : "part-16A",
+      "id" : "part-16A",
+      "href" : "part/16A",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : "Super-complaints and references to FCA",
         "ref" : "part-16A-crossheading-supercomplaints-and-references-to-fca",
+        "id" : "part-16A-crossheading-supercomplaints-and-references-to-fca",
+        "href" : "part/16A/crossheading/supercomplaints-and-references-to-fca",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "234C",
           "title" : "Complaints by consumer bodies",
           "ref" : "section-234C",
+          "id" : "section-234C",
+          "href" : "section/234C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "234D",
           "title" : "Reference by scheme operator or regulated person",
           "ref" : "section-234D",
+          "id" : "section-234D",
+          "href" : "section/234D",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "234E",
           "title" : "Response by FCA",
           "ref" : "section-234E",
+          "id" : "section-234E",
+          "href" : "section/234E",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "234F",
           "title" : "Section 234E: exceptions",
           "ref" : "section-234F",
+          "id" : "section-234F",
+          "href" : "section/234F",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "234G",
           "title" : "Guidance",
           "ref" : "section-234G",
+          "id" : "section-234G",
+          "href" : "section/234G",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -16091,54 +18079,72 @@
         "number" : null,
         "title" : "Competition",
         "ref" : "part-16A-crossheading-competition",
+        "id" : "part-16A-crossheading-competition",
+        "href" : "part/16A/crossheading/competition",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "234H",
           "title" : "Power of FCA to make request to  Competition and Markets Authority ",
           "ref" : "section-234H",
+          "id" : "section-234H",
+          "href" : "section/234H",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "234I",
           "title" : "The FCA's functions under Part 4 of the Enterprise Act 2002",
           "ref" : "section-234I",
+          "id" : "section-234I",
+          "href" : "section/234I",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "234J",
           "title" : "The FCA's functions under the Competition Act 1998",
           "ref" : "section-234J",
+          "id" : "section-234J",
+          "href" : "section/234J",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "234K",
           "title" : "Duty to consider exercise of powers under Competition Act 1998",
           "ref" : "section-234K",
+          "id" : "section-234K",
+          "href" : "section/234K",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "234L",
           "title" : "Provision of information and assistance to a CMA group",
           "ref" : "section-234L",
+          "id" : "section-234L",
+          "href" : "section/234L",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "234M",
           "title" : "Function of keeping market under review",
           "ref" : "section-234M",
+          "id" : "section-234M",
+          "href" : "section/234M",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "234N",
           "title" : "Exclusion of general duties",
           "ref" : "section-234N",
+          "id" : "section-234N",
+          "href" : "section/234N",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "234O",
           "title" : "Supplementary provision",
           "ref" : "section-234O",
+          "id" : "section-234O",
+          "href" : "section/234O",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -16147,42 +18153,56 @@
       "number" : "Part XVII",
       "title" : "Collective Investment Schemes",
       "ref" : "part-XVII",
+      "id" : "part-XVII",
+      "href" : "part/XVII",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "chapter",
         "number" : "Chapter I",
         "title" : " Interpretation",
         "ref" : "part-XVII-chapter-I",
+        "id" : "part-XVII-chapter-I",
+        "href" : "part/XVII/chapter/I",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "235",
           "title" : " Collective investment schemes.",
           "ref" : "section-235",
+          "id" : "section-235",
+          "href" : "section/235",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "235A",
           "title" : "Contractual schemes",
           "ref" : "section-235A",
+          "id" : "section-235A",
+          "href" : "section/235A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "236",
           "title" : " Open-ended investment companies.",
           "ref" : "section-236",
+          "id" : "section-236",
+          "href" : "section/236",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "236A",
           "title" : "Meaning of  “UCITS”",
           "ref" : "section-236A",
+          "id" : "section-236A",
+          "href" : "section/236A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "237",
           "title" : " Other definitions.",
           "ref" : "section-237",
+          "id" : "section-237",
+          "href" : "section/237",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -16190,30 +18210,40 @@
         "number" : "Chapter II",
         "title" : " Restrictions on Promotion",
         "ref" : "part-XVII-chapter-II",
+        "id" : "part-XVII-chapter-II",
+        "href" : "part/XVII/chapter/II",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "238",
           "title" : " Restrictions on promotion.",
           "ref" : "section-238",
+          "id" : "section-238",
+          "href" : "section/238",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "239",
           "title" : " Single property schemes.",
           "ref" : "section-239",
+          "id" : "section-239",
+          "href" : "section/239",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "240",
           "title" : " Restriction on approval of promotion.",
           "ref" : "section-240",
+          "id" : "section-240",
+          "href" : "section/240",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "241",
           "title" : " Actions for damages.",
           "ref" : "section-241",
+          "id" : "section-241",
+          "href" : "section/241",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -16221,12 +18251,16 @@
         "number" : "CHAPTER 2A",
         "title" : "PROHIBITION ON ISSUE OF BEARER UNITS",
         "ref" : "part-XVII-chapter-2A",
+        "id" : "part-XVII-chapter-2A",
+        "href" : "part/XVII/chapter/2A",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "241A",
           "title" : "Bearer units no longer to be issued",
           "ref" : "section-241A",
+          "id" : "section-241A",
+          "href" : "section/241A",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -16234,36 +18268,48 @@
         "number" : "Chapter III",
         "title" : " Authorised Unit Trust Schemes",
         "ref" : "part-XVII-chapter-III",
+        "id" : "part-XVII-chapter-III",
+        "href" : "part/XVII/chapter/III",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : " Applications for authorisation",
           "ref" : "part-XVII-chapter-III-crossheading-applications-for-authorisation",
+          "id" : "part-XVII-chapter-III-crossheading-applications-for-authorisation",
+          "href" : "part/XVII/chapter/III/crossheading/applications-for-authorisation",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "242",
             "title" : " Applications for authorisation of unit trust schemes.",
             "ref" : "section-242",
+            "id" : "section-242",
+            "href" : "section/242",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "243",
             "title" : " Authorisation orders : authorised unit trust schemes.",
             "ref" : "section-243",
+            "id" : "section-243",
+            "href" : "section/243",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "243A",
             "title" : "Authorisation orders: authorised money market funds",
             "ref" : "section-243A",
+            "id" : "section-243A",
+            "href" : "section/243A",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "244",
             "title" : " Determination of applications.",
             "ref" : "section-244",
+            "id" : "section-244",
+            "href" : "section/244",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -16271,12 +18317,16 @@
           "number" : null,
           "title" : " Applications refused",
           "ref" : "part-XVII-chapter-III-crossheading-applications-refused",
+          "id" : "part-XVII-chapter-III-crossheading-applications-refused",
+          "href" : "part/XVII/chapter/III/crossheading/applications-refused",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "245",
             "title" : " Procedure when refusing an application.",
             "ref" : "section-245",
+            "id" : "section-245",
+            "href" : "section/245",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -16284,12 +18334,16 @@
           "number" : null,
           "title" : " Certificates",
           "ref" : "part-XVII-chapter-III-crossheading-certificates",
+          "id" : "part-XVII-chapter-III-crossheading-certificates",
+          "href" : "part/XVII/chapter/III/crossheading/certificates",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "246",
             "title" : " Certificates.",
             "ref" : "section-246",
+            "id" : "section-246",
+            "href" : "section/246",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -16297,30 +18351,40 @@
           "number" : null,
           "title" : " Rules",
           "ref" : "part-XVII-chapter-III-crossheading-rules",
+          "id" : "part-XVII-chapter-III-crossheading-rules",
+          "href" : "part/XVII/chapter/III/crossheading/rules",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "247",
             "title" : " Trust scheme rules.",
             "ref" : "section-247",
+            "id" : "section-247",
+            "href" : "section/247",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "248",
             "title" : " Scheme particulars rules.",
             "ref" : "section-248",
+            "id" : "section-248",
+            "href" : "section/248",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "249",
             "title" : " Disciplinary measures",
             "ref" : "section-249",
+            "id" : "section-249",
+            "href" : "section/249",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "250",
             "title" : " Modification or waiver of rules.",
             "ref" : "section-250",
+            "id" : "section-250",
+            "href" : "section/250",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -16328,24 +18392,32 @@
           "number" : null,
           "title" : " Alterations",
           "ref" : "part-XVII-chapter-III-crossheading-alterations",
+          "id" : "part-XVII-chapter-III-crossheading-alterations",
+          "href" : "part/XVII/chapter/III/crossheading/alterations",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "251",
             "title" : " Alteration of schemes and changes of manager or trustee.",
             "ref" : "section-251",
+            "id" : "section-251",
+            "href" : "section/251",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "252",
             "title" : " Procedure when refusing approval  of a proposal under section 251.",
             "ref" : "section-252",
+            "id" : "section-252",
+            "href" : "section/252",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "252A",
             "title" : "Proposal to convert to a non-feeder UCITS",
             "ref" : "section-252A",
+            "id" : "section-252A",
+            "href" : "section/252A",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -16353,12 +18425,16 @@
           "number" : null,
           "title" : " Exclusion clauses",
           "ref" : "part-XVII-chapter-III-crossheading-exclusion-clauses",
+          "id" : "part-XVII-chapter-III-crossheading-exclusion-clauses",
+          "href" : "part/XVII/chapter/III/crossheading/exclusion-clauses",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "253",
             "title" : " Avoidance of exclusion clauses.",
             "ref" : "section-253",
+            "id" : "section-253",
+            "href" : "section/253",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -16366,24 +18442,32 @@
           "number" : null,
           "title" : " Ending of authorisation",
           "ref" : "part-XVII-chapter-III-crossheading-ending-of-authorisation",
+          "id" : "part-XVII-chapter-III-crossheading-ending-of-authorisation",
+          "href" : "part/XVII/chapter/III/crossheading/ending-of-authorisation",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "254",
             "title" : " Revocation of authorisation order otherwise than by consent.",
             "ref" : "section-254",
+            "id" : "section-254",
+            "href" : "section/254",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "255",
             "title" : " Procedure.",
             "ref" : "section-255",
+            "id" : "section-255",
+            "href" : "section/255",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "256",
             "title" : " Requests for revocation of authorisation order.",
             "ref" : "section-256",
+            "id" : "section-256",
+            "href" : "section/256",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -16391,54 +18475,72 @@
           "number" : null,
           "title" : " Powers of intervention",
           "ref" : "part-XVII-chapter-III-crossheading-powers-of-intervention",
+          "id" : "part-XVII-chapter-III-crossheading-powers-of-intervention",
+          "href" : "part/XVII/chapter/III/crossheading/powers-of-intervention",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "257",
             "title" : "Directions.",
             "ref" : "section-257",
+            "id" : "section-257",
+            "href" : "section/257",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "258",
             "title" : " Applications to the court.",
             "ref" : "section-258",
+            "id" : "section-258",
+            "href" : "section/258",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "258A",
             "title" : "Winding up or merger of master UCITS",
             "ref" : "section-258A",
+            "id" : "section-258A",
+            "href" : "section/258A",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "259",
             "title" : " Procedure on giving directions under section 257  or 258A and varying them on  FCA's  own initiative.",
             "ref" : "section-259",
+            "id" : "section-259",
+            "href" : "section/259",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "260",
             "title" : " Procedure: refusal to revoke or vary direction.",
             "ref" : "section-260",
+            "id" : "section-260",
+            "href" : "section/260",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "261",
             "title" : " Procedure: revocation of direction and grant of request for variation.",
             "ref" : "section-261",
+            "id" : "section-261",
+            "href" : "section/261",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "261A",
             "title" : "Information for home state regulator",
             "ref" : "section-261A",
+            "id" : "section-261A",
+            "href" : "section/261A",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "261B",
             "title" : "Information for feeder UCITS",
             "ref" : "section-261B",
+            "id" : "section-261B",
+            "href" : "section/261B",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -16447,42 +18549,56 @@
         "number" : "CHAPTER 3A",
         "title" : "AUTHORISED CONTRACTUAL SCHEMES",
         "ref" : "part-XVII-chapter-3A",
+        "id" : "part-XVII-chapter-3A",
+        "href" : "part/XVII/chapter/3A",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Applications for authorisation",
           "ref" : "part-XVII-chapter-3A-crossheading-applications-for-authorisation",
+          "id" : "part-XVII-chapter-3A-crossheading-applications-for-authorisation",
+          "href" : "part/XVII/chapter/3A/crossheading/applications-for-authorisation",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "261C",
             "title" : "Applications for authorisation of contractual schemes",
             "ref" : "section-261C",
+            "id" : "section-261C",
+            "href" : "section/261C",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "261D",
             "title" : "Authorisation orders : authorised contractual schemes ",
             "ref" : "section-261D",
+            "id" : "section-261D",
+            "href" : "section/261D",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "261E",
             "title" : "Authorised contractual schemes: holding of units",
             "ref" : "section-261E",
+            "id" : "section-261E",
+            "href" : "section/261E",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "261EA",
             "title" : "Authorisation orders: authorised money market funds",
             "ref" : "section-261EA",
+            "id" : "section-261EA",
+            "href" : "section/261EA",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "261F",
             "title" : "Determination of applications",
             "ref" : "section-261F",
+            "id" : "section-261F",
+            "href" : "section/261F",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -16490,12 +18606,16 @@
           "number" : null,
           "title" : "Applications refused",
           "ref" : "part-XVII-chapter-3A-crossheading-applications-refused",
+          "id" : "part-XVII-chapter-3A-crossheading-applications-refused",
+          "href" : "part/XVII/chapter/3A/crossheading/applications-refused",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "261G",
             "title" : "Procedure when refusing an application",
             "ref" : "section-261G",
+            "id" : "section-261G",
+            "href" : "section/261G",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -16503,12 +18623,16 @@
           "number" : null,
           "title" : "Certificates",
           "ref" : "part-XVII-chapter-3A-crossheading-certificates",
+          "id" : "part-XVII-chapter-3A-crossheading-certificates",
+          "href" : "part/XVII/chapter/3A/crossheading/certificates",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "261H",
             "title" : "Certificates",
             "ref" : "section-261H",
+            "id" : "section-261H",
+            "href" : "section/261H",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -16516,30 +18640,40 @@
           "number" : null,
           "title" : "Rules",
           "ref" : "part-XVII-chapter-3A-crossheading-rules",
+          "id" : "part-XVII-chapter-3A-crossheading-rules",
+          "href" : "part/XVII/chapter/3A/crossheading/rules",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "261I",
             "title" : "Contractual scheme rules",
             "ref" : "section-261I",
+            "id" : "section-261I",
+            "href" : "section/261I",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "261J",
             "title" : "Contractual scheme particulars rules",
             "ref" : "section-261J",
+            "id" : "section-261J",
+            "href" : "section/261J",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "261K",
             "title" : "Disciplinary measures",
             "ref" : "section-261K",
+            "id" : "section-261K",
+            "href" : "section/261K",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "261L",
             "title" : "Modification or waiver of rules",
             "ref" : "section-261L",
+            "id" : "section-261L",
+            "href" : "section/261L",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -16547,30 +18681,40 @@
           "number" : null,
           "title" : "Co-ownership schemes: rights and liabilities of participants",
           "ref" : "part-XVII-chapter-3A-crossheading-coownership-schemes-rights-and-liabilities-of-participants",
+          "id" : "part-XVII-chapter-3A-crossheading-coownership-schemes-rights-and-liabilities-of-participants",
+          "href" : "part/XVII/chapter/3A/crossheading/coownership-schemes-rights-and-liabilities-of-participants",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "261M",
             "title" : "Contracts",
             "ref" : "section-261M",
+            "id" : "section-261M",
+            "href" : "section/261M",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "261N",
             "title" : "Effect of becoming or ceasing to be a participant",
             "ref" : "section-261N",
+            "id" : "section-261N",
+            "href" : "section/261N",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "261O",
             "title" : "Limited liability",
             "ref" : "section-261O",
+            "id" : "section-261O",
+            "href" : "section/261O",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "261P",
             "title" : "Segregated liability in relation to umbrella co-ownership schemes",
             "ref" : "section-261P",
+            "id" : "section-261P",
+            "href" : "section/261P",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -16578,24 +18722,32 @@
           "number" : null,
           "title" : "Alterations",
           "ref" : "part-XVII-chapter-3A-crossheading-alterations",
+          "id" : "part-XVII-chapter-3A-crossheading-alterations",
+          "href" : "part/XVII/chapter/3A/crossheading/alterations",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "261Q",
             "title" : "Alteration of contractual schemes and changes of operator or depositary",
             "ref" : "section-261Q",
+            "id" : "section-261Q",
+            "href" : "section/261Q",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "261R",
             "title" : "Procedure when refusing approval of a proposal under section 261Q",
             "ref" : "section-261R",
+            "id" : "section-261R",
+            "href" : "section/261R",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "261S",
             "title" : "Proposal to convert to a non-feeder UCITS",
             "ref" : "section-261S",
+            "id" : "section-261S",
+            "href" : "section/261S",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -16603,12 +18755,16 @@
           "number" : null,
           "title" : "Exclusion clauses",
           "ref" : "part-XVII-chapter-3A-crossheading-exclusion-clauses",
+          "id" : "part-XVII-chapter-3A-crossheading-exclusion-clauses",
+          "href" : "part/XVII/chapter/3A/crossheading/exclusion-clauses",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "261T",
             "title" : "Avoidance of exclusion clauses",
             "ref" : "section-261T",
+            "id" : "section-261T",
+            "href" : "section/261T",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -16616,24 +18772,32 @@
           "number" : null,
           "title" : "Ending of authorisation",
           "ref" : "part-XVII-chapter-3A-crossheading-ending-of-authorisation",
+          "id" : "part-XVII-chapter-3A-crossheading-ending-of-authorisation",
+          "href" : "part/XVII/chapter/3A/crossheading/ending-of-authorisation",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "261U",
             "title" : "Revocation of authorisation order otherwise than by consent",
             "ref" : "section-261U",
+            "id" : "section-261U",
+            "href" : "section/261U",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "261V",
             "title" : "Procedure for revoking authorisation order",
             "ref" : "section-261V",
+            "id" : "section-261V",
+            "href" : "section/261V",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "261W",
             "title" : "Requests for revocation of authorisation order",
             "ref" : "section-261W",
+            "id" : "section-261W",
+            "href" : "section/261W",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -16641,54 +18805,72 @@
           "number" : null,
           "title" : "Powers of intervention",
           "ref" : "part-XVII-chapter-3A-crossheading-powers-of-intervention",
+          "id" : "part-XVII-chapter-3A-crossheading-powers-of-intervention",
+          "href" : "part/XVII/chapter/3A/crossheading/powers-of-intervention",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "261X",
             "title" : "Directions",
             "ref" : "section-261X",
+            "id" : "section-261X",
+            "href" : "section/261X",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "261Y",
             "title" : "Applications to the court",
             "ref" : "section-261Y",
+            "id" : "section-261Y",
+            "href" : "section/261Y",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "261Z",
             "title" : "Winding up or merger of master UCITS",
             "ref" : "section-261Z",
+            "id" : "section-261Z",
+            "href" : "section/261Z",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "261Z1",
             "title" : "Procedure on giving directions under section 261X or 261Z and varying them on FCA’s own initiative",
             "ref" : "section-261Z1",
+            "id" : "section-261Z1",
+            "href" : "section/261Z1",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "261Z2",
             "title" : "Procedure: refusal to revoke or vary direction",
             "ref" : "section-261Z2",
+            "id" : "section-261Z2",
+            "href" : "section/261Z2",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "261Z3",
             "title" : "Procedure: revocation of direction and grant of request for variation",
             "ref" : "section-261Z3",
+            "id" : "section-261Z3",
+            "href" : "section/261Z3",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "261Z4",
             "title" : "Information for home state regulator",
             "ref" : "section-261Z4",
+            "id" : "section-261Z4",
+            "href" : "section/261Z4",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "261Z5",
             "title" : "Information for feeder UCITS",
             "ref" : "section-261Z5",
+            "id" : "section-261Z5",
+            "href" : "section/261Z5",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -16697,12 +18879,16 @@
         "number" : "CHAPTER 3B",
         "title" : "Unauthorised co-ownership AIFs",
         "ref" : "part-XVII-chapter-3B",
+        "id" : "part-XVII-chapter-3B",
+        "href" : "part/XVII/chapter/3B",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "261Z6",
           "title" : "Power to make provision about unauthorised co-ownership AIFs",
           "ref" : "section-261Z6",
+          "id" : "section-261Z6",
+          "href" : "section/261Z6",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -16710,18 +18896,24 @@
         "number" : "Chapter IV",
         "title" : " Open-ended Investment Companies",
         "ref" : "part-XVII-chapter-IV",
+        "id" : "part-XVII-chapter-IV",
+        "href" : "part/XVII/chapter/IV",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "262",
           "title" : " Open-ended investment companies.",
           "ref" : "section-262",
+          "id" : "section-262",
+          "href" : "section/262",
           "extent" : [ "E", "W", "S" ]
         }, {
           "name" : "item",
           "number" : "263",
           "title" : " Amendment of section 716 Companies Act 1985.",
           "ref" : "section-263",
+          "id" : "section-263",
+          "href" : "section/263",
           "extent" : [ "E", "W", "S" ]
         } ]
       }, {
@@ -16729,48 +18921,64 @@
         "number" : "Chapter V",
         "title" : " Recognised Overseas Schemes",
         "ref" : "part-XVII-chapter-V",
+        "id" : "part-XVII-chapter-V",
+        "href" : "part/XVII/chapter/V",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : " Schemes constituted in other EEA States",
           "ref" : "part-XVII-chapter-V-crossheading-schemes-constituted-in-other-eea-states",
+          "id" : "part-XVII-chapter-V-crossheading-schemes-constituted-in-other-eea-states",
+          "href" : "part/XVII/chapter/V/crossheading/schemes-constituted-in-other-eea-states",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "264",
             "title" : " Schemes constituted in other EEA States.",
             "ref" : "section-264",
+            "id" : "section-264",
+            "href" : "section/264",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "265",
             "title" : " Representations and references to the Tribunal.",
             "ref" : "section-265",
+            "id" : "section-265",
+            "href" : "section/265",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "266",
             "title" : " Disapplication of rules.",
             "ref" : "section-266",
+            "id" : "section-266",
+            "href" : "section/266",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "267",
             "title" : " Power of  FCA  to suspend promotion of scheme.",
             "ref" : "section-267",
+            "id" : "section-267",
+            "href" : "section/267",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "268",
             "title" : " Procedure on giving directions under section 267 and varying them on  FCA's  own initiative.",
             "ref" : "section-268",
+            "id" : "section-268",
+            "href" : "section/268",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "269",
             "title" : " Procedure on application for variation or revocation of direction.",
             "ref" : "section-269",
+            "id" : "section-269",
+            "href" : "section/269",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -16778,18 +18986,24 @@
           "number" : null,
           "title" : " ...",
           "ref" : "part-XVII-chapter-V-crossheading-schemes-authorised-in-designated-countries-or-territories",
+          "id" : "part-XVII-chapter-V-crossheading-schemes-authorised-in-designated-countries-or-territories",
+          "href" : "part/XVII/chapter/V/crossheading/schemes-authorised-in-designated-countries-or-territories",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "270",
             "title" : " Schemes authorised in designated countries or territories.",
             "ref" : "section-270",
+            "id" : "section-270",
+            "href" : "section/270",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "271",
             "title" : " Procedure.",
             "ref" : "section-271",
+            "id" : "section-271",
+            "href" : "section/271",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -16797,120 +19011,160 @@
           "number" : null,
           "title" : "Schemes authorised in approved countries",
           "ref" : "chapter-V-crossheading-schemes-authorised-in-approved-countries",
+          "id" : "chapter-V-crossheading-schemes-authorised-in-approved-countries",
+          "href" : "chapter/V/crossheading/schemes-authorised-in-approved-countries",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "271A",
             "title" : "Schemes authorised in approved countries",
             "ref" : "section-271A",
+            "id" : "section-271A",
+            "href" : "section/271A",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "271B",
             "title" : "Approval of country: equivalent protection afforded to participants",
             "ref" : "section-271B",
+            "id" : "section-271B",
+            "href" : "section/271B",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "271C",
             "title" : "Approval of country: regulatory co-operation",
             "ref" : "section-271C",
+            "id" : "section-271C",
+            "href" : "section/271C",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "271D",
             "title" : "Report by the FCA in relation to approval",
             "ref" : "section-271D",
+            "id" : "section-271D",
+            "href" : "section/271D",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "271E",
             "title" : "Power to impose requirements on schemes",
             "ref" : "section-271E",
+            "id" : "section-271E",
+            "href" : "section/271E",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "271F",
             "title" : "Application for recognition to the FCA",
             "ref" : "section-271F",
+            "id" : "section-271F",
+            "href" : "section/271F",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "271G",
             "title" : "Determination of applications",
             "ref" : "section-271G",
+            "id" : "section-271G",
+            "href" : "section/271G",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "271H",
             "title" : "Procedure when determining an application",
             "ref" : "section-271H",
+            "id" : "section-271H",
+            "href" : "section/271H",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "271I",
             "title" : "Obligations on operator of a section 271A scheme",
             "ref" : "section-271I",
+            "id" : "section-271I",
+            "href" : "section/271I",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "271J",
             "title" : "Provision of information to the FCA",
             "ref" : "section-271J",
+            "id" : "section-271J",
+            "href" : "section/271J",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "271K",
             "title" : "Rules as to scheme particulars",
             "ref" : "section-271K",
+            "id" : "section-271K",
+            "href" : "section/271K",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "271L",
             "title" : "Suspension of recognition",
             "ref" : "section-271L",
+            "id" : "section-271L",
+            "href" : "section/271L",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "271M",
             "title" : "Procedure when suspending recognition",
             "ref" : "section-271M",
+            "id" : "section-271M",
+            "href" : "section/271M",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "271N",
             "title" : "Revocation of recognition on the FCA's initiative",
             "ref" : "section-271N",
+            "id" : "section-271N",
+            "href" : "section/271N",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "271O",
             "title" : "Requests for revocation of recognition",
             "ref" : "section-271O",
+            "id" : "section-271O",
+            "href" : "section/271O",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "271P",
             "title" : "Obligations on operator where recognition is revoked or suspended",
             "ref" : "section-271P",
+            "id" : "section-271P",
+            "href" : "section/271P",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "271Q",
             "title" : "Effect of variation or revocation of Treasury regulations",
             "ref" : "section-271Q",
+            "id" : "section-271Q",
+            "href" : "section/271Q",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "271R",
             "title" : "Public censure",
             "ref" : "section-271R",
+            "id" : "section-271R",
+            "href" : "section/271R",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "271S",
             "title" : "Recognition of parts of schemes under section 271A",
             "ref" : "section-271S",
+            "id" : "section-271S",
+            "href" : "section/271S",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -16918,48 +19172,64 @@
           "number" : null,
           "title" : " Individually recognised overseas schemes",
           "ref" : "part-XVII-chapter-V-crossheading-individually-recognised-overseas-schemes",
+          "id" : "part-XVII-chapter-V-crossheading-individually-recognised-overseas-schemes",
+          "href" : "part/XVII/chapter/V/crossheading/individually-recognised-overseas-schemes",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "272",
             "title" : " Individually recognised overseas schemes.",
             "ref" : "section-272",
+            "id" : "section-272",
+            "href" : "section/272",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "273",
             "title" : " Matters that may be taken into account.",
             "ref" : "section-273",
+            "id" : "section-273",
+            "href" : "section/273",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "274",
             "title" : " Applications for recognition of individual schemes.",
             "ref" : "section-274",
+            "id" : "section-274",
+            "href" : "section/274",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "275",
             "title" : " Determination of applications.",
             "ref" : "section-275",
+            "id" : "section-275",
+            "href" : "section/275",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "276",
             "title" : " Procedure when refusing an application.",
             "ref" : "section-276",
+            "id" : "section-276",
+            "href" : "section/276",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "277",
             "title" : " Alteration of schemes and changes of operator, trustee or depositary.",
             "ref" : "section-277",
+            "id" : "section-277",
+            "href" : "section/277",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "277A",
             "title" : "Regular provision of information relating to compliance with requirements for recognition",
             "ref" : "section-277A",
+            "id" : "section-277A",
+            "href" : "section/277A",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -16967,54 +19237,72 @@
           "number" : null,
           "title" : "...",
           "ref" : "part-XVII-chapter-V-crossheading-schemes-recognised-under-sections-270-and-272",
+          "id" : "part-XVII-chapter-V-crossheading-schemes-recognised-under-sections-270-and-272",
+          "href" : "part/XVII/chapter/V/crossheading/schemes-recognised-under-sections-270-and-272",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "278",
             "title" : " Rules as to scheme particulars.",
             "ref" : "section-278",
+            "id" : "section-278",
+            "href" : "section/278",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "279",
             "title" : " Revocation of recognition.",
             "ref" : "section-279",
+            "id" : "section-279",
+            "href" : "section/279",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "280",
             "title" : " Procedure.",
             "ref" : "section-280",
+            "id" : "section-280",
+            "href" : "section/280",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "281",
             "title" : " Directions.",
             "ref" : "section-281",
+            "id" : "section-281",
+            "href" : "section/281",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "282",
             "title" : " Procedure on giving directions under section 281 and varying them otherwise than as requested.",
             "ref" : "section-282",
+            "id" : "section-282",
+            "href" : "section/282",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "282A",
             "title" : "Obligations on operator where recognition is revoked or suspended",
             "ref" : "section-282A",
+            "id" : "section-282A",
+            "href" : "section/282A",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "282B",
             "title" : "Public censure",
             "ref" : "section-282B",
+            "id" : "section-282B",
+            "href" : "section/282B",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "282C",
             "title" : "Recognition of parts of schemes under section 272",
             "ref" : "section-282C",
+            "id" : "section-282C",
+            "href" : "section/282C",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -17022,12 +19310,16 @@
           "number" : null,
           "title" : " Facilities and information in UK",
           "ref" : "part-XVII-chapter-V-crossheading-facilities-and-information-in-uk",
+          "id" : "part-XVII-chapter-V-crossheading-facilities-and-information-in-uk",
+          "href" : "part/XVII/chapter/V/crossheading/facilities-and-information-in-uk",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "283",
             "title" : " Facilities and information in UK.",
             "ref" : "section-283",
+            "id" : "section-283",
+            "href" : "section/283",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -17036,18 +19328,24 @@
         "number" : "CHAPTER 5A",
         "title" : "MASTER-FEEDER STRUCTURES",
         "ref" : "part-XVII-chapter-5A",
+        "id" : "part-XVII-chapter-5A",
+        "href" : "part/XVII/chapter/5A",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "283A",
           "title" : "Master-feeder structures",
           "ref" : "section-283A",
+          "id" : "section-283A",
+          "href" : "section/283A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "283B",
           "title" : "Reports on derivative instruments",
           "ref" : "section-283B",
+          "id" : "section-283B",
+          "href" : "section/283B",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -17055,12 +19353,16 @@
         "number" : "Chapter VI",
         "title" : " Investigations",
         "ref" : "part-XVII-chapter-VI",
+        "id" : "part-XVII-chapter-VI",
+        "href" : "part/XVII/chapter/VI",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "284",
           "title" : " Power to investigate.",
           "ref" : "section-284",
+          "id" : "section-284",
+          "href" : "section/284",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -17069,12 +19371,16 @@
       "number" : "PART 17A",
       "title" : "Transformer Vehicles",
       "ref" : "part-17A",
+      "id" : "part-17A",
+      "href" : "part/17A",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "284A",
         "title" : "Transformer vehicles",
         "ref" : "section-284A",
+        "id" : "section-284A",
+        "href" : "section/284A",
         "extent" : [ "E", "W", "S", "NI" ]
       } ]
     }, {
@@ -17082,36 +19388,48 @@
       "number" : "Part XVIII",
       "title" : "Recognised investment exchanges, clearing houses , CSDs and other parties",
       "ref" : "part-XVIII",
+      "id" : "part-XVIII",
+      "href" : "part/XVIII",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "chapter",
         "number" : "Chapter I",
         "title" : "Exemption",
         "ref" : "part-XVIII-chapter-I",
+        "id" : "part-XVIII-chapter-I",
+        "href" : "part/XVIII/chapter/I",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "General",
           "ref" : "part-XVIII-chapter-I-crossheading-general",
+          "id" : "part-XVIII-chapter-I-crossheading-general",
+          "href" : "part/XVIII/chapter/I/crossheading/general",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "285",
             "title" : "Exemption for recognised bodies etc.",
             "ref" : "section-285",
+            "id" : "section-285",
+            "href" : "section/285",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "285A",
             "title" : "Powers exercisable in relation to recognised bodies etc",
             "ref" : "section-285A",
+            "id" : "section-285A",
+            "href" : "section/285A",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "286",
             "title" : "Qualification for recognition.",
             "ref" : "section-286",
+            "id" : "section-286",
+            "href" : "section/286",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -17119,72 +19437,96 @@
           "number" : null,
           "title" : "Applications for recognition",
           "ref" : "part-XVIII-chapter-I-crossheading-applications-for-recognition",
+          "id" : "part-XVIII-chapter-I-crossheading-applications-for-recognition",
+          "href" : "part/XVIII/chapter/I/crossheading/applications-for-recognition",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "287",
             "title" : "Application by an investment exchange.",
             "ref" : "section-287",
+            "id" : "section-287",
+            "href" : "section/287",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "287A",
             "title" : "Application by an investment exchange: persons connected with an applicant",
             "ref" : "section-287A",
+            "id" : "section-287A",
+            "href" : "section/287A",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "288",
             "title" : "Application by a clearing house.",
             "ref" : "section-288",
+            "id" : "section-288",
+            "href" : "section/288",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "288A",
             "title" : "Application by a central securities depository",
             "ref" : "section-288A",
+            "id" : "section-288A",
+            "href" : "section/288A",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "289",
             "title" : "Applications: supplementary.",
             "ref" : "section-289",
+            "id" : "section-289",
+            "href" : "section/289",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "290",
             "title" : "Recognition orders.",
             "ref" : "section-290",
+            "id" : "section-290",
+            "href" : "section/290",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "290ZA",
             "title" : "Variation of central counterparty recognition order",
             "ref" : "section-290ZA",
+            "id" : "section-290ZA",
+            "href" : "section/290ZA",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "290ZB",
             "title" : "Variation of CSD recognition order",
             "ref" : "section-290ZB",
+            "id" : "section-290ZB",
+            "href" : "section/290ZB",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "290A",
             "title" : "Refusal of recognition on ground of excessive regulatory provision",
             "ref" : "section-290A",
+            "id" : "section-290A",
+            "href" : "section/290A",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "291",
             "title" : "Liability in relation to recognised body’s regulatory functions.",
             "ref" : "section-291",
+            "id" : "section-291",
+            "href" : "section/291",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "292",
             "title" : "Overseas investment exchanges and overseas clearing houses.",
             "ref" : "section-292",
+            "id" : "section-292",
+            "href" : "section/292",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -17192,12 +19534,16 @@
           "number" : null,
           "title" : "Publication of information by recognised investment exchange",
           "ref" : "part-XVIII-chapter-I-crossheading-publication-of-information-by-recognised-investment-exchange",
+          "id" : "part-XVIII-chapter-I-crossheading-publication-of-information-by-recognised-investment-exchange",
+          "href" : "part/XVIII/chapter/I/crossheading/publication-of-information-by-recognised-investment-exchange",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "292A",
             "title" : "Publication of information by recognised investment exchange",
             "ref" : "section-292A",
+            "id" : "section-292A",
+            "href" : "section/292A",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -17205,72 +19551,96 @@
           "number" : null,
           "title" : "Supervision",
           "ref" : "part-XVIII-chapter-I-crossheading-supervision",
+          "id" : "part-XVIII-chapter-I-crossheading-supervision",
+          "href" : "part/XVIII/chapter/I/crossheading/supervision",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "293",
             "title" : "Notification requirements.",
             "ref" : "section-293",
+            "id" : "section-293",
+            "href" : "section/293",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "293A",
             "title" : "Information: compliance with specified requirements",
             "ref" : "section-293A",
+            "id" : "section-293A",
+            "href" : "section/293A",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "294",
             "title" : "Modification or waiver of rules.",
             "ref" : "section-294",
+            "id" : "section-294",
+            "href" : "section/294",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "295",
             "title" : "Notification: overseas investment exchanges and overseas clearing houses.",
             "ref" : "section-295",
+            "id" : "section-295",
+            "href" : "section/295",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "295A",
             "title" : "On-site inspection of United Kingdom branches of third country CSDs",
             "ref" : "section-295A",
+            "id" : "section-295A",
+            "href" : "section/295A",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "296",
             "title" : "Appropriate regulator's power to give directions.",
             "ref" : "section-296",
+            "id" : "section-296",
+            "href" : "section/296",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "296A",
             "title" : "Additional power to direct recognised central counterparties",
             "ref" : "section-296A",
+            "id" : "section-296A",
+            "href" : "section/296A",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "297",
             "title" : "Revoking recognition.",
             "ref" : "section-297",
+            "id" : "section-297",
+            "href" : "section/297",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "298",
             "title" : "Directions and revocation: procedure.",
             "ref" : "section-298",
+            "id" : "section-298",
+            "href" : "section/298",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "299",
             "title" : "Complaints about recognised bodies.",
             "ref" : "section-299",
+            "id" : "section-299",
+            "href" : "section/299",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "300",
             "title" : "Extension of functions of Tribunal.",
             "ref" : "section-300",
+            "id" : "section-300",
+            "href" : "section/300",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -17278,36 +19648,48 @@
           "number" : null,
           "title" : "Power to disallow excessive regulatory provision",
           "ref" : "part-XVIII-chapter-I-crossheading-power-to-disallow-excessive-regulatory-provision",
+          "id" : "part-XVIII-chapter-I-crossheading-power-to-disallow-excessive-regulatory-provision",
+          "href" : "part/XVIII/chapter/I/crossheading/power-to-disallow-excessive-regulatory-provision",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "300A",
             "title" : "Power of appropriate regulator to disallow excessive regulatory provision",
             "ref" : "section-300A",
+            "id" : "section-300A",
+            "href" : "section/300A",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "300B",
             "title" : "Duty to notify proposal to make regulatory provision",
             "ref" : "section-300B",
+            "id" : "section-300B",
+            "href" : "section/300B",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "300C",
             "title" : "Restriction on making provision before appropriate regulator decides whether to act",
             "ref" : "section-300C",
+            "id" : "section-300C",
+            "href" : "section/300C",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "300D",
             "title" : "Consideration by appropriate regulator whether to disallow proposed provision",
             "ref" : "section-300D",
+            "id" : "section-300D",
+            "href" : "section/300D",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "300E",
             "title" : "Power to disallow excessive regulatory provision: supplementary",
             "ref" : "section-300E",
+            "id" : "section-300E",
+            "href" : "section/300E",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -17315,24 +19697,32 @@
           "number" : null,
           "title" : "General rule-making powers",
           "ref" : "chapter-I-crossheading-general-rulemaking-powers",
+          "id" : "chapter-I-crossheading-general-rulemaking-powers",
+          "href" : "chapter/I/crossheading/general-rulemaking-powers",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "300F",
             "title" : "Rules relating to central counterparties and central securities depositories",
             "ref" : "section-300F",
+            "id" : "section-300F",
+            "href" : "section/300F",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "300G",
             "title" : "Section 300F: rules in relation to overseas FMI entities",
             "ref" : "section-300G",
+            "id" : "section-300G",
+            "href" : "section/300G",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "300H",
             "title" : "Rules relating to investment exchanges and data reporting service providers",
             "ref" : "section-300H",
+            "id" : "section-300H",
+            "href" : "section/300H",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -17340,36 +19730,48 @@
           "number" : null,
           "title" : "Bank of England rules",
           "ref" : "chapter-I-crossheading-bank-of-england-rules",
+          "id" : "chapter-I-crossheading-bank-of-england-rules",
+          "href" : "chapter/I/crossheading/bank-of-england-rules",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "300I",
             "title" : "Duty of Bank of England to review rules",
             "ref" : "section-300I",
+            "id" : "section-300I",
+            "href" : "section/300I",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "300J",
             "title" : "Statement of policy relating to review of rules",
             "ref" : "section-300J",
+            "id" : "section-300J",
+            "href" : "section/300J",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "300K",
             "title" : "Requirement to review specified rules",
             "ref" : "section-300K",
+            "id" : "section-300K",
+            "href" : "section/300K",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "300L",
             "title" : "Report on certain reviews",
             "ref" : "section-300L",
+            "id" : "section-300L",
+            "href" : "section/300L",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "300M",
             "title" : "Power of Treasury to require making of rules by regulations",
             "ref" : "section-300M",
+            "id" : "section-300M",
+            "href" : "section/300M",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -17377,12 +19779,16 @@
           "number" : null,
           "title" : "Other matters",
           "ref" : "part-XVIII-chapter-I-crossheading-other-matters",
+          "id" : "part-XVIII-chapter-I-crossheading-other-matters",
+          "href" : "part/XVIII/chapter/I/crossheading/other-matters",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "301",
             "title" : "Supervision of certain contracts.",
             "ref" : "section-301",
+            "id" : "section-301",
+            "href" : "section/301",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -17391,30 +19797,40 @@
         "number" : "CHAPTER 1A",
         "title" : "CONTROL OVER RECOGNISED INVESTMENT EXCHANGE",
         "ref" : "part-XVIII-chapter-1A",
+        "id" : "part-XVIII-chapter-1A",
+        "href" : "part/XVIII/chapter/1A",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Notices of acquisitions of control over recognised investment exchanges",
           "ref" : "part-XVIII-chapter-1A-crossheading-notices-of-acquisitions-of-control-over-recognised-investment-exchanges",
+          "id" : "part-XVIII-chapter-1A-crossheading-notices-of-acquisitions-of-control-over-recognised-investment-exchanges",
+          "href" : "part/XVIII/chapter/1A/crossheading/notices-of-acquisitions-of-control-over-recognised-investment-exchanges",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "301A",
             "title" : "Obligation to notify the FCA: acquisitions of control",
             "ref" : "section-301A",
+            "id" : "section-301A",
+            "href" : "section/301A",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "301B",
             "title" : "Requirements for section 301A notices",
             "ref" : "section-301B",
+            "id" : "section-301B",
+            "href" : "section/301B",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "301C",
             "title" : "Acknowledgment of receipt",
             "ref" : "section-301C",
+            "id" : "section-301C",
+            "href" : "section/301C",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -17422,18 +19838,24 @@
           "number" : null,
           "title" : "Acquiring and increasing control",
           "ref" : "part-XVIII-chapter-1A-crossheading-acquiring-and-increasing-control",
+          "id" : "part-XVIII-chapter-1A-crossheading-acquiring-and-increasing-control",
+          "href" : "part/XVIII/chapter/1A/crossheading/acquiring-and-increasing-control",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "301D",
             "title" : "Acquiring and increasing control",
             "ref" : "section-301D",
+            "id" : "section-301D",
+            "href" : "section/301D",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "301E",
             "title" : "Disregarded holdings",
             "ref" : "section-301E",
+            "id" : "section-301E",
+            "href" : "section/301E",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -17441,24 +19863,32 @@
           "number" : null,
           "title" : "Assessment procedure",
           "ref" : "part-XVIII-chapter-1A-crossheading-assessment-procedure",
+          "id" : "part-XVIII-chapter-1A-crossheading-assessment-procedure",
+          "href" : "part/XVIII/chapter/1A/crossheading/assessment-procedure",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "301F",
             "title" : "Assessment: general",
             "ref" : "section-301F",
+            "id" : "section-301F",
+            "href" : "section/301F",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "301G",
             "title" : "Assessment: Procedure",
             "ref" : "section-301G",
+            "id" : "section-301G",
+            "href" : "section/301G",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "301H",
             "title" : "Duration of approval",
             "ref" : "section-301H",
+            "id" : "section-301H",
+            "href" : "section/301H",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -17466,24 +19896,32 @@
           "number" : null,
           "title" : "Enforcement procedures",
           "ref" : "part-XVIII-chapter-1A-crossheading-enforcement-procedures",
+          "id" : "part-XVIII-chapter-1A-crossheading-enforcement-procedures",
+          "href" : "part/XVIII/chapter/1A/crossheading/enforcement-procedures",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "301I",
             "title" : "Objections by the FCA",
             "ref" : "section-301I",
+            "id" : "section-301I",
+            "href" : "section/301I",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "301J",
             "title" : "Restriction notices",
             "ref" : "section-301J",
+            "id" : "section-301J",
+            "href" : "section/301J",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "301K",
             "title" : "Orders for sale of shares",
             "ref" : "section-301K",
+            "id" : "section-301K",
+            "href" : "section/301K",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -17491,12 +19929,16 @@
           "number" : null,
           "title" : "Offences",
           "ref" : "part-XVIII-chapter-1A-crossheading-offences",
+          "id" : "part-XVIII-chapter-1A-crossheading-offences",
+          "href" : "part/XVIII/chapter/1A/crossheading/offences",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "301L",
             "title" : "Offences under this Chapter",
             "ref" : "section-301L",
+            "id" : "section-301L",
+            "href" : "section/301L",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -17504,12 +19946,16 @@
           "number" : null,
           "title" : "Interpretation",
           "ref" : "part-XVIII-chapter-1A-crossheading-interpretation",
+          "id" : "part-XVIII-chapter-1A-crossheading-interpretation",
+          "href" : "part/XVIII/chapter/1A/crossheading/interpretation",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "301M",
             "title" : "Interpretation",
             "ref" : "section-301M",
+            "id" : "section-301M",
+            "href" : "section/301M",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -17518,36 +19964,48 @@
         "number" : "Chapter II",
         "title" : "Competition Scrutiny",
         "ref" : "part-XVIII-chapter-II",
+        "id" : "part-XVIII-chapter-II",
+        "href" : "part/XVIII/chapter/II",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "302",
           "title" : "Interpretation.",
           "ref" : "section-302",
+          "id" : "section-302",
+          "href" : "section/302",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "pblock",
           "number" : null,
           "title" : "Role of Office of Fair Trading",
           "ref" : "part-XVIII-chapter-II-crossheading-role-of-director-general-of-fair-trading",
+          "id" : "part-XVIII-chapter-II-crossheading-role-of-director-general-of-fair-trading",
+          "href" : "part/XVIII/chapter/II/crossheading/role-of-director-general-of-fair-trading",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "303",
             "title" : "Initial report by OFT.",
             "ref" : "section-303",
+            "id" : "section-303",
+            "href" : "section/303",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "304",
             "title" : "Further reports by OFT.",
             "ref" : "section-304",
+            "id" : "section-304",
+            "href" : "section/304",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "305",
             "title" : "Investigations by OFT.",
             "ref" : "section-305",
+            "id" : "section-305",
+            "href" : "section/305",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -17555,12 +20013,16 @@
           "number" : null,
           "title" : "Role of Competition Commission",
           "ref" : "part-XVIII-chapter-II-crossheading-role-of-competition-commission",
+          "id" : "part-XVIII-chapter-II-crossheading-role-of-competition-commission",
+          "href" : "part/XVIII/chapter/II/crossheading/role-of-competition-commission",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "306",
             "title" : "Consideration by Competition Commission.",
             "ref" : "section-306",
+            "id" : "section-306",
+            "href" : "section/306",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -17568,30 +20030,40 @@
           "number" : null,
           "title" : "Role of the Treasury",
           "ref" : "part-XVIII-chapter-II-crossheading-role-of-the-treasury",
+          "id" : "part-XVIII-chapter-II-crossheading-role-of-the-treasury",
+          "href" : "part/XVIII/chapter/II/crossheading/role-of-the-treasury",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "307",
             "title" : "Recognition orders: role of the Treasury.",
             "ref" : "section-307",
+            "id" : "section-307",
+            "href" : "section/307",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "308",
             "title" : "Directions by the Treasury.",
             "ref" : "section-308",
+            "id" : "section-308",
+            "href" : "section/308",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "309",
             "title" : "Statements by the Treasury.",
             "ref" : "section-309",
+            "id" : "section-309",
+            "href" : "section/309",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "310",
             "title" : "Procedure on exercise of certain powers by the Treasury.",
             "ref" : "section-310",
+            "id" : "section-310",
+            "href" : "section/310",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -17600,18 +20072,24 @@
         "number" : "CHAPTER 2A",
         "title" : "Performance of functions of recognised bodies",
         "ref" : "part-XVIII-chapter-2A",
+        "id" : "part-XVIII-chapter-2A",
+        "href" : "part/XVIII/chapter/2A",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Relevant recognised bodies",
           "ref" : "part-XVIII-chapter-2A-crossheading-relevant-recognised-bodies",
+          "id" : "part-XVIII-chapter-2A-crossheading-relevant-recognised-bodies",
+          "href" : "part/XVIII/chapter/2A/crossheading/relevant-recognised-bodies",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "309A",
             "title" : "Recognised bodies to which this Chapter applies",
             "ref" : "section-309A",
+            "id" : "section-309A",
+            "href" : "section/309A",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -17619,36 +20097,48 @@
           "number" : null,
           "title" : "Prohibition",
           "ref" : "part-XVIII-chapter-2A-crossheading-prohibition",
+          "id" : "part-XVIII-chapter-2A-crossheading-prohibition",
+          "href" : "part/XVIII/chapter/2A/crossheading/prohibition",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "309B",
             "title" : "Part 18 prohibition orders",
             "ref" : "section-309B",
+            "id" : "section-309B",
+            "href" : "section/309B",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "309C",
             "title" : "Procedure for making Part 18 prohibition orders",
             "ref" : "section-309C",
+            "id" : "section-309C",
+            "href" : "section/309C",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "309D",
             "title" : "Varying and withdrawing Part 18 prohibition orders",
             "ref" : "section-309D",
+            "id" : "section-309D",
+            "href" : "section/309D",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "309E",
             "title" : "Offence of breaching prohibition",
             "ref" : "section-309E",
+            "id" : "section-309E",
+            "href" : "section/309E",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "309F",
             "title" : "Duty in relation to prohibited individuals",
             "ref" : "section-309F",
+            "id" : "section-309F",
+            "href" : "section/309F",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -17656,114 +20146,152 @@
           "number" : null,
           "title" : "Approval",
           "ref" : "part-XVIII-chapter-2A-crossheading-approval",
+          "id" : "part-XVIII-chapter-2A-crossheading-approval",
+          "href" : "part/XVIII/chapter/2A/crossheading/approval",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "309G",
             "title" : "Requirement for approval",
             "ref" : "section-309G",
+            "id" : "section-309G",
+            "href" : "section/309G",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "309H",
             "title" : "Rules under section 309G(3): transitional provision",
             "ref" : "section-309H",
+            "id" : "section-309H",
+            "href" : "section/309H",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "309I",
             "title" : "Applications for approval",
             "ref" : "section-309I",
+            "id" : "section-309I",
+            "href" : "section/309I",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "309J",
             "title" : "Vetting by relevant recognised bodies",
             "ref" : "section-309J",
+            "id" : "section-309J",
+            "href" : "section/309J",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "309K",
             "title" : "Determining applications: power to grant approval",
             "ref" : "section-309K",
+            "id" : "section-309K",
+            "href" : "section/309K",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "309L",
             "title" : "Determining applications: period for approval",
             "ref" : "section-309L",
+            "id" : "section-309L",
+            "href" : "section/309L",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "309M",
             "title" : "Determining applications: further procedure",
             "ref" : "section-309M",
+            "id" : "section-309M",
+            "href" : "section/309M",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "309N",
             "title" : "Changes in responsibilities",
             "ref" : "section-309N",
+            "id" : "section-309N",
+            "href" : "section/309N",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "309O",
             "title" : "Withdrawing approval",
             "ref" : "section-309O",
+            "id" : "section-309O",
+            "href" : "section/309O",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "309P",
             "title" : "Procedure for withdrawing approval",
             "ref" : "section-309P",
+            "id" : "section-309P",
+            "href" : "section/309P",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "309Q",
             "title" : "Varying approval at request of relevant recognised body",
             "ref" : "section-309Q",
+            "id" : "section-309Q",
+            "href" : "section/309Q",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "309R",
             "title" : "Varying approval on the appropriate regulator’s initiative",
             "ref" : "section-309R",
+            "id" : "section-309R",
+            "href" : "section/309R",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "309S",
             "title" : "Statement of policy on approval",
             "ref" : "section-309S",
+            "id" : "section-309S",
+            "href" : "section/309S",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "309T",
             "title" : "Breach of statutory duty by relevant recognised bodies",
             "ref" : "section-309T",
+            "id" : "section-309T",
+            "href" : "section/309T",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "309U",
             "title" : "Power to impose penalties",
             "ref" : "section-309U",
+            "id" : "section-309U",
+            "href" : "section/309U",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "309V",
             "title" : "Procedure for imposing penalties",
             "ref" : "section-309V",
+            "id" : "section-309V",
+            "href" : "section/309V",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "309W",
             "title" : "Statement of policy on penalties",
             "ref" : "section-309W",
+            "id" : "section-309W",
+            "href" : "section/309W",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "309X",
             "title" : "Procedure for statement of policy on penalties",
             "ref" : "section-309X",
+            "id" : "section-309X",
+            "href" : "section/309X",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -17771,18 +20299,24 @@
           "number" : null,
           "title" : "Certification of employees",
           "ref" : "part-XVIII-chapter-2A-crossheading-certification-of-employees",
+          "id" : "part-XVIII-chapter-2A-crossheading-certification-of-employees",
+          "href" : "part/XVIII/chapter/2A/crossheading/certification-of-employees",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "309Y",
             "title" : "Certification of employees by relevant recognised bodies",
             "ref" : "section-309Y",
+            "id" : "section-309Y",
+            "href" : "section/309Y",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "309Z",
             "title" : "Issuing certificates",
             "ref" : "section-309Z",
+            "id" : "section-309Z",
+            "href" : "section/309Z",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -17790,12 +20324,16 @@
           "number" : null,
           "title" : "Rules of conduct",
           "ref" : "part-XVIII-chapter-2A-crossheading-rules-of-conduct",
+          "id" : "part-XVIII-chapter-2A-crossheading-rules-of-conduct",
+          "href" : "part/XVIII/chapter/2A/crossheading/rules-of-conduct",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "309Z1",
             "title" : "Rules of conduct",
             "ref" : "section-309Z1",
+            "id" : "section-309Z1",
+            "href" : "section/309Z1",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -17803,36 +20341,48 @@
           "number" : null,
           "title" : "Disciplinary action by appropriate regulator",
           "ref" : "part-XVIII-chapter-2A-crossheading-disciplinary-action-by-appropriate-regulator",
+          "id" : "part-XVIII-chapter-2A-crossheading-disciplinary-action-by-appropriate-regulator",
+          "href" : "part/XVIII/chapter/2A/crossheading/disciplinary-action-by-appropriate-regulator",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "309Z2",
             "title" : "Power to take disciplinary action for misconduct",
             "ref" : "section-309Z2",
+            "id" : "section-309Z2",
+            "href" : "section/309Z2",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "309Z3",
             "title" : "Meaning of “misconduct”",
             "ref" : "section-309Z3",
+            "id" : "section-309Z3",
+            "href" : "section/309Z3",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "309Z4",
             "title" : "Procedure for disciplinary action",
             "ref" : "section-309Z4",
+            "id" : "section-309Z4",
+            "href" : "section/309Z4",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "309Z5",
             "title" : "Statement of policy about disciplinary action",
             "ref" : "section-309Z5",
+            "id" : "section-309Z5",
+            "href" : "section/309Z5",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "309Z6",
             "title" : "Procedure for statement of policy about disciplinary action",
             "ref" : "section-309Z6",
+            "id" : "section-309Z6",
+            "href" : "section/309Z6",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -17840,12 +20390,16 @@
           "number" : null,
           "title" : "Interpretation",
           "ref" : "part-XVIII-chapter-2A-crossheading-interpretation",
+          "id" : "part-XVIII-chapter-2A-crossheading-interpretation",
+          "href" : "part/XVIII/chapter/2A/crossheading/interpretation",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "309Z7",
             "title" : "Interpretation of Chapter 2A",
             "ref" : "section-309Z7",
+            "id" : "section-309Z7",
+            "href" : "section/309Z7",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -17853,12 +20407,16 @@
           "number" : null,
           "title" : "Application of this Chapter to credit rating agencies",
           "ref" : "part-XVIII-chapter-2A-crossheading-application-of-this-chapter-to-credit-rating-agencies",
+          "id" : "part-XVIII-chapter-2A-crossheading-application-of-this-chapter-to-credit-rating-agencies",
+          "href" : "part/XVIII/chapter/2A/crossheading/application-of-this-chapter-to-credit-rating-agencies",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "309Z8",
             "title" : "Power to apply this Chapter to credit rating agencies",
             "ref" : "section-309Z8",
+            "id" : "section-309Z8",
+            "href" : "section/309Z8",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -17867,18 +20425,24 @@
         "number" : "Chapter III",
         "title" : "Exclusion from the Competition Act 1998",
         "ref" : "part-XVIII-chapter-III",
+        "id" : "part-XVIII-chapter-III",
+        "href" : "part/XVIII/chapter/III",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "311",
           "title" : "The Chapter I prohibition.",
           "ref" : "section-311",
+          "id" : "section-311",
+          "href" : "section/311",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "312",
           "title" : "The Chapter II prohibition.",
           "ref" : "section-312",
+          "id" : "section-312",
+          "href" : "section/312",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -17886,24 +20450,32 @@
         "number" : "CHAPTER 3A",
         "title" : "PASSPORT RIGHTS",
         "ref" : "part-XVIII-chapter-3A",
+        "id" : "part-XVIII-chapter-3A",
+        "href" : "part/XVIII/chapter/3A",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "EEA market operators in United Kingdom",
           "ref" : "part-XVIII-chapter-3A-crossheading-eea-market-operators-in-united-kingdom",
+          "id" : "part-XVIII-chapter-3A-crossheading-eea-market-operators-in-united-kingdom",
+          "href" : "part/XVIII/chapter/3A/crossheading/eea-market-operators-in-united-kingdom",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "312A",
             "title" : "Exercise of passport rights by EEA market operator",
             "ref" : "section-312A",
+            "id" : "section-312A",
+            "href" : "section/312A",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "312B",
             "title" : "Removal of passport rights from EEA market operator",
             "ref" : "section-312B",
+            "id" : "section-312B",
+            "href" : "section/312B",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -17911,12 +20483,16 @@
           "number" : null,
           "title" : "Recognised investment exchanges operating in EEA States (other than the United Kingdom)",
           "ref" : "part-XVIII-chapter-3A-crossheading-recognised-investment-exchanges-operating-in-eea-states-other-than-the-united-kingdom",
+          "id" : "part-XVIII-chapter-3A-crossheading-recognised-investment-exchanges-operating-in-eea-states-other-than-the-united-kingdom",
+          "href" : "part/XVIII/chapter/3A/crossheading/recognised-investment-exchanges-operating-in-eea-states-other-than-the-united-kingdom",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "312C",
             "title" : "Exercise of passport rights by recognised investment exchange",
             "ref" : "section-312C",
+            "id" : "section-312C",
+            "href" : "section/312C",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -17924,12 +20500,16 @@
           "number" : null,
           "title" : "Interpretation",
           "ref" : "part-XVIII-chapter-3A-crossheading-interpretation",
+          "id" : "part-XVIII-chapter-3A-crossheading-interpretation",
+          "href" : "part/XVIII/chapter/3A/crossheading/interpretation",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "312D",
             "title" : "Interpretation of Chapter 3A",
             "ref" : "section-312D",
+            "id" : "section-312D",
+            "href" : "section/312D",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -17938,54 +20518,72 @@
         "number" : "CHAPTER 3B",
         "title" : "Disciplinary measures in respect of recognised bodies",
         "ref" : "part-XVIII-chapter-3B",
+        "id" : "part-XVIII-chapter-3B",
+        "href" : "part/XVIII/chapter/3B",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "312E",
           "title" : "Public censure",
           "ref" : "section-312E",
+          "id" : "section-312E",
+          "href" : "section/312E",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "312F",
           "title" : "Financial penalties",
           "ref" : "section-312F",
+          "id" : "section-312F",
+          "href" : "section/312F",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "312FA",
           "title" : "Central securities depositories: further disciplinary measures",
           "ref" : "section-312FA",
+          "id" : "section-312FA",
+          "href" : "section/312FA",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "312G",
           "title" : "Proposal to take disciplinary measures",
           "ref" : "section-312G",
+          "id" : "section-312G",
+          "href" : "section/312G",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "312H",
           "title" : "Decision notice",
           "ref" : "section-312H",
+          "id" : "section-312H",
+          "href" : "section/312H",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "312I",
           "title" : "Publication",
           "ref" : "section-312I",
+          "id" : "section-312I",
+          "href" : "section/312I",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "312J",
           "title" : "Statement of policy",
           "ref" : "section-312J",
+          "id" : "section-312J",
+          "href" : "section/312J",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "312K",
           "title" : "Statement of policy: procedure",
           "ref" : "section-312K",
+          "id" : "section-312K",
+          "href" : "section/312K",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -17993,78 +20591,104 @@
         "number" : "CHAPTER 3C",
         "title" : "Critical third parties",
         "ref" : "part-XVIII-chapter-3C",
+        "id" : "part-XVIII-chapter-3C",
+        "href" : "part/XVIII/chapter/3C",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "312L",
           "title" : "Critical third parties",
           "ref" : "section-312L",
+          "id" : "section-312L",
+          "href" : "section/312L",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "312M",
           "title" : "Power to make rules",
           "ref" : "section-312M",
+          "id" : "section-312M",
+          "href" : "section/312M",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "312N",
           "title" : "Power of direction",
           "ref" : "section-312N",
+          "id" : "section-312N",
+          "href" : "section/312N",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "312O",
           "title" : "Directions: procedure",
           "ref" : "section-312O",
+          "id" : "section-312O",
+          "href" : "section/312O",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "312P",
           "title" : "Information gathering and investigations",
           "ref" : "section-312P",
+          "id" : "section-312P",
+          "href" : "section/312P",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "312Q",
           "title" : "Power of censure",
           "ref" : "section-312Q",
+          "id" : "section-312Q",
+          "href" : "section/312Q",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "312R",
           "title" : "Disciplinary measures",
           "ref" : "section-312R",
+          "id" : "section-312R",
+          "href" : "section/312R",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "312S",
           "title" : "Procedure and right to refer to Tribunal",
           "ref" : "section-312S",
+          "id" : "section-312S",
+          "href" : "section/312S",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "312T",
           "title" : "Statement of policy relating to disciplinary measures",
           "ref" : "section-312T",
+          "id" : "section-312T",
+          "href" : "section/312T",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "312U",
           "title" : "Duty to ensure co-ordinated exercise of functions etc",
           "ref" : "section-312U",
+          "id" : "section-312U",
+          "href" : "section/312U",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "312V",
           "title" : "Memorandum of understanding",
           "ref" : "section-312V",
+          "id" : "section-312V",
+          "href" : "section/312V",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "312W",
           "title" : "Application of provisions of this Act to this Chapter",
           "ref" : "section-312W",
+          "id" : "section-312W",
+          "href" : "section/312W",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -18072,18 +20696,24 @@
         "number" : "Chapter IV",
         "title" : null,
         "ref" : "part-XVIII-chapter-IV",
+        "id" : "part-XVIII-chapter-IV",
+        "href" : "part/XVIII/chapter/IV",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Interpretation",
           "ref" : "part-XVIII-chapter-IV-crossheading-interpretation",
+          "id" : "part-XVIII-chapter-IV-crossheading-interpretation",
+          "href" : "part/XVIII/chapter/IV/crossheading/interpretation",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "313",
             "title" : "Interpretation of Part XVIII.",
             "ref" : "section-313",
+            "id" : "section-313",
+            "href" : "section/313",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -18093,78 +20723,104 @@
       "number" : "Part 18A",
       "title" : "SUSPENSION AND REMOVAL OF FINANCIAL INSTRUMENTS FROM TRADING",
       "ref" : "part-18A",
+      "id" : "part-18A",
+      "href" : "part/18A",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "313A",
         "title" : " FCA's  power to require suspension or removal of financial instruments from trading",
         "ref" : "section-313A",
+        "id" : "section-313A",
+        "href" : "section/313A",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "313B",
         "title" : "Suspension or removal of financial instruments from trading: procedure",
         "ref" : "section-313B",
+        "id" : "section-313B",
+        "href" : "section/313B",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "313BA",
         "title" : "Procedure following consideration of representations",
         "ref" : "section-313BA",
+        "id" : "section-313BA",
+        "href" : "section/313BA",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "313BB",
         "title" : "Revocation of requirements: applications by institutions",
         "ref" : "section-313BB",
+        "id" : "section-313BB",
+        "href" : "section/313BB",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "313BC",
         "title" : "Decisions on applications for revocation by institutions",
         "ref" : "section-313BC",
+        "id" : "section-313BC",
+        "href" : "section/313BC",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "313BD",
         "title" : "Revocation of requirements: applications by issuers",
         "ref" : "section-313BD",
+        "id" : "section-313BD",
+        "href" : "section/313BD",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "313BE",
         "title" : "Decisions on applications for revocation by issuers",
         "ref" : "section-313BE",
+        "id" : "section-313BE",
+        "href" : "section/313BE",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "313C",
         "title" : "Notification in relation to suspension or removal of a financial instrument from trading",
         "ref" : "section-313C",
+        "id" : "section-313C",
+        "href" : "section/313C",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "313CA",
         "title" : "Suspension or removal of financial instruments from trading: notification and trading on other venues",
         "ref" : "section-313CA",
+        "id" : "section-313CA",
+        "href" : "section/313CA",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "313CB",
         "title" : "Suspension or removal of a financial instrument from a trading by a trading venue: FCA duties",
         "ref" : "section-313CB",
+        "id" : "section-313CB",
+        "href" : "section/313CB",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "313CC",
         "title" : "Suspension or removal of a financial instrument from trading in another EEA state: FCA duties",
         "ref" : "section-313CC",
+        "id" : "section-313CC",
+        "href" : "section/313CC",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "313D",
         "title" : "Interpretation of Part 18A",
         "ref" : "section-313D",
+        "id" : "section-313D",
+        "href" : "section/313D",
         "extent" : [ "E", "W", "S", "NI" ]
       } ]
     }, {
@@ -18172,24 +20828,32 @@
       "number" : "Part XIX",
       "title" : " Lloyd’s",
       "ref" : "part-XIX",
+      "id" : "part-XIX",
+      "href" : "part/XIX",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : " General",
         "ref" : "part-XIX-crossheading-general",
+        "id" : "part-XIX-crossheading-general",
+        "href" : "part/XIX/crossheading/general",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "314",
           "title" : "  Regulators'  general duty.",
           "ref" : "section-314",
+          "id" : "section-314",
+          "href" : "section/314",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "314A",
           "title" : "The PRA's objectives in relation to Lloyd's etc",
           "ref" : "section-314A",
+          "id" : "section-314A",
+          "href" : "section/314A",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -18197,12 +20861,16 @@
         "number" : null,
         "title" : " The Society",
         "ref" : "part-XIX-crossheading-the-society",
+        "id" : "part-XIX-crossheading-the-society",
+        "href" : "part/XIX/crossheading/the-society",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "315",
           "title" : "The Society: regulated activities",
           "ref" : "section-315",
+          "id" : "section-315",
+          "href" : "section/315",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -18210,30 +20878,40 @@
         "number" : null,
         "title" : " Power to apply Act to Lloyd’s underwriting",
         "ref" : "part-XIX-crossheading-power-to-apply-act-to-lloyds-underwriting",
+        "id" : "part-XIX-crossheading-power-to-apply-act-to-lloyds-underwriting",
+        "href" : "part/XIX/crossheading/power-to-apply-act-to-lloyds-underwriting",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "316",
           "title" : " Direction by  a regulator ",
           "ref" : "section-316",
+          "id" : "section-316",
+          "href" : "section/316",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "317",
           "title" : " The core provisions.",
           "ref" : "section-317",
+          "id" : "section-317",
+          "href" : "section/317",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "318",
           "title" : " Exercise of powers through Council.",
           "ref" : "section-318",
+          "id" : "section-318",
+          "href" : "section/318",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "319",
           "title" : " Consultation.",
           "ref" : "section-319",
+          "id" : "section-319",
+          "href" : "section/319",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -18241,24 +20919,32 @@
         "number" : null,
         "title" : " Former underwriting members",
         "ref" : "part-XIX-crossheading-former-underwriting-members",
+        "id" : "part-XIX-crossheading-former-underwriting-members",
+        "href" : "part/XIX/crossheading/former-underwriting-members",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "320",
           "title" : " Former underwriting members.",
           "ref" : "section-320",
+          "id" : "section-320",
+          "href" : "section/320",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "321",
           "title" : " Requirements imposed under section 320.",
           "ref" : "section-321",
+          "id" : "section-321",
+          "href" : "section/321",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "322",
           "title" : " Rules applicable to former underwriting members.",
           "ref" : "section-322",
+          "id" : "section-322",
+          "href" : "section/322",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -18266,12 +20952,16 @@
         "number" : null,
         "title" : " Transfers of business done at Lloyd’s",
         "ref" : "part-XIX-crossheading-transfers-of-business-done-at-lloyds",
+        "id" : "part-XIX-crossheading-transfers-of-business-done-at-lloyds",
+        "href" : "part/XIX/crossheading/transfers-of-business-done-at-lloyds",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "323",
           "title" : " Transfer schemes.",
           "ref" : "section-323",
+          "id" : "section-323",
+          "href" : "section/323",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -18279,12 +20969,16 @@
         "number" : null,
         "title" : " Supplemental",
         "ref" : "part-XIX-crossheading-supplemental",
+        "id" : "part-XIX-crossheading-supplemental",
+        "href" : "part/XIX/crossheading/supplemental",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "324",
           "title" : " Interpretation of this Part.",
           "ref" : "section-324",
+          "id" : "section-324",
+          "href" : "section/324",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -18293,60 +20987,80 @@
       "number" : "Part XX",
       "title" : " Provision of Financial Services by Members of the Professions",
       "ref" : "part-XX",
+      "id" : "part-XX",
+      "href" : "part/XX",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "325",
         "title" : "  FCA's  general duty.",
         "ref" : "section-325",
+        "id" : "section-325",
+        "href" : "section/325",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "326",
         "title" : " Designation of professional bodies.",
         "ref" : "section-326",
+        "id" : "section-326",
+        "href" : "section/326",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "327",
         "title" : " Exemption from the general prohibition.",
         "ref" : "section-327",
+        "id" : "section-327",
+        "href" : "section/327",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "328",
         "title" : " Directions in relation to the general prohibition.",
         "ref" : "section-328",
+        "id" : "section-328",
+        "href" : "section/328",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "329",
         "title" : " Orders in relation to the general prohibition.",
         "ref" : "section-329",
+        "id" : "section-329",
+        "href" : "section/329",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "330",
         "title" : " Consultation.",
         "ref" : "section-330",
+        "id" : "section-330",
+        "href" : "section/330",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "331",
         "title" : " Procedure on making or varying orders under section 329.",
         "ref" : "section-331",
+        "id" : "section-331",
+        "href" : "section/331",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "332",
         "title" : " Rules in relation to persons to whom the general prohibition does not apply.",
         "ref" : "section-332",
+        "id" : "section-332",
+        "href" : "section/332",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "333",
         "title" : " False claims to be a person to whom the general prohibition does not apply.",
         "ref" : "section-333",
+        "id" : "section-333",
+        "href" : "section/333",
         "extent" : [ "E", "W", "S", "NI" ]
       } ]
     }, {
@@ -18354,36 +21068,48 @@
       "number" : "PART 20A",
       "title" : "PENSIONS GUIDANCE",
       "ref" : "part-20A",
+      "id" : "part-20A",
+      "href" : "part/20A",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "333A",
         "title" : "Introduction and definitions",
         "ref" : "section-333A",
+        "id" : "section-333A",
+        "href" : "section/333A",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "pblock",
         "number" : null,
         "title" : "Giving of pensions guidance",
         "ref" : "part-20A-crossheading-giving-of-pensions-guidance",
+        "id" : "part-20A-crossheading-giving-of-pensions-guidance",
+        "href" : "part/20A/crossheading/giving-of-pensions-guidance",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "333B",
           "title" : " Secretary of State’s  role in relation to pensions guidance",
           "ref" : "section-333B",
+          "id" : "section-333B",
+          "href" : "section/333B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "333C",
           "title" : "Giving of pensions guidance",
           "ref" : "section-333C",
+          "id" : "section-333C",
+          "href" : "section/333C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "333D",
           "title" : "Financial assistance to bodies involved in giving pensions guidance",
           "ref" : "section-333D",
+          "id" : "section-333D",
+          "href" : "section/333D",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -18391,12 +21117,16 @@
         "number" : null,
         "title" : "Designation of guidance providers",
         "ref" : "part-20A-crossheading-designation-of-guidance-providers",
+        "id" : "part-20A-crossheading-designation-of-guidance-providers",
+        "href" : "part/20A/crossheading/designation-of-guidance-providers",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "333E",
           "title" : "Designation of providers of pensions guidance",
           "ref" : "section-333E",
+          "id" : "section-333E",
+          "href" : "section/333E",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -18404,12 +21134,16 @@
         "number" : null,
         "title" : "Co-operation and information sharing",
         "ref" : "part-20A-crossheading-cooperation-and-information-sharing",
+        "id" : "part-20A-crossheading-cooperation-and-information-sharing",
+        "href" : "part/20A/crossheading/cooperation-and-information-sharing",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "333F",
           "title" : "Co-operation and information sharing",
           "ref" : "section-333F",
+          "id" : "section-333F",
+          "href" : "section/333F",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -18417,12 +21151,16 @@
         "number" : null,
         "title" : "False claims when giving pensions guidance",
         "ref" : "part-20A-crossheading-false-claims-when-giving-pensions-guidance",
+        "id" : "part-20A-crossheading-false-claims-when-giving-pensions-guidance",
+        "href" : "part/20A/crossheading/false-claims-when-giving-pensions-guidance",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "333G",
           "title" : "Offence of falsely claiming to be giving pensions guidance under  arrangements made with Secretary of State ",
           "ref" : "section-333G",
+          "id" : "section-333G",
+          "href" : "section/333G",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -18430,48 +21168,64 @@
         "number" : null,
         "title" : "Standards for giving of pensions guidance by designated guidance providers",
         "ref" : "part-20A-crossheading-standards-for-giving-of-pensions-guidance-by-designated-guidance-providers",
+        "id" : "part-20A-crossheading-standards-for-giving-of-pensions-guidance-by-designated-guidance-providers",
+        "href" : "part/20A/crossheading/standards-for-giving-of-pensions-guidance-by-designated-guidance-providers",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "333H",
           "title" : "Standards for giving of pensions guidance by designated guidance providers",
           "ref" : "section-333H",
+          "id" : "section-333H",
+          "href" : "section/333H",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "333I",
           "title" : "Monitoring of compliance with standards by designated guidance providers",
           "ref" : "section-333I",
+          "id" : "section-333I",
+          "href" : "section/333I",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "333J",
           "title" : "Failure by designated guidance providers to comply with standards: FCA recommendations",
           "ref" : "section-333J",
+          "id" : "section-333J",
+          "href" : "section/333J",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "333K",
           "title" : "FCA policy on making recommendations under section 333J",
           "ref" : "section-333K",
+          "id" : "section-333K",
+          "href" : "section/333K",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "333L",
           "title" : "FCA policy on making recommendations under section 333J: procedure",
           "ref" : "section-333L",
+          "id" : "section-333L",
+          "href" : "section/333L",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "333M",
           "title" : "Failure by designated guidance providers to comply with standards: ... directions",
           "ref" : "section-333M",
+          "id" : "section-333M",
+          "href" : "section/333M",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "333N",
           "title" : "Directions to designated guidance providers under section 333M: relationship with power to revoke a designation",
           "ref" : "section-333N",
+          "id" : "section-333N",
+          "href" : "section/333N",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -18479,18 +21233,24 @@
         "number" : null,
         "title" : "FCA's duties and power to give guidance",
         "ref" : "part-20A-crossheading-fcas-duties-and-power-to-give-guidance",
+        "id" : "part-20A-crossheading-fcas-duties-and-power-to-give-guidance",
+        "href" : "part/20A/crossheading/fcas-duties-and-power-to-give-guidance",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "333O",
           "title" : "FCA's duties",
           "ref" : "section-333O",
+          "id" : "section-333O",
+          "href" : "section/333O",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "333P",
           "title" : "Power of the FCA to give guidance",
           "ref" : "section-333P",
+          "id" : "section-333P",
+          "href" : "section/333P",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -18498,18 +21258,24 @@
         "number" : null,
         "title" : "Funding of pensions guidance",
         "ref" : "part-20A-crossheading-funding-of-pensions-guidance",
+        "id" : "part-20A-crossheading-funding-of-pensions-guidance",
+        "href" : "part/20A/crossheading/funding-of-pensions-guidance",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "333Q",
           "title" : "Funding of FCA's pensions guidance costs",
           "ref" : "section-333Q",
+          "id" : "section-333Q",
+          "href" : "section/333Q",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "333R",
           "title" : "Funding of  Secretary of State’s  pensions guidance costs",
           "ref" : "section-333R",
+          "id" : "section-333R",
+          "href" : "section/333R",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -18518,18 +21284,24 @@
       "number" : "PART 20B",
       "title" : "Illegal Money Lending",
       "ref" : "part-20B",
+      "id" : "part-20B",
+      "href" : "part/20B",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "333S",
         "title" : "Financial assistance for action against illegal money lending",
         "ref" : "section-333S",
+        "id" : "section-333S",
+        "href" : "section/333S",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "333T",
         "title" : "Funding of action against illegal money lending",
         "ref" : "section-333T",
+        "id" : "section-333T",
+        "href" : "section/333T",
         "extent" : [ "E", "W", "S", "NI" ]
       } ]
     }, {
@@ -18537,24 +21309,32 @@
       "number" : "Part XXI",
       "title" : " Mutual Societies",
       "ref" : "part-XXI",
+      "id" : "part-XXI",
+      "href" : "part/XXI",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : " Friendly societies",
         "ref" : "part-XXI-crossheading-friendly-societies",
+        "id" : "part-XXI-crossheading-friendly-societies",
+        "href" : "part/XXI/crossheading/friendly-societies",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "334",
           "title" : " The Friendly Societies Commission.",
           "ref" : "section-334",
+          "id" : "section-334",
+          "href" : "section/334",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "335",
           "title" : " The Registry of Friendly Societies.",
           "ref" : "section-335",
+          "id" : "section-335",
+          "href" : "section/335",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -18562,18 +21342,24 @@
         "number" : null,
         "title" : " Building societies",
         "ref" : "part-XXI-crossheading-building-societies",
+        "id" : "part-XXI-crossheading-building-societies",
+        "href" : "part/XXI/crossheading/building-societies",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "336",
           "title" : " The Building Societies Commission.",
           "ref" : "section-336",
+          "id" : "section-336",
+          "href" : "section/336",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "337",
           "title" : " The Building Societies Investor Protection Board.",
           "ref" : "section-337",
+          "id" : "section-337",
+          "href" : "section/337",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -18581,12 +21367,16 @@
         "number" : null,
         "title" : " Industrial and provident societies and credit unions",
         "ref" : "part-XXI-crossheading-industrial-and-provident-societies-and-credit-unions",
+        "id" : "part-XXI-crossheading-industrial-and-provident-societies-and-credit-unions",
+        "href" : "part/XXI/crossheading/industrial-and-provident-societies-and-credit-unions",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "338",
           "title" : " Industrial and provident societies and credit unions.",
           "ref" : "section-338",
+          "id" : "section-338",
+          "href" : "section/338",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -18594,12 +21384,16 @@
         "number" : null,
         "title" : " Supplemental",
         "ref" : "part-XXI-crossheading-supplemental",
+        "id" : "part-XXI-crossheading-supplemental",
+        "href" : "part/XXI/crossheading/supplemental",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "339",
           "title" : " Supplemental provisions.",
           "ref" : "section-339",
+          "id" : "section-339",
+          "href" : "section/339",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -18608,30 +21402,40 @@
       "number" : "Part XXII",
       "title" : " Auditors and Actuaries",
       "ref" : "part-XXII",
+      "id" : "part-XXII",
+      "href" : "part/XXII",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : "General duties of regulator",
         "ref" : "part-XXII-crossheading-general-duties-of-pra",
+        "id" : "part-XXII-crossheading-general-duties-of-pra",
+        "href" : "part/XXII/crossheading/general-duties-of-pra",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "339A",
           "title" : "General duties of PRA in relation to auditors",
           "ref" : "section-339A",
+          "id" : "section-339A",
+          "href" : "section/339A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "339B",
           "title" : " Duty to meet auditors of certain institutions",
           "ref" : "section-339B",
+          "id" : "section-339B",
+          "href" : "section/339B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "339C",
           "title" : "PRA-authorised persons to which this section applies",
           "ref" : "section-339C",
+          "id" : "section-339C",
+          "href" : "section/339C",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -18639,12 +21443,16 @@
         "number" : null,
         "title" : " Appointment",
         "ref" : "part-XXII-crossheading-appointment",
+        "id" : "part-XXII-crossheading-appointment",
+        "href" : "part/XXII/crossheading/appointment",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "340",
           "title" : "Appointment.",
           "ref" : "section-340",
+          "id" : "section-340",
+          "href" : "section/340",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -18652,30 +21460,40 @@
         "number" : null,
         "title" : " Information",
         "ref" : "part-XXII-crossheading-information",
+        "id" : "part-XXII-crossheading-information",
+        "href" : "part/XXII/crossheading/information",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "341",
           "title" : " Access to books etc.",
           "ref" : "section-341",
+          "id" : "section-341",
+          "href" : "section/341",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "342",
           "title" : " Information given by auditor or actuary to  a regulator.",
           "ref" : "section-342",
+          "id" : "section-342",
+          "href" : "section/342",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "343",
           "title" : " Information given by auditor or actuary to  a regulator: persons with close links.",
           "ref" : "section-343",
+          "id" : "section-343",
+          "href" : "section/343",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "344",
           "title" : " Duty of auditor or actuary resigning etc. to give notice.",
           "ref" : "section-344",
+          "id" : "section-344",
+          "href" : "section/344",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -18683,42 +21501,56 @@
         "number" : null,
         "title" : " Disciplinary measures",
         "ref" : "part-XXII-crossheading-disqualification",
+        "id" : "part-XXII-crossheading-disqualification",
+        "href" : "part/XXII/crossheading/disqualification",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "345",
           "title" : " Disciplinary measures: FCA",
           "ref" : "section-345",
+          "id" : "section-345",
+          "href" : "section/345",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "345A",
           "title" : "Disciplinary measures: PRA",
           "ref" : "section-345A",
+          "id" : "section-345A",
+          "href" : "section/345A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "345B",
           "title" : "Procedure and right to refer to Tribunal",
           "ref" : "section-345B",
+          "id" : "section-345B",
+          "href" : "section/345B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "345C",
           "title" : "Duty on publication of statement",
           "ref" : "section-345C",
+          "id" : "section-345C",
+          "href" : "section/345C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "345D",
           "title" : "Imposition of penalties on auditors or actuaries: statement of policy",
           "ref" : "section-345D",
+          "id" : "section-345D",
+          "href" : "section/345D",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "345E",
           "title" : "Statements of policy: procedure",
           "ref" : "section-345E",
+          "id" : "section-345E",
+          "href" : "section/345E",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -18726,12 +21558,16 @@
         "number" : null,
         "title" : " Offence",
         "ref" : "part-XXII-crossheading-offence",
+        "id" : "part-XXII-crossheading-offence",
+        "href" : "part/XXII/crossheading/offence",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "346",
           "title" : " Provision of false or misleading information to auditor or actuary.",
           "ref" : "section-346",
+          "id" : "section-346",
+          "href" : "section/346",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -18740,24 +21576,32 @@
       "number" : "Part XXIII",
       "title" : " Public Record, Disclosure of Information and Co-operation",
       "ref" : "part-XXIII",
+      "id" : "part-XXIII",
+      "href" : "part/XXIII",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : " The public record",
         "ref" : "part-XXIII-crossheading-the-public-record",
+        "id" : "part-XXIII-crossheading-the-public-record",
+        "href" : "part/XXIII/crossheading/the-public-record",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "347",
           "title" : "The record of authorised persons etc.",
           "ref" : "section-347",
+          "id" : "section-347",
+          "href" : "section/347",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "347A",
           "title" : "Duty of PRA to disclose information relevant to the record",
           "ref" : "section-347A",
+          "id" : "section-347A",
+          "href" : "section/347A",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -18765,48 +21609,64 @@
         "number" : null,
         "title" : " Disclosure of information",
         "ref" : "part-XXIII-crossheading-disclosure-of-information",
+        "id" : "part-XXIII-crossheading-disclosure-of-information",
+        "href" : "part/XXIII/crossheading/disclosure-of-information",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "348",
           "title" : "Restrictions on disclosure of confidential information by FCA, PRA etc.",
           "ref" : "section-348",
+          "id" : "section-348",
+          "href" : "section/348",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "349",
           "title" : " Exceptions from section 348.",
           "ref" : "section-349",
+          "id" : "section-349",
+          "href" : "section/349",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "350",
           "title" : " Disclosure of information by the Inland Revenue.",
           "ref" : "section-350",
+          "id" : "section-350",
+          "href" : "section/350",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "351",
           "title" : " Competition information.",
           "ref" : "section-351",
+          "id" : "section-351",
+          "href" : "section/351",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "351A",
           "title" : "Disclosure under the UCITS directive",
           "ref" : "section-351A",
+          "id" : "section-351A",
+          "href" : "section/351A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "352",
           "title" : "Offences.",
           "ref" : "section-352",
+          "id" : "section-352",
+          "href" : "section/352",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "353",
           "title" : " Removal of other restrictions on disclosure.",
           "ref" : "section-353",
+          "id" : "section-353",
+          "href" : "section/353",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -18814,12 +21674,16 @@
         "number" : null,
         "title" : "Information received from Bank of England",
         "ref" : "part-XXIII-crossheading-information-received-from-bank-of-england",
+        "id" : "part-XXIII-crossheading-information-received-from-bank-of-england",
+        "href" : "part/XXIII/crossheading/information-received-from-bank-of-england",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "353A",
           "title" : "Information received from Bank of England",
           "ref" : "section-353A",
+          "id" : "section-353A",
+          "href" : "section/353A",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -18827,30 +21691,40 @@
         "number" : null,
         "title" : " Co-operation",
         "ref" : "part-XXIII-crossheading-cooperation",
+        "id" : "part-XXIII-crossheading-cooperation",
+        "href" : "part/XXIII/crossheading/cooperation",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "354",
           "title" : " Authority’s duty to co-operate with others.",
           "ref" : "section-354",
+          "id" : "section-354",
+          "href" : "section/354",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "354A",
           "title" : "FCA's duty to co-operate with others",
           "ref" : "section-354A",
+          "id" : "section-354A",
+          "href" : "section/354A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "354B",
           "title" : "PRA's duty to co-operate with others",
           "ref" : "section-354B",
+          "id" : "section-354B",
+          "href" : "section/354B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "354C",
           "title" : "PRA's duty to provide information to Bank of England",
           "ref" : "section-354C",
+          "id" : "section-354C",
+          "href" : "section/354C",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -18858,36 +21732,48 @@
         "number" : null,
         "title" : "Provision of information to ESMA, the Commission and other EEA States",
         "ref" : "part-XXIII-crossheading-provision-of-information-to-esma-the-commission-and-other-eea-states",
+        "id" : "part-XXIII-crossheading-provision-of-information-to-esma-the-commission-and-other-eea-states",
+        "href" : "part/XXIII/crossheading/provision-of-information-to-esma-the-commission-and-other-eea-states",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "354D",
           "title" : "Information under the markets in financial instruments directive",
           "ref" : "section-354D",
+          "id" : "section-354D",
+          "href" : "section/354D",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "354E",
           "title" : "Competent authorities under the markets in financial instruments directive: designation and co-operation",
           "ref" : "section-354E",
+          "id" : "section-354E",
+          "href" : "section/354E",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "354F",
           "title" : "Information under the transparency obligations directive",
           "ref" : "section-354F",
+          "id" : "section-354F",
+          "href" : "section/354F",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "354G",
           "title" : "Information under the UCITS directive",
           "ref" : "section-354G",
+          "id" : "section-354G",
+          "href" : "section/354G",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "354H",
           "title" : "Information under the Insurance Distribution Directive",
           "ref" : "section-354H",
+          "id" : "section-354H",
+          "href" : "section/354H",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -18896,18 +21782,24 @@
       "number" : "Part XXIV",
       "title" : " Insolvency",
       "ref" : "part-XXIV",
+      "id" : "part-XXIV",
+      "href" : "part/XXIV",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : " Interpretation",
         "ref" : "part-XXIV-crossheading-interpretation",
+        "id" : "part-XXIV-crossheading-interpretation",
+        "href" : "part/XXIV/crossheading/interpretation",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "355",
           "title" : " Interpretation of this Part.",
           "ref" : "section-355",
+          "id" : "section-355",
+          "href" : "section/355",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -18915,18 +21807,24 @@
         "number" : null,
         "title" : "Arrangements and reconstructions: companies in financial difficulty",
         "ref" : "part-XXIV-crossheading-arrangements-and-reconstructions-companies-in-financial-difficulty",
+        "id" : "part-XXIV-crossheading-arrangements-and-reconstructions-companies-in-financial-difficulty",
+        "href" : "part/XXIV/crossheading/arrangements-and-reconstructions-companies-in-financial-difficulty",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "355A",
           "title" : "Powers of FCA and PRA to participate in proceedings",
           "ref" : "section-355A",
+          "id" : "section-355A",
+          "href" : "section/355A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "355B",
           "title" : "Enforcement of requirements imposed by section 355A",
           "ref" : "section-355B",
+          "id" : "section-355B",
+          "href" : "section/355B",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -18934,24 +21832,32 @@
         "number" : null,
         "title" : " Voluntary arrangements",
         "ref" : "part-XXIV-crossheading-voluntary-arrangements",
+        "id" : "part-XXIV-crossheading-voluntary-arrangements",
+        "href" : "part/XXIV/crossheading/voluntary-arrangements",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "356",
           "title" : "  Powers of FCA and PRA  to participate in proceedings: company voluntary arrangements.",
           "ref" : "section-356",
+          "id" : "section-356",
+          "href" : "section/356",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "357",
           "title" : " Powers of FCA and PRA  to participate in proceedings: individual voluntary arrangements.",
           "ref" : "section-357",
+          "id" : "section-357",
+          "href" : "section/357",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "358",
           "title" : " Powers of FCA and PRA  to participate in proceedings: trust deeds for creditors in Scotland.",
           "ref" : "section-358",
+          "id" : "section-358",
+          "href" : "section/358",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -18959,36 +21865,48 @@
         "number" : null,
         "title" : " Administration orders",
         "ref" : "part-XXIV-crossheading-administration-orders",
+        "id" : "part-XXIV-crossheading-administration-orders",
+        "href" : "part/XXIV/crossheading/administration-orders",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "359",
           "title" : " Administration order",
           "ref" : "section-359",
+          "id" : "section-359",
+          "href" : "section/359",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "360",
           "title" : "Insurers.",
           "ref" : "section-360",
+          "id" : "section-360",
+          "href" : "section/360",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "361",
           "title" : "Administrator’s duty to report to  FCA and PRA ",
           "ref" : "section-361",
+          "id" : "section-361",
+          "href" : "section/361",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "362",
           "title" : " Powers of FCA and PRA  to participate in proceedings.",
           "ref" : "section-362",
+          "id" : "section-362",
+          "href" : "section/362",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "362A",
           "title" : " Administrator appointed by company or directors",
           "ref" : "section-362A",
+          "id" : "section-362A",
+          "href" : "section/362A",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -18996,18 +21914,24 @@
         "number" : null,
         "title" : " Receivership",
         "ref" : "part-XXIV-crossheading-receivership",
+        "id" : "part-XXIV-crossheading-receivership",
+        "href" : "part/XXIV/crossheading/receivership",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "363",
           "title" : "  Powers of FCA and PRA  to participate in proceedings.",
           "ref" : "section-363",
+          "id" : "section-363",
+          "href" : "section/363",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "364",
           "title" : " Receiver’s duty to report to  FCA and PRA ",
           "ref" : "section-364",
+          "id" : "section-364",
+          "href" : "section/364",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -19015,18 +21939,24 @@
         "number" : null,
         "title" : " Voluntary winding up",
         "ref" : "part-XXIV-crossheading-voluntary-winding-up",
+        "id" : "part-XXIV-crossheading-voluntary-winding-up",
+        "href" : "part/XXIV/crossheading/voluntary-winding-up",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "365",
           "title" : "  Powers of FCA and PRA  to participate in proceedings.",
           "ref" : "section-365",
+          "id" : "section-365",
+          "href" : "section/365",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "366",
           "title" : " Insurers effecting or carrying out long-term contracts or insurance.",
           "ref" : "section-366",
+          "id" : "section-366",
+          "href" : "section/366",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -19034,42 +21964,56 @@
         "number" : null,
         "title" : " Winding up by the court",
         "ref" : "part-XXIV-crossheading-winding-up-by-the-court",
+        "id" : "part-XXIV-crossheading-winding-up-by-the-court",
+        "href" : "part/XXIV/crossheading/winding-up-by-the-court",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "367",
           "title" : " Winding-up petitions.",
           "ref" : "section-367",
+          "id" : "section-367",
+          "href" : "section/367",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "368",
           "title" : " Winding-up petitions: EEA and Treaty firms.",
           "ref" : "section-368",
+          "id" : "section-368",
+          "href" : "section/368",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "369",
           "title" : " Insurers: service of petition etc. on  FCA and PRA.",
           "ref" : "section-369",
+          "id" : "section-369",
+          "href" : "section/369",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "369A",
           "title" : "Reclaim funds: service of petition etc on  FCA and PRA ",
           "ref" : "section-369A",
+          "id" : "section-369A",
+          "href" : "section/369A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "370",
           "title" : "Liquidator's duty to report to FCA and PRA",
           "ref" : "section-370",
+          "id" : "section-370",
+          "href" : "section/370",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "371",
           "title" : " Powers of FCA and PRA  to participate in proceedings.",
           "ref" : "section-371",
+          "id" : "section-371",
+          "href" : "section/371",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -19077,24 +22021,32 @@
         "number" : null,
         "title" : " Bankruptcy",
         "ref" : "part-XXIV-crossheading-bankruptcy",
+        "id" : "part-XXIV-crossheading-bankruptcy",
+        "href" : "part/XXIV/crossheading/bankruptcy",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "372",
           "title" : " Petitions.",
           "ref" : "section-372",
+          "id" : "section-372",
+          "href" : "section/372",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "373",
           "title" : " Insolvency practitioner’s duty to report  to FCA and PRA.",
           "ref" : "section-373",
+          "id" : "section-373",
+          "href" : "section/373",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "374",
           "title" : " Powers of FCA or PRA  to participate in proceedings.",
           "ref" : "section-374",
+          "id" : "section-374",
+          "href" : "section/374",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -19102,12 +22054,16 @@
         "number" : null,
         "title" : " Provisions against debt avoidance",
         "ref" : "part-XXIV-crossheading-provisions-against-debt-avoidance",
+        "id" : "part-XXIV-crossheading-provisions-against-debt-avoidance",
+        "href" : "part/XXIV/crossheading/provisions-against-debt-avoidance",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "375",
           "title" : "  Right of FCA and PRA  to apply for an order.",
           "ref" : "section-375",
+          "id" : "section-375",
+          "href" : "section/375",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -19115,96 +22071,128 @@
         "number" : null,
         "title" : "Supplemental provisions concerning insurers",
         "ref" : "part-XXIV-crossheading-supplemental-provisions-concerning-insurers",
+        "id" : "part-XXIV-crossheading-supplemental-provisions-concerning-insurers",
+        "href" : "part/XXIV/crossheading/supplemental-provisions-concerning-insurers",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "376",
           "title" : "Continuation of contracts of long-term insurance where insurer in liquidation.",
           "ref" : "section-376",
+          "id" : "section-376",
+          "href" : "section/376",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "377",
           "title" : "Reducing the value of contracts instead of winding up.",
           "ref" : "section-377",
+          "id" : "section-377",
+          "href" : "section/377",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "377A",
           "title" : "Write-down orders",
           "ref" : "section-377A",
+          "id" : "section-377A",
+          "href" : "section/377A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "377B",
           "title" : "Excluded liabilities",
           "ref" : "section-377B",
+          "id" : "section-377B",
+          "href" : "section/377B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "377C",
           "title" : "Application for a write-down order",
           "ref" : "section-377C",
+          "id" : "section-377C",
+          "href" : "section/377C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "377D",
           "title" : "Powers of the FCA and PRA to participate in proceedings",
           "ref" : "section-377D",
+          "id" : "section-377D",
+          "href" : "section/377D",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "377E",
           "title" : "Powers of the court",
           "ref" : "section-377E",
+          "id" : "section-377E",
+          "href" : "section/377E",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "377F",
           "title" : "Duty to notify creditors",
           "ref" : "section-377F",
+          "id" : "section-377F",
+          "href" : "section/377F",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "377G",
           "title" : "The manager",
           "ref" : "section-377G",
+          "id" : "section-377G",
+          "href" : "section/377G",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "377H",
           "title" : "Write-down order ceasing to have effect",
           "ref" : "section-377H",
+          "id" : "section-377H",
+          "href" : "section/377H",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "377I",
           "title" : "Variation or revocation of a write-down order",
           "ref" : "section-377I",
+          "id" : "section-377I",
+          "href" : "section/377I",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "377J",
           "title" : "Further provision about write-down orders",
           "ref" : "section-377J",
+          "id" : "section-377J",
+          "href" : "section/377J",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "377K",
           "title" : "Insurers in financial difficulties: enforcement of contracts",
           "ref" : "section-377K",
+          "id" : "section-377K",
+          "href" : "section/377K",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "378",
           "title" : "Treatment of assets on winding up.",
           "ref" : "section-378",
+          "id" : "section-378",
+          "href" : "section/378",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "379",
           "title" : "Winding-up rules.",
           "ref" : "section-379",
+          "id" : "section-379",
+          "href" : "section/379",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -19212,12 +22200,16 @@
         "number" : null,
         "title" : "Settlement finality",
         "ref" : "part-XXIV-crossheading-settlement-finality",
+        "id" : "part-XXIV-crossheading-settlement-finality",
+        "href" : "part/XXIV/crossheading/settlement-finality",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "379A",
           "title" : "Power to apply settlement finality regime to payment institutions",
           "ref" : "section-379A",
+          "id" : "section-379A",
+          "href" : "section/379A",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -19226,24 +22218,32 @@
       "number" : "Part XXV",
       "title" : " Injunctions and Restitution",
       "ref" : "part-XXV",
+      "id" : "part-XXV",
+      "href" : "part/XXV",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : " Injunctions",
         "ref" : "part-XXV-crossheading-injunctions",
+        "id" : "part-XXV-crossheading-injunctions",
+        "href" : "part/XXV/crossheading/injunctions",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "380",
           "title" : "Injunctions.",
           "ref" : "section-380",
+          "id" : "section-380",
+          "href" : "section/380",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "381",
           "title" : " Injunctions in cases of market abuse.",
           "ref" : "section-381",
+          "id" : "section-381",
+          "href" : "section/381",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -19251,18 +22251,24 @@
         "number" : null,
         "title" : " Restitution orders",
         "ref" : "part-XXV-crossheading-restitution-orders",
+        "id" : "part-XXV-crossheading-restitution-orders",
+        "href" : "part/XXV/crossheading/restitution-orders",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "382",
           "title" : "Restitution orders.",
           "ref" : "section-382",
+          "id" : "section-382",
+          "href" : "section/382",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "383",
           "title" : " Restitution orders in cases of market abuse.",
           "ref" : "section-383",
+          "id" : "section-383",
+          "href" : "section/383",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -19270,24 +22276,32 @@
         "number" : null,
         "title" : " Restitution required by  FCA or PRA ",
         "ref" : "part-XXV-crossheading-restitution-required-by-authority",
+        "id" : "part-XXV-crossheading-restitution-required-by-authority",
+        "href" : "part/XXV/crossheading/restitution-required-by-authority",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "384",
           "title" : " Power of  FCA or PRA  to require restitution.",
           "ref" : "section-384",
+          "id" : "section-384",
+          "href" : "section/384",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "385",
           "title" : " Warning notices.",
           "ref" : "section-385",
+          "id" : "section-385",
+          "href" : "section/385",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "386",
           "title" : " Decision notices.",
           "ref" : "section-386",
+          "id" : "section-386",
+          "href" : "section/386",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -19296,18 +22310,24 @@
       "number" : "Part XXVI",
       "title" : " Notices",
       "ref" : "part-XXVI",
+      "id" : "part-XXVI",
+      "href" : "part/XXVI",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : " Warning notices",
         "ref" : "part-XXVI-crossheading-warning-notices",
+        "id" : "part-XXVI-crossheading-warning-notices",
+        "href" : "part/XXVI/crossheading/warning-notices",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "387",
           "title" : " Warning notices.",
           "ref" : "section-387",
+          "id" : "section-387",
+          "href" : "section/387",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -19315,12 +22335,16 @@
         "number" : null,
         "title" : " Decision notices",
         "ref" : "part-XXVI-crossheading-decision-notices",
+        "id" : "part-XXVI-crossheading-decision-notices",
+        "href" : "part/XXVI/crossheading/decision-notices",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "388",
           "title" : "Decision notices.",
           "ref" : "section-388",
+          "id" : "section-388",
+          "href" : "section/388",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -19328,18 +22352,24 @@
         "number" : null,
         "title" : " Conclusion of proceedings",
         "ref" : "part-XXVI-crossheading-conclusion-of-proceedings",
+        "id" : "part-XXVI-crossheading-conclusion-of-proceedings",
+        "href" : "part/XXVI/crossheading/conclusion-of-proceedings",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "389",
           "title" : " Notices of discontinuance.",
           "ref" : "section-389",
+          "id" : "section-389",
+          "href" : "section/389",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "390",
           "title" : " Final notices.",
           "ref" : "section-390",
+          "id" : "section-390",
+          "href" : "section/390",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -19347,48 +22377,64 @@
         "number" : null,
         "title" : " Publication",
         "ref" : "part-XXVI-crossheading-publication",
+        "id" : "part-XXVI-crossheading-publication",
+        "href" : "part/XXVI/crossheading/publication",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "391",
           "title" : "Publication.",
           "ref" : "section-391",
+          "id" : "section-391",
+          "href" : "section/391",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "391A",
           "title" : "Publication: special provisions relating to  capital requirements ",
           "ref" : "section-391A",
+          "id" : "section-391A",
+          "href" : "section/391A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "391B",
           "title" : "Publication: special provisions relating to  transparency obligations ",
           "ref" : "section-391B",
+          "id" : "section-391B",
+          "href" : "section/391B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "391C",
           "title" : "Publication: special provisions relating to  UCITS ",
           "ref" : "section-391C",
+          "id" : "section-391C",
+          "href" : "section/391C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "391D",
           "title" : "Publication: special provisions relating to  markets in financial instruments ",
           "ref" : "section-391D",
+          "id" : "section-391D",
+          "href" : "section/391D",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "391E",
           "title" : "Publication: special provisions relating to  insurance distribution ",
           "ref" : "section-391E",
+          "id" : "section-391E",
+          "href" : "section/391E",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "391F",
           "title" : "Publication: special provisions relating to the prospectus regulation",
           "ref" : "section-391F",
+          "id" : "section-391F",
+          "href" : "section/391F",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -19396,24 +22442,32 @@
         "number" : null,
         "title" : " Third party rights and access to evidence",
         "ref" : "part-XXVI-crossheading-third-party-rights-and-access-to-evidence",
+        "id" : "part-XXVI-crossheading-third-party-rights-and-access-to-evidence",
+        "href" : "part/XXVI/crossheading/third-party-rights-and-access-to-evidence",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "392",
           "title" : "Application of sections 393 and 394.",
           "ref" : "section-392",
+          "id" : "section-392",
+          "href" : "section/392",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "393",
           "title" : "Third party rights.",
           "ref" : "section-393",
+          "id" : "section-393",
+          "href" : "section/393",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "394",
           "title" : "Access to FCA or PRA material.",
           "ref" : "section-394",
+          "id" : "section-394",
+          "href" : "section/394",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -19421,18 +22475,24 @@
         "number" : null,
         "title" : " The  FCA's and PRA's  procedures",
         "ref" : "part-XXVI-crossheading-the-authoritys-procedures",
+        "id" : "part-XXVI-crossheading-the-authoritys-procedures",
+        "href" : "part/XXVI/crossheading/the-authoritys-procedures",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "395",
           "title" : "The FCA's and PRA's procedures.",
           "ref" : "section-395",
+          "id" : "section-395",
+          "href" : "section/395",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "396",
           "title" : " Statements under section 395: consultation.",
           "ref" : "section-396",
+          "id" : "section-396",
+          "href" : "section/396",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -19441,30 +22501,40 @@
       "number" : "Part XXVII",
       "title" : " Offences",
       "ref" : "part-XXVII",
+      "id" : "part-XXVII",
+      "href" : "part/XXVII",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : " Miscellaneous offences",
         "ref" : "part-XXVII-crossheading-miscellaneous-offences",
+        "id" : "part-XXVII-crossheading-miscellaneous-offences",
+        "href" : "part/XXVII/crossheading/miscellaneous-offences",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "397",
           "title" : " Misleading statements and practices.",
           "ref" : "section-397",
+          "id" : "section-397",
+          "href" : "section/397",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "398",
           "title" : "Misleading FCA or PRA: residual cases.",
           "ref" : "section-398",
+          "id" : "section-398",
+          "href" : "section/398",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "399",
           "title" : " Misleading   the CMA.",
           "ref" : "section-399",
+          "id" : "section-399",
+          "href" : "section/399",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -19472,12 +22542,16 @@
         "number" : null,
         "title" : " Bodies corporate and partnerships",
         "ref" : "part-XXVII-crossheading-bodies-corporate-and-partnerships",
+        "id" : "part-XXVII-crossheading-bodies-corporate-and-partnerships",
+        "href" : "part/XXVII/crossheading/bodies-corporate-and-partnerships",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "400",
           "title" : "Offences by bodies corporate etc.",
           "ref" : "section-400",
+          "id" : "section-400",
+          "href" : "section/400",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -19485,24 +22559,32 @@
         "number" : null,
         "title" : " Institution of proceedings",
         "ref" : "part-XXVII-crossheading-institution-of-proceedings",
+        "id" : "part-XXVII-crossheading-institution-of-proceedings",
+        "href" : "part/XXVII/crossheading/institution-of-proceedings",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "401",
           "title" : "Proceedings for offences.",
           "ref" : "section-401",
+          "id" : "section-401",
+          "href" : "section/401",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "402",
           "title" : " Power of FCA  to institute proceedings for certain other offences.",
           "ref" : "section-402",
+          "id" : "section-402",
+          "href" : "section/402",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "403",
           "title" : "Jurisdiction and procedure in respect of offences.",
           "ref" : "section-403",
+          "id" : "section-403",
+          "href" : "section/403",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -19511,60 +22593,80 @@
       "number" : "Part XXVIII",
       "title" : "Miscellaneous",
       "ref" : "part-XXVIII",
+      "id" : "part-XXVIII",
+      "href" : "part/XXVIII",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : "Consumer redress schemes",
         "ref" : "part-XXVIII-crossheading-schemes-for-reviewing-past-business",
+        "id" : "part-XXVIII-crossheading-schemes-for-reviewing-past-business",
+        "href" : "part/XXVIII/crossheading/schemes-for-reviewing-past-business",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "404",
           "title" : "Consumer redress schemes",
           "ref" : "section-404",
+          "id" : "section-404",
+          "href" : "section/404",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "404A",
           "title" : "Rules under s.404: supplementary",
           "ref" : "section-404A",
+          "id" : "section-404A",
+          "href" : "section/404A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "404B",
           "title" : "Complaints to the ombudsman scheme",
           "ref" : "section-404B",
+          "id" : "section-404B",
+          "href" : "section/404B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "404C",
           "title" : "Enforcement",
           "ref" : "section-404C",
+          "id" : "section-404C",
+          "href" : "section/404C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "404D",
           "title" : "Applications to Tribunal to quash rules or provision of rules",
           "ref" : "section-404D",
+          "id" : "section-404D",
+          "href" : "section/404D",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "404E",
           "title" : "Meaning of “consumers”",
           "ref" : "section-404E",
+          "id" : "section-404E",
+          "href" : "section/404E",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "404F",
           "title" : "Other definitions etc",
           "ref" : "section-404F",
+          "id" : "section-404F",
+          "href" : "section/404F",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "404G",
           "title" : "Power to widen the scope of consumer redress schemes",
           "ref" : "section-404G",
+          "id" : "section-404G",
+          "href" : "section/404G",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -19572,36 +22674,48 @@
         "number" : null,
         "title" : "Third countries",
         "ref" : "part-XXVIII-crossheading-third-countries",
+        "id" : "part-XXVIII-crossheading-third-countries",
+        "href" : "part/XXVIII/crossheading/third-countries",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "405",
           "title" : "Directions.",
           "ref" : "section-405",
+          "id" : "section-405",
+          "href" : "section/405",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "406",
           "title" : "Interpretation of section 405.",
           "ref" : "section-406",
+          "id" : "section-406",
+          "href" : "section/406",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "407",
           "title" : "Consequences of a direction under section 405.",
           "ref" : "section-407",
+          "id" : "section-407",
+          "href" : "section/407",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "408",
           "title" : "EFTA firms.",
           "ref" : "section-408",
+          "id" : "section-408",
+          "href" : "section/408",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "409",
           "title" : "Gibraltar.",
           "ref" : "section-409",
+          "id" : "section-409",
+          "href" : "section/409",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -19609,24 +22723,32 @@
         "number" : null,
         "title" : "International powers and obligations",
         "ref" : "part-XXVIII-crossheading-international-obligations",
+        "id" : "part-XXVIII-crossheading-international-obligations",
+        "href" : "part/XXVIII/crossheading/international-obligations",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "409A",
           "title" : "Consultation in relation to deference decisions",
           "ref" : "section-409A",
+          "id" : "section-409A",
+          "href" : "section/409A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "409B",
           "title" : "Notification in relation to international trade obligations",
           "ref" : "section-409B",
+          "id" : "section-409B",
+          "href" : "section/409B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "410",
           "title" : "International obligations.",
           "ref" : "section-410",
+          "id" : "section-410",
+          "href" : "section/410",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -19634,18 +22756,24 @@
         "number" : null,
         "title" : "Fees to meet Treasury expenses",
         "ref" : "part-XXVIII-crossheading-fees-to-meet-treasury-expenses",
+        "id" : "part-XXVIII-crossheading-fees-to-meet-treasury-expenses",
+        "href" : "part/XXVIII/crossheading/fees-to-meet-treasury-expenses",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "410A",
           "title" : "Fees to meet certain expenses of the Treasury",
           "ref" : "section-410A",
+          "id" : "section-410A",
+          "href" : "section/410A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "410B",
           "title" : "Directions in pursuance of section 410A",
           "ref" : "section-410B",
+          "id" : "section-410B",
+          "href" : "section/410B",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -19653,12 +22781,16 @@
         "number" : null,
         "title" : "Tax treatment of levies and repayments",
         "ref" : "part-XXVIII-crossheading-tax-treatment-of-levies-and-repayments",
+        "id" : "part-XXVIII-crossheading-tax-treatment-of-levies-and-repayments",
+        "href" : "part/XXVIII/crossheading/tax-treatment-of-levies-and-repayments",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "411",
           "title" : "Tax treatment of levies and repayments.",
           "ref" : "section-411",
+          "id" : "section-411",
+          "href" : "section/411",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -19666,12 +22798,16 @@
         "number" : null,
         "title" : "Gaming contracts",
         "ref" : "part-XXVIII-crossheading-gaming-contracts",
+        "id" : "part-XXVIII-crossheading-gaming-contracts",
+        "href" : "part/XXVIII/crossheading/gaming-contracts",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "412",
           "title" : "Gaming contracts.",
           "ref" : "section-412",
+          "id" : "section-412",
+          "href" : "section/412",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -19679,18 +22815,24 @@
         "number" : null,
         "title" : "Trade-matching and reporting systems",
         "ref" : "part-XXVIII-crossheading-tradematching-and-reporting-systems",
+        "id" : "part-XXVIII-crossheading-tradematching-and-reporting-systems",
+        "href" : "part/XXVIII/crossheading/tradematching-and-reporting-systems",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "412A",
           "title" : "Approval and monitoring of trade-matching and reporting systems",
           "ref" : "section-412A",
+          "id" : "section-412A",
+          "href" : "section/412A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "412B",
           "title" : "Procedure for approval and suspension or withdrawal of approval",
           "ref" : "section-412B",
+          "id" : "section-412B",
+          "href" : "section/412B",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -19698,12 +22840,16 @@
         "number" : null,
         "title" : "Limitation on powers to require documents",
         "ref" : "part-XXVIII-crossheading-limitation-on-powers-to-require-documents",
+        "id" : "part-XXVIII-crossheading-limitation-on-powers-to-require-documents",
+        "href" : "part/XXVIII/crossheading/limitation-on-powers-to-require-documents",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "413",
           "title" : "Protected items.",
           "ref" : "section-413",
+          "id" : "section-413",
+          "href" : "section/413",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -19711,12 +22857,16 @@
         "number" : null,
         "title" : "Service of notices",
         "ref" : "part-XXVIII-crossheading-service-of-notices",
+        "id" : "part-XXVIII-crossheading-service-of-notices",
+        "href" : "part/XXVIII/crossheading/service-of-notices",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "414",
           "title" : "Service of notices.",
           "ref" : "section-414",
+          "id" : "section-414",
+          "href" : "section/414",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -19724,12 +22874,16 @@
         "number" : null,
         "title" : "Jurisdiction",
         "ref" : "part-XXVIII-crossheading-jurisdiction",
+        "id" : "part-XXVIII-crossheading-jurisdiction",
+        "href" : "part/XXVIII/crossheading/jurisdiction",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "415",
           "title" : "Jurisdiction in civil proceedings.",
           "ref" : "section-415",
+          "id" : "section-415",
+          "href" : "section/415",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -19737,18 +22891,24 @@
         "number" : null,
         "title" : "Powers under the Act",
         "ref" : "part-XXVIII-crossheading-powers-of-the-authority",
+        "id" : "part-XXVIII-crossheading-powers-of-the-authority",
+        "href" : "part/XXVIII/crossheading/powers-of-the-authority",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "415A",
           "title" : "Powers under the Act",
           "ref" : "section-415A",
+          "id" : "section-415A",
+          "href" : "section/415A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "415AA",
           "title" : "Application of powers to formerly authorised persons",
           "ref" : "section-415AA",
+          "id" : "section-415AA",
+          "href" : "section/415AA",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -19756,18 +22916,24 @@
         "number" : null,
         "title" : "Consultation and co-operation",
         "ref" : "part-XXVIII-crossheading-consultation",
+        "id" : "part-XXVIII-crossheading-consultation",
+        "href" : "part/XXVIII/crossheading/consultation",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "415B",
           "title" : "Consultation in relation to taking certain enforcement action",
           "ref" : "section-415B",
+          "id" : "section-415B",
+          "href" : "section/415B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "415C",
           "title" : "Co-operation and consultation in relation to exercise of functions",
           "ref" : "section-415C",
+          "id" : "section-415C",
+          "href" : "section/415C",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -19775,12 +22941,16 @@
         "number" : null,
         "title" : "Removal of certain unnecessary provisions",
         "ref" : "part-XXVIII-crossheading-removal-of-certain-unnecessary-provisions",
+        "id" : "part-XXVIII-crossheading-removal-of-certain-unnecessary-provisions",
+        "href" : "part/XXVIII/crossheading/removal-of-certain-unnecessary-provisions",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "416",
           "title" : "Provisions relating to industrial assurance and certain other enactments.",
           "ref" : "section-416",
+          "id" : "section-416",
+          "href" : "section/416",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -19788,18 +22958,24 @@
         "number" : null,
         "title" : "Sustainability disclosure requirements",
         "ref" : "part-XXVIII-crossheading-sustainability-disclosure-requirements",
+        "id" : "part-XXVIII-crossheading-sustainability-disclosure-requirements",
+        "href" : "part/XXVIII/crossheading/sustainability-disclosure-requirements",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "416A",
           "title" : "SDR policy statement",
           "ref" : "section-416A",
+          "id" : "section-416A",
+          "href" : "section/416A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "416B",
           "title" : "FCA and PRA rules etc",
           "ref" : "section-416B",
+          "id" : "section-416B",
+          "href" : "section/416B",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -19808,120 +22984,160 @@
       "number" : "Part XXIX",
       "title" : " Interpretation",
       "ref" : "part-XXIX",
+      "id" : "part-XXIX",
+      "href" : "part/XXIX",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "417",
         "title" : "Definitions.",
         "ref" : "section-417",
+        "id" : "section-417",
+        "href" : "section/417",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "418",
         "title" : " Carrying on regulated activities in the United Kingdom.",
         "ref" : "section-418",
+        "id" : "section-418",
+        "href" : "section/418",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "419",
         "title" : " Carrying on regulated activities by way of business.",
         "ref" : "section-419",
+        "id" : "section-419",
+        "href" : "section/419",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "419A",
         "title" : "Claims management services",
         "ref" : "section-419A",
+        "id" : "section-419A",
+        "href" : "section/419A",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "419B",
         "title" : "Carrying on claims management activity in Great Britain",
         "ref" : "section-419B",
+        "id" : "section-419B",
+        "href" : "section/419B",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "420",
         "title" : " Parent and subsidiary undertaking.",
         "ref" : "section-420",
+        "id" : "section-420",
+        "href" : "section/420",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "421",
         "title" : " Group.",
         "ref" : "section-421",
+        "id" : "section-421",
+        "href" : "section/421",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "421ZA",
         "title" : "Immediate group",
         "ref" : "section-421ZA",
+        "id" : "section-421ZA",
+        "href" : "section/421ZA",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "421A",
         "title" : "Meaning of  “participating interest”",
         "ref" : "section-421A",
+        "id" : "section-421A",
+        "href" : "section/421A",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "422",
         "title" : " Controller.",
         "ref" : "section-422",
+        "id" : "section-422",
+        "href" : "section/422",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "422A",
         "title" : "Disregarded holdings",
         "ref" : "section-422A",
+        "id" : "section-422A",
+        "href" : "section/422A",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "423",
         "title" : " Manager.",
         "ref" : "section-423",
+        "id" : "section-423",
+        "href" : "section/423",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "423A",
         "title" : "Mortgage agreements etc",
         "ref" : "section-423A",
+        "id" : "section-423A",
+        "href" : "section/423A",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "424",
         "title" : " Insurance.",
         "ref" : "section-424",
+        "id" : "section-424",
+        "href" : "section/424",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "424A",
         "title" : "Investment firm",
         "ref" : "section-424A",
+        "id" : "section-424A",
+        "href" : "section/424A",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "425",
         "title" : " Expressions relating to authorisation ... in the single market.",
         "ref" : "section-425",
+        "id" : "section-425",
+        "href" : "section/425",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "425A",
         "title" : "Consumers: regulated activities etc carried on by authorised persons",
         "ref" : "section-425A",
+        "id" : "section-425A",
+        "href" : "section/425A",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "425B",
         "title" : "Consumers: regulated activities carried on by others",
         "ref" : "section-425B",
+        "id" : "section-425B",
+        "href" : "section/425B",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "425C",
         "title" : "“Qualifying provision”",
         "ref" : "section-425C",
+        "id" : "section-425C",
+        "href" : "section/425C",
         "extent" : [ "E", "W", "S", "NI" ]
       } ]
     }, {
@@ -19929,54 +23145,72 @@
       "number" : "Part XXX",
       "title" : " Supplemental",
       "ref" : "part-XXX",
+      "id" : "part-XXX",
+      "href" : "part/XXX",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "426",
         "title" : " Consequential and supplementary provision.",
         "ref" : "section-426",
+        "id" : "section-426",
+        "href" : "section/426",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "427",
         "title" : "Transitional provisions.",
         "ref" : "section-427",
+        "id" : "section-427",
+        "href" : "section/427",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "428",
         "title" : "Regulations and orders.",
         "ref" : "section-428",
+        "id" : "section-428",
+        "href" : "section/428",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "429",
         "title" : "Parliamentary control of statutory instruments.",
         "ref" : "section-429",
+        "id" : "section-429",
+        "href" : "section/429",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "430",
         "title" : " Extent.",
         "ref" : "section-430",
+        "id" : "section-430",
+        "href" : "section/430",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "431",
         "title" : " Commencement.",
         "ref" : "section-431",
+        "id" : "section-431",
+        "href" : "section/431",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "432",
         "title" : " Minor and consequential amendments, transitional provisions and repeals.",
         "ref" : "section-432",
+        "id" : "section-432",
+        "href" : "section/432",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "433",
         "title" : " Short title.",
         "ref" : "section-433",
+        "id" : "section-433",
+        "href" : "section/433",
         "extent" : [ "E", "W", "S", "NI" ]
       } ]
     } ],
@@ -19985,24 +23219,32 @@
       "number" : "SCHEDULE 1",
       "title" : " The Financial Services Authority",
       "ref" : "schedule-1",
+      "id" : "schedule-1",
+      "href" : "schedule/1",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "part",
         "number" : "Part I",
         "title" : " General",
         "ref" : "schedule-1-part-I",
+        "id" : "schedule-1-part-I",
+        "href" : "schedule/1/part/I",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : " Interpretation",
           "ref" : "schedule-1-part-I-crossheading-interpretation",
+          "id" : "schedule-1-part-I-crossheading-interpretation",
+          "href" : "schedule/1/part/I/crossheading/interpretation",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "1",
             "title" : " The Financial Services Authority",
             "ref" : "schedule-1-paragraph-1",
+            "id" : "schedule-1-paragraph-1",
+            "href" : "schedule/1/paragraph/1",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20010,12 +23252,16 @@
           "number" : null,
           "title" : " Constitution",
           "ref" : "schedule-1-part-I-crossheading-constitution",
+          "id" : "schedule-1-part-I-crossheading-constitution",
+          "href" : "schedule/1/part/I/crossheading/constitution",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "2",
             "title" : "(1) The constitution of the Authority must continue to provide...",
             "ref" : "schedule-1-paragraph-2",
+            "id" : "schedule-1-paragraph-2",
+            "href" : "schedule/1/paragraph/2",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20023,12 +23269,16 @@
           "number" : null,
           "title" : " Non-executive members of the governing body",
           "ref" : "schedule-1-part-I-crossheading-nonexecutive-members-of-the-governing-body",
+          "id" : "schedule-1-part-I-crossheading-nonexecutive-members-of-the-governing-body",
+          "href" : "schedule/1/part/I/crossheading/nonexecutive-members-of-the-governing-body",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "3",
             "title" : "(1) The Authority must secure— (a) that the majority of...",
             "ref" : "schedule-1-paragraph-3",
+            "id" : "schedule-1-paragraph-3",
+            "href" : "schedule/1/paragraph/3",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20036,12 +23286,16 @@
           "number" : null,
           "title" : " Functions of the non-executive committee",
           "ref" : "schedule-1-part-I-crossheading-functions-of-the-nonexecutive-committee",
+          "id" : "schedule-1-part-I-crossheading-functions-of-the-nonexecutive-committee",
+          "href" : "schedule/1/part/I/crossheading/functions-of-the-nonexecutive-committee",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "4",
             "title" : "(1) In this paragraph “the committee” means the non-executive committee....",
             "ref" : "schedule-1-paragraph-4",
+            "id" : "schedule-1-paragraph-4",
+            "href" : "schedule/1/paragraph/4",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20049,12 +23303,16 @@
           "number" : null,
           "title" : " Arrangements for discharging functions",
           "ref" : "schedule-1-part-I-crossheading-arrangements-for-discharging-functions",
+          "id" : "schedule-1-part-I-crossheading-arrangements-for-discharging-functions",
+          "href" : "schedule/1/part/I/crossheading/arrangements-for-discharging-functions",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "5",
             "title" : "(1) The Authority may make arrangements for any of its...",
             "ref" : "schedule-1-paragraph-5",
+            "id" : "schedule-1-paragraph-5",
+            "href" : "schedule/1/paragraph/5",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20062,12 +23320,16 @@
           "number" : null,
           "title" : " Monitoring and enforcement",
           "ref" : "schedule-1-part-I-crossheading-monitoring-and-enforcement",
+          "id" : "schedule-1-part-I-crossheading-monitoring-and-enforcement",
+          "href" : "schedule/1/part/I/crossheading/monitoring-and-enforcement",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "6",
             "title" : "(1) The Authority must maintain arrangements designed to enable it...",
             "ref" : "schedule-1-paragraph-6",
+            "id" : "schedule-1-paragraph-6",
+            "href" : "schedule/1/paragraph/6",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20075,12 +23337,16 @@
           "number" : null,
           "title" : " Arrangements for the investigation of complaints",
           "ref" : "schedule-1-part-I-crossheading-arrangements-for-the-investigation-of-complaints",
+          "id" : "schedule-1-part-I-crossheading-arrangements-for-the-investigation-of-complaints",
+          "href" : "schedule/1/part/I/crossheading/arrangements-for-the-investigation-of-complaints",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "7",
             "title" : "(1) The Authority must— (a) make arrangements (“the complaints scheme”)...",
             "ref" : "schedule-1-paragraph-7",
+            "id" : "schedule-1-paragraph-7",
+            "href" : "schedule/1/paragraph/7",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20088,12 +23354,16 @@
           "number" : null,
           "title" : " Investigation of complaints",
           "ref" : "schedule-1-part-I-crossheading-investigation-of-complaints",
+          "id" : "schedule-1-part-I-crossheading-investigation-of-complaints",
+          "href" : "schedule/1/part/I/crossheading/investigation-of-complaints",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "8",
             "title" : "(1) The Authority is not obliged to investigate a complaint...",
             "ref" : "schedule-1-paragraph-8",
+            "id" : "schedule-1-paragraph-8",
+            "href" : "schedule/1/paragraph/8",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20101,12 +23371,16 @@
           "number" : null,
           "title" : " Records",
           "ref" : "schedule-1-part-I-crossheading-records",
+          "id" : "schedule-1-part-I-crossheading-records",
+          "href" : "schedule/1/part/I/crossheading/records",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "9",
             "title" : "The Authority must maintain satisfactory arrangements for— ",
             "ref" : "schedule-1-paragraph-9",
+            "id" : "schedule-1-paragraph-9",
+            "href" : "schedule/1/paragraph/9",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20114,12 +23388,16 @@
           "number" : null,
           "title" : " Annual report",
           "ref" : "schedule-1-part-I-crossheading-annual-report",
+          "id" : "schedule-1-part-I-crossheading-annual-report",
+          "href" : "schedule/1/part/I/crossheading/annual-report",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "10",
             "title" : "(1) At least once a year the Authority must make...",
             "ref" : "schedule-1-paragraph-10",
+            "id" : "schedule-1-paragraph-10",
+            "href" : "schedule/1/paragraph/10",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20127,12 +23405,16 @@
           "number" : null,
           "title" : " Annual public meeting",
           "ref" : "schedule-1-part-I-crossheading-annual-public-meeting",
+          "id" : "schedule-1-part-I-crossheading-annual-public-meeting",
+          "href" : "schedule/1/part/I/crossheading/annual-public-meeting",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "11",
             "title" : "(1) Not later than three months after making a report...",
             "ref" : "schedule-1-paragraph-11",
+            "id" : "schedule-1-paragraph-11",
+            "href" : "schedule/1/paragraph/11",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20140,12 +23422,16 @@
           "number" : null,
           "title" : " Report of annual meeting",
           "ref" : "schedule-1-part-I-crossheading-report-of-annual-meeting",
+          "id" : "schedule-1-part-I-crossheading-report-of-annual-meeting",
+          "href" : "schedule/1/part/I/crossheading/report-of-annual-meeting",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "12",
             "title" : "Not later than one month after its annual meeting, the...",
             "ref" : "schedule-1-paragraph-12",
+            "id" : "schedule-1-paragraph-12",
+            "href" : "schedule/1/paragraph/12",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -20154,30 +23440,40 @@
         "number" : "Part II",
         "title" : " Status",
         "ref" : "schedule-1-part-II",
+        "id" : "schedule-1-part-II",
+        "href" : "schedule/1/part/II",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "13",
           "title" : "In relation to any of its functions— ",
           "ref" : "schedule-1-paragraph-13",
+          "id" : "schedule-1-paragraph-13",
+          "href" : "schedule/1/paragraph/13",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "pblock",
           "number" : null,
           "title" : " Exemption from requirement of “limited” in Authority’s name",
           "ref" : "schedule-1-part-II-crossheading-exemption-from-requirement-of-limited-in-authoritys-name",
+          "id" : "schedule-1-part-II-crossheading-exemption-from-requirement-of-limited-in-authoritys-name",
+          "href" : "schedule/1/part/II/crossheading/exemption-from-requirement-of-limited-in-authoritys-name",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "14",
             "title" : "The Authority is to continue to be exempt from the...",
             "ref" : "schedule-1-paragraph-14",
+            "id" : "schedule-1-paragraph-14",
+            "href" : "schedule/1/paragraph/14",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "15",
             "title" : "If the Secretary of State is satisfied that any action...",
             "ref" : "schedule-1-paragraph-15",
+            "id" : "schedule-1-paragraph-15",
+            "href" : "schedule/1/paragraph/15",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -20186,18 +23482,24 @@
         "number" : "Part III",
         "title" : " Penalties and Fees",
         "ref" : "schedule-1-part-III",
+        "id" : "schedule-1-part-III",
+        "href" : "schedule/1/part/III",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : " Penalties",
           "ref" : "schedule-1-part-III-crossheading-penalties",
+          "id" : "schedule-1-part-III-crossheading-penalties",
+          "href" : "schedule/1/part/III/crossheading/penalties",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "16",
             "title" : "(1) In determining its policy with respect to the amounts...",
             "ref" : "schedule-1-paragraph-16",
+            "id" : "schedule-1-paragraph-16",
+            "href" : "schedule/1/paragraph/16",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20205,12 +23507,16 @@
           "number" : null,
           "title" : " Fees",
           "ref" : "schedule-1-part-III-crossheading-fees",
+          "id" : "schedule-1-part-III-crossheading-fees",
+          "href" : "schedule/1/part/III/crossheading/fees",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "17",
             "title" : "(1) The Authority may make rules providing for the payment...",
             "ref" : "schedule-1-paragraph-17",
+            "id" : "schedule-1-paragraph-17",
+            "href" : "schedule/1/paragraph/17",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20218,12 +23524,16 @@
           "number" : null,
           "title" : " Services for which fees may not be charged",
           "ref" : "schedule-1-part-III-crossheading-services-for-which-fees-may-not-be-charged",
+          "id" : "schedule-1-part-III-crossheading-services-for-which-fees-may-not-be-charged",
+          "href" : "schedule/1/part/III/crossheading/services-for-which-fees-may-not-be-charged",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "18",
             "title" : "The power conferred by paragraph 17 may not be used...",
             "ref" : "schedule-1-paragraph-18",
+            "id" : "schedule-1-paragraph-18",
+            "href" : "schedule/1/paragraph/18",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -20232,24 +23542,32 @@
         "number" : "Part IV",
         "title" : " Miscellaneous",
         "ref" : "schedule-1-part-IV",
+        "id" : "schedule-1-part-IV",
+        "href" : "schedule/1/part/IV",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : " Exemption from liability in damages",
           "ref" : "schedule-1-part-IV-crossheading-exemption-from-liability-in-damages",
+          "id" : "schedule-1-part-IV-crossheading-exemption-from-liability-in-damages",
+          "href" : "schedule/1/part/IV/crossheading/exemption-from-liability-in-damages",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "19",
             "title" : "(1) Neither the Authority nor any person who is, or...",
             "ref" : "schedule-1-paragraph-19",
+            "id" : "schedule-1-paragraph-19",
+            "href" : "schedule/1/paragraph/19",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "19A",
             "title" : "For the purposes of this Act anything done by an...",
             "ref" : "schedule-1-paragraph-19A",
+            "id" : "schedule-1-paragraph-19A",
+            "href" : "schedule/1/paragraph/19A",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20257,12 +23575,16 @@
           "number" : null,
           "title" : "<i>Amounts required by rules to be paid to the Authority</i>",
           "ref" : "schedule-1-part-IV-crossheading-amounts-required-by-rules-to-be-paid-to-the-authority",
+          "id" : "schedule-1-part-IV-crossheading-amounts-required-by-rules-to-be-paid-to-the-authority",
+          "href" : "schedule/1/part/IV/crossheading/amounts-required-by-rules-to-be-paid-to-the-authority",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "19B",
             "title" : "Any amount (other than a fee) which is required by...",
             "ref" : "schedule-1-paragraph-19B",
+            "id" : "schedule-1-paragraph-19B",
+            "href" : "schedule/1/paragraph/19B",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20270,12 +23592,16 @@
           "number" : null,
           "title" : " Disqualification for membership of House of Commons",
           "ref" : "schedule-1-part-IV-crossheading-disqualification-for-membership-of-house-of-commons",
+          "id" : "schedule-1-part-IV-crossheading-disqualification-for-membership-of-house-of-commons",
+          "href" : "schedule/1/part/IV/crossheading/disqualification-for-membership-of-house-of-commons",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "20",
             "title" : "In Part III of Schedule 1 to the House of...",
             "ref" : "schedule-1-paragraph-20",
+            "id" : "schedule-1-paragraph-20",
+            "href" : "schedule/1/paragraph/20",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20283,12 +23609,16 @@
           "number" : null,
           "title" : " Disqualification for membership of Northern Ireland Assembly",
           "ref" : "schedule-1-part-IV-crossheading-disqualification-for-membership-of-northern-ireland-assembly",
+          "id" : "schedule-1-part-IV-crossheading-disqualification-for-membership-of-northern-ireland-assembly",
+          "href" : "schedule/1/part/IV/crossheading/disqualification-for-membership-of-northern-ireland-assembly",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "21",
             "title" : "In Part III of Schedule 1 to the Northern Ireland...",
             "ref" : "schedule-1-paragraph-21",
+            "id" : "schedule-1-paragraph-21",
+            "href" : "schedule/1/paragraph/21",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -20298,24 +23628,32 @@
       "number" : "SCHEDULE 1ZA",
       "title" : "The Financial Conduct Authority",
       "ref" : "schedule-1ZA",
+      "id" : "schedule-1ZA",
+      "href" : "schedule/1ZA",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "part",
         "number" : "PART 1",
         "title" : "General",
         "ref" : "schedule-1ZA-part-1",
+        "id" : "schedule-1ZA-part-1",
+        "href" : "schedule/1ZA/part/1",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Interpretation",
           "ref" : "schedule-1ZA-part-1-crossheading-interpretation",
+          "id" : "schedule-1ZA-part-1-crossheading-interpretation",
+          "href" : "schedule/1ZA/part/1/crossheading/interpretation",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "1",
             "title" : "In this Schedule— “ the Bank ” means the Bank...",
             "ref" : "schedule-1ZA-paragraph-1",
+            "id" : "schedule-1ZA-paragraph-1",
+            "href" : "schedule/1ZA/paragraph/1",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20323,54 +23661,72 @@
           "number" : null,
           "title" : "Constitution",
           "ref" : "schedule-1ZA-part-1-crossheading-constitution",
+          "id" : "schedule-1ZA-part-1-crossheading-constitution",
+          "href" : "schedule/1ZA/part/1/crossheading/constitution",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "2",
             "title" : "(1) The constitution of the FCA must provide for the...",
             "ref" : "schedule-1ZA-paragraph-2",
+            "id" : "schedule-1ZA-paragraph-2",
+            "href" : "schedule/1ZA/paragraph/2",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "2A",
             "title" : "(1) The term of office of a person appointed as...",
             "ref" : "schedule-1ZA-paragraph-2A",
+            "id" : "schedule-1ZA-paragraph-2A",
+            "href" : "schedule/1ZA/paragraph/2A",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "2B",
             "title" : "(1) A person may not be appointed as chief executive...",
             "ref" : "schedule-1ZA-paragraph-2B",
+            "id" : "schedule-1ZA-paragraph-2B",
+            "href" : "schedule/1ZA/paragraph/2B",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "3",
             "title" : "(1) The terms of service of the appointed members are...",
             "ref" : "schedule-1ZA-paragraph-3",
+            "id" : "schedule-1ZA-paragraph-3",
+            "href" : "schedule/1ZA/paragraph/3",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "4",
             "title" : "(1) The Treasury may remove an appointed member from office—...",
             "ref" : "schedule-1ZA-paragraph-4",
+            "id" : "schedule-1ZA-paragraph-4",
+            "href" : "schedule/1ZA/paragraph/4",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "5",
             "title" : "The validity of any act of the FCA is not...",
             "ref" : "schedule-1ZA-paragraph-5",
+            "id" : "schedule-1ZA-paragraph-5",
+            "href" : "schedule/1ZA/paragraph/5",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "6",
             "title" : "The Bank's Deputy Governor for prudential regulation must not take...",
             "ref" : "schedule-1ZA-paragraph-6",
+            "id" : "schedule-1ZA-paragraph-6",
+            "href" : "schedule/1ZA/paragraph/6",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "6A",
             "title" : "(1) The Chair of the Payment Systems Regulator must not...",
             "ref" : "schedule-1ZA-paragraph-6A",
+            "id" : "schedule-1ZA-paragraph-6A",
+            "href" : "schedule/1ZA/paragraph/6A",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20378,12 +23734,16 @@
           "number" : null,
           "title" : "Remuneration",
           "ref" : "schedule-1ZA-part-1-crossheading-remuneration",
+          "id" : "schedule-1ZA-part-1-crossheading-remuneration",
+          "href" : "schedule/1ZA/part/1/crossheading/remuneration",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "7",
             "title" : "The FCA must pay to the appointed members such remuneration...",
             "ref" : "schedule-1ZA-paragraph-7",
+            "id" : "schedule-1ZA-paragraph-7",
+            "href" : "schedule/1ZA/paragraph/7",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20391,12 +23751,16 @@
           "number" : null,
           "title" : "Arrangements for discharging functions",
           "ref" : "schedule-1ZA-part-1-crossheading-arrangements-for-discharging-functions",
+          "id" : "schedule-1ZA-part-1-crossheading-arrangements-for-discharging-functions",
+          "href" : "schedule/1ZA/part/1/crossheading/arrangements-for-discharging-functions",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "8",
             "title" : "(1) The FCA may make arrangements for any of its...",
             "ref" : "schedule-1ZA-paragraph-8",
+            "id" : "schedule-1ZA-paragraph-8",
+            "href" : "schedule/1ZA/paragraph/8",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20404,12 +23768,16 @@
           "number" : null,
           "title" : "Records",
           "ref" : "schedule-1ZA-part-1-crossheading-records",
+          "id" : "schedule-1ZA-part-1-crossheading-records",
+          "href" : "schedule/1ZA/part/1/crossheading/records",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "9",
             "title" : "The FCA must maintain satisfactory arrangements for— ",
             "ref" : "schedule-1ZA-paragraph-9",
+            "id" : "schedule-1ZA-paragraph-9",
+            "href" : "schedule/1ZA/paragraph/9",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20417,12 +23785,16 @@
           "number" : null,
           "title" : "Publication of record of meetings of governing body",
           "ref" : "schedule-1ZA-part-1-crossheading-publication-of-record-of-meetings-of-governing-body",
+          "id" : "schedule-1ZA-part-1-crossheading-publication-of-record-of-meetings-of-governing-body",
+          "href" : "schedule/1ZA/part/1/crossheading/publication-of-record-of-meetings-of-governing-body",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "10",
             "title" : "(1) The FCA must publish a record of each meeting...",
             "ref" : "schedule-1ZA-paragraph-10",
+            "id" : "schedule-1ZA-paragraph-10",
+            "href" : "schedule/1ZA/paragraph/10",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20430,12 +23802,16 @@
           "number" : null,
           "title" : "Annual report",
           "ref" : "schedule-1ZA-part-1-crossheading-annual-report",
+          "id" : "schedule-1ZA-part-1-crossheading-annual-report",
+          "href" : "schedule/1ZA/part/1/crossheading/annual-report",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "11",
             "title" : "(1) At least once a year the FCA must make...",
             "ref" : "schedule-1ZA-paragraph-11",
+            "id" : "schedule-1ZA-paragraph-11",
+            "href" : "schedule/1ZA/paragraph/11",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20443,12 +23819,16 @@
           "number" : null,
           "title" : "Other reports",
           "ref" : "schedule-1ZA-part-1-crossheading-other-reports",
+          "id" : "schedule-1ZA-part-1-crossheading-other-reports",
+          "href" : "schedule/1ZA/part/1/crossheading/other-reports",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "11A",
             "title" : "(1) The Treasury may (subject to this paragraph) at any...",
             "ref" : "schedule-1ZA-paragraph-11A",
+            "id" : "schedule-1ZA-paragraph-11A",
+            "href" : "schedule/1ZA/paragraph/11A",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20456,12 +23836,16 @@
           "number" : null,
           "title" : "Annual public meeting",
           "ref" : "schedule-1ZA-part-1-crossheading-annual-public-meeting",
+          "id" : "schedule-1ZA-part-1-crossheading-annual-public-meeting",
+          "href" : "schedule/1ZA/part/1/crossheading/annual-public-meeting",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "12",
             "title" : "(1) Not later than 3 months after making a report...",
             "ref" : "schedule-1ZA-paragraph-12",
+            "id" : "schedule-1ZA-paragraph-12",
+            "href" : "schedule/1ZA/paragraph/12",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20469,12 +23853,16 @@
           "number" : null,
           "title" : "Report of annual meeting",
           "ref" : "schedule-1ZA-part-1-crossheading-report-of-annual-meeting",
+          "id" : "schedule-1ZA-part-1-crossheading-report-of-annual-meeting",
+          "href" : "schedule/1ZA/part/1/crossheading/report-of-annual-meeting",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "13",
             "title" : "Not later than one month after its annual meeting, the...",
             "ref" : "schedule-1ZA-paragraph-13",
+            "id" : "schedule-1ZA-paragraph-13",
+            "href" : "schedule/1ZA/paragraph/13",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20482,18 +23870,24 @@
           "number" : null,
           "title" : "Accounts and audit",
           "ref" : "schedule-1ZA-part-1-crossheading-accounts-and-audit",
+          "id" : "schedule-1ZA-part-1-crossheading-accounts-and-audit",
+          "href" : "schedule/1ZA/part/1/crossheading/accounts-and-audit",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "14",
             "title" : "(1) The Treasury may— (a) require the FCA to comply...",
             "ref" : "schedule-1ZA-paragraph-14",
+            "id" : "schedule-1ZA-paragraph-14",
+            "href" : "schedule/1ZA/paragraph/14",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "15",
             "title" : "(1) The FCA must send a copy of its annual...",
             "ref" : "schedule-1ZA-paragraph-15",
+            "id" : "schedule-1ZA-paragraph-15",
+            "href" : "schedule/1ZA/paragraph/15",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -20502,18 +23896,24 @@
         "number" : "PART 2",
         "title" : "Status",
         "ref" : "schedule-1ZA-part-2",
+        "id" : "schedule-1ZA-part-2",
+        "href" : "schedule/1ZA/part/2",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Status",
           "ref" : "schedule-1ZA-part-2-crossheading-status",
+          "id" : "schedule-1ZA-part-2-crossheading-status",
+          "href" : "schedule/1ZA/part/2/crossheading/status",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "16",
             "title" : "In relation to any of its functions— ",
             "ref" : "schedule-1ZA-paragraph-16",
+            "id" : "schedule-1ZA-paragraph-16",
+            "href" : "schedule/1ZA/paragraph/16",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20521,18 +23921,24 @@
           "number" : null,
           "title" : "Exemption from requirement for use of “limited” in name of FCA",
           "ref" : "schedule-1ZA-part-2-crossheading-exemption-from-requirement-for-use-of-limited-in-name-of-fca",
+          "id" : "schedule-1ZA-part-2-crossheading-exemption-from-requirement-for-use-of-limited-in-name-of-fca",
+          "href" : "schedule/1ZA/part/2/crossheading/exemption-from-requirement-for-use-of-limited-in-name-of-fca",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "17",
             "title" : "The FCA is to continue to be exempt from the...",
             "ref" : "schedule-1ZA-paragraph-17",
+            "id" : "schedule-1ZA-paragraph-17",
+            "href" : "schedule/1ZA/paragraph/17",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "18",
             "title" : "If the Secretary of State is satisfied that any action...",
             "ref" : "schedule-1ZA-paragraph-18",
+            "id" : "schedule-1ZA-paragraph-18",
+            "href" : "schedule/1ZA/paragraph/18",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -20541,36 +23947,48 @@
         "number" : "PART 3",
         "title" : "Penalties and fees",
         "ref" : "schedule-1ZA-part-3",
+        "id" : "schedule-1ZA-part-3",
+        "href" : "schedule/1ZA/part/3",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Penalties",
           "ref" : "schedule-1ZA-part-3-crossheading-penalties",
+          "id" : "schedule-1ZA-part-3-crossheading-penalties",
+          "href" : "schedule/1ZA/part/3/crossheading/penalties",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "19",
             "title" : "In determining its policy with respect to the amounts of...",
             "ref" : "schedule-1ZA-paragraph-19",
+            "id" : "schedule-1ZA-paragraph-19",
+            "href" : "schedule/1ZA/paragraph/19",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "20",
             "title" : "(1) The FCA must in respect of each of its...",
             "ref" : "schedule-1ZA-paragraph-20",
+            "id" : "schedule-1ZA-paragraph-20",
+            "href" : "schedule/1ZA/paragraph/20",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "21",
             "title" : "(1) The FCA must prepare and operate a scheme (“...",
             "ref" : "schedule-1ZA-paragraph-21",
+            "id" : "schedule-1ZA-paragraph-21",
+            "href" : "schedule/1ZA/paragraph/21",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "22",
             "title" : "(1) The scheme details must be published by the FCA...",
             "ref" : "schedule-1ZA-paragraph-22",
+            "id" : "schedule-1ZA-paragraph-22",
+            "href" : "schedule/1ZA/paragraph/22",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20578,12 +23996,16 @@
           "number" : null,
           "title" : "Fees",
           "ref" : "schedule-1ZA-part-3-crossheading-fees",
+          "id" : "schedule-1ZA-part-3-crossheading-fees",
+          "href" : "schedule/1ZA/part/3/crossheading/fees",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "23",
             "title" : "(1) The FCA may make rules providing for the payment...",
             "ref" : "schedule-1ZA-paragraph-23",
+            "id" : "schedule-1ZA-paragraph-23",
+            "href" : "schedule/1ZA/paragraph/23",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20591,12 +24013,16 @@
           "number" : null,
           "title" : "Services for which fees may not be charged",
           "ref" : "schedule-1ZA-part-3-crossheading-services-for-which-fees-may-not-be-charged",
+          "id" : "schedule-1ZA-part-3-crossheading-services-for-which-fees-may-not-be-charged",
+          "href" : "schedule/1ZA/part/3/crossheading/services-for-which-fees-may-not-be-charged",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "24",
             "title" : "The power conferred by paragraph 23 may not be used...",
             "ref" : "schedule-1ZA-paragraph-24",
+            "id" : "schedule-1ZA-paragraph-24",
+            "href" : "schedule/1ZA/paragraph/24",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -20605,18 +24031,24 @@
         "number" : "PART 4",
         "title" : "Miscellaneous",
         "ref" : "schedule-1ZA-part-4",
+        "id" : "schedule-1ZA-part-4",
+        "href" : "schedule/1ZA/part/4",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Exemption from liability in damages",
           "ref" : "schedule-1ZA-part-4-crossheading-exemption-from-liability-in-damages",
+          "id" : "schedule-1ZA-part-4-crossheading-exemption-from-liability-in-damages",
+          "href" : "schedule/1ZA/part/4/crossheading/exemption-from-liability-in-damages",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "25",
             "title" : "(1) None of the following is to be liable in...",
             "ref" : "schedule-1ZA-paragraph-25",
+            "id" : "schedule-1ZA-paragraph-25",
+            "href" : "schedule/1ZA/paragraph/25",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20624,12 +24056,16 @@
           "number" : null,
           "title" : "Accredited financial investigators",
           "ref" : "schedule-1ZA-part-4-crossheading-accredited-financial-investigators",
+          "id" : "schedule-1ZA-part-4-crossheading-accredited-financial-investigators",
+          "href" : "schedule/1ZA/part/4/crossheading/accredited-financial-investigators",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "26",
             "title" : "For the purposes of this Act anything done by an...",
             "ref" : "schedule-1ZA-paragraph-26",
+            "id" : "schedule-1ZA-paragraph-26",
+            "href" : "schedule/1ZA/paragraph/26",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20637,12 +24073,16 @@
           "number" : null,
           "title" : "Amounts required by rules to be paid to the FCA",
           "ref" : "schedule-1ZA-part-4-crossheading-amounts-required-by-rules-to-be-paid-to-the-fca",
+          "id" : "schedule-1ZA-part-4-crossheading-amounts-required-by-rules-to-be-paid-to-the-fca",
+          "href" : "schedule/1ZA/part/4/crossheading/amounts-required-by-rules-to-be-paid-to-the-fca",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "27",
             "title" : "Any amount (other than a fee) which is required by...",
             "ref" : "schedule-1ZA-paragraph-27",
+            "id" : "schedule-1ZA-paragraph-27",
+            "href" : "schedule/1ZA/paragraph/27",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20650,18 +24090,24 @@
           "number" : null,
           "title" : "Engagement with Parliamentary Committees",
           "ref" : "schedule-1ZA-part-4-crossheading-engagement-with-parliamentary-committees",
+          "id" : "schedule-1ZA-part-4-crossheading-engagement-with-parliamentary-committees",
+          "href" : "schedule/1ZA/part/4/crossheading/engagement-with-parliamentary-committees",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "28",
             "title" : "(1) This paragraph applies where the FCA issues a relevant...",
             "ref" : "schedule-1ZA-paragraph-28",
+            "id" : "schedule-1ZA-paragraph-28",
+            "href" : "schedule/1ZA/paragraph/28",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "29",
             "title" : "(1) This paragraph applies where— (a) the FCA issues a...",
             "ref" : "schedule-1ZA-paragraph-29",
+            "id" : "schedule-1ZA-paragraph-29",
+            "href" : "schedule/1ZA/paragraph/29",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -20671,24 +24117,32 @@
       "number" : "SCHEDULE 1ZB",
       "title" : "The Prudential Regulation Authority",
       "ref" : "schedule-1ZB",
+      "id" : "schedule-1ZB",
+      "href" : "schedule/1ZB",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "part",
         "number" : "PART 1",
         "title" : "General",
         "ref" : "schedule-1ZB-part-1",
+        "id" : "schedule-1ZB-part-1",
+        "href" : "schedule/1ZB/part/1",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Interpretation",
           "ref" : "schedule-1ZB-part-1-crossheading-interpretation",
+          "id" : "schedule-1ZB-part-1-crossheading-interpretation",
+          "href" : "schedule/1ZB/part/1/crossheading/interpretation",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "1",
             "title" : "In this Schedule— ... “ functions ”, in relation to...",
             "ref" : "schedule-1ZB-paragraph-1",
+            "id" : "schedule-1ZB-paragraph-1",
+            "href" : "schedule/1ZB/paragraph/1",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20696,30 +24150,40 @@
           "number" : null,
           "title" : "Constitution",
           "ref" : "schedule-1ZB-part-1-crossheading-constitution",
+          "id" : "schedule-1ZB-part-1-crossheading-constitution",
+          "href" : "schedule/1ZB/part/1/crossheading/constitution",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "2",
             "title" : "The constitution of the PRA must provide— ",
             "ref" : "schedule-1ZB-paragraph-2",
+            "id" : "schedule-1ZB-paragraph-2",
+            "href" : "schedule/1ZB/paragraph/2",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "3",
             "title" : "The governing body must consist of — ",
             "ref" : "schedule-1ZB-paragraph-3",
+            "id" : "schedule-1ZB-paragraph-3",
+            "href" : "schedule/1ZB/paragraph/3",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "4",
             "title" : "The validity of any act of the PRA is not...",
             "ref" : "schedule-1ZB-paragraph-4",
+            "id" : "schedule-1ZB-paragraph-4",
+            "href" : "schedule/1ZB/paragraph/4",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "5",
             "title" : "The chief executive of the FCA must not take part...",
             "ref" : "schedule-1ZB-paragraph-5",
+            "id" : "schedule-1ZB-paragraph-5",
+            "href" : "schedule/1ZB/paragraph/5",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20727,60 +24191,80 @@
           "number" : null,
           "title" : "Appointed members of governing body",
           "ref" : "schedule-1ZB-part-1-crossheading-appointed-members-of-governing-body",
+          "id" : "schedule-1ZB-part-1-crossheading-appointed-members-of-governing-body",
+          "href" : "schedule/1ZB/part/1/crossheading/appointed-members-of-governing-body",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "6",
             "title" : "The appointed members must be appointed by the court of...",
             "ref" : "schedule-1ZB-paragraph-6",
+            "id" : "schedule-1ZB-paragraph-6",
+            "href" : "schedule/1ZB/paragraph/6",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "7",
             "title" : "Paragraphs 8 to 12 apply to the exercise by the...",
             "ref" : "schedule-1ZB-paragraph-7",
+            "id" : "schedule-1ZB-paragraph-7",
+            "href" : "schedule/1ZB/paragraph/7",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "8",
             "title" : "The court of directors must secure that the majority of...",
             "ref" : "schedule-1ZB-paragraph-8",
+            "id" : "schedule-1ZB-paragraph-8",
+            "href" : "schedule/1ZB/paragraph/8",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "9",
             "title" : "For the purposes of paragraph 8, and for the purposes...",
             "ref" : "schedule-1ZB-paragraph-9",
+            "id" : "schedule-1ZB-paragraph-9",
+            "href" : "schedule/1ZB/paragraph/9",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "10",
             "title" : "The court of directors must have regard to generally accepted...",
             "ref" : "schedule-1ZB-paragraph-10",
+            "id" : "schedule-1ZB-paragraph-10",
+            "href" : "schedule/1ZB/paragraph/10",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "11",
             "title" : "(1) Before appointing a person as an appointed member, the...",
             "ref" : "schedule-1ZB-paragraph-11",
+            "id" : "schedule-1ZB-paragraph-11",
+            "href" : "schedule/1ZB/paragraph/11",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "12",
             "title" : "An employee of the FCA is disqualified for appointment as...",
             "ref" : "schedule-1ZB-paragraph-12",
+            "id" : "schedule-1ZB-paragraph-12",
+            "href" : "schedule/1ZB/paragraph/12",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "13",
             "title" : "The PRA must pay to the Bank the amount of...",
             "ref" : "schedule-1ZB-paragraph-13",
+            "id" : "schedule-1ZB-paragraph-13",
+            "href" : "schedule/1ZB/paragraph/13",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "14",
             "title" : "The court of directors of the Bank may, with the...",
             "ref" : "schedule-1ZB-paragraph-14",
+            "id" : "schedule-1ZB-paragraph-14",
+            "href" : "schedule/1ZB/paragraph/14",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20788,12 +24272,16 @@
           "number" : null,
           "title" : "Terms of service",
           "ref" : "schedule-1ZB-part-1-crossheading-terms-of-service",
+          "id" : "schedule-1ZB-part-1-crossheading-terms-of-service",
+          "href" : "schedule/1ZB/part/1/crossheading/terms-of-service",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "15",
             "title" : "(1) The terms of service of the members of the...",
             "ref" : "schedule-1ZB-paragraph-15",
+            "id" : "schedule-1ZB-paragraph-15",
+            "href" : "schedule/1ZB/paragraph/15",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20801,12 +24289,16 @@
           "number" : null,
           "title" : "Arrangements for discharging functions",
           "ref" : "schedule-1ZB-part-1-crossheading-arrangements-for-discharging-functions",
+          "id" : "schedule-1ZB-part-1-crossheading-arrangements-for-discharging-functions",
+          "href" : "schedule/1ZB/part/1/crossheading/arrangements-for-discharging-functions",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "16",
             "title" : "(1) The PRA may make arrangements for any of its...",
             "ref" : "schedule-1ZB-paragraph-16",
+            "id" : "schedule-1ZB-paragraph-16",
+            "href" : "schedule/1ZB/paragraph/16",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20814,12 +24306,16 @@
           "number" : null,
           "title" : "Records",
           "ref" : "schedule-1ZB-part-1-crossheading-records",
+          "id" : "schedule-1ZB-part-1-crossheading-records",
+          "href" : "schedule/1ZB/part/1/crossheading/records",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "17",
             "title" : "The PRA must maintain satisfactory arrangements for— ",
             "ref" : "schedule-1ZB-paragraph-17",
+            "id" : "schedule-1ZB-paragraph-17",
+            "href" : "schedule/1ZB/paragraph/17",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20827,12 +24323,16 @@
           "number" : null,
           "title" : "Budget",
           "ref" : "schedule-1ZB-part-1-crossheading-budget",
+          "id" : "schedule-1ZB-part-1-crossheading-budget",
+          "href" : "schedule/1ZB/part/1/crossheading/budget",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "18",
             "title" : "(1) The PRA must, for each of its financial years,...",
             "ref" : "schedule-1ZB-paragraph-18",
+            "id" : "schedule-1ZB-paragraph-18",
+            "href" : "schedule/1ZB/paragraph/18",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20840,12 +24340,16 @@
           "number" : null,
           "title" : "Annual report",
           "ref" : "schedule-1ZB-part-1-crossheading-annual-report",
+          "id" : "schedule-1ZB-part-1-crossheading-annual-report",
+          "href" : "schedule/1ZB/part/1/crossheading/annual-report",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "19",
             "title" : "(1) At least once a year the PRA must make...",
             "ref" : "schedule-1ZB-paragraph-19",
+            "id" : "schedule-1ZB-paragraph-19",
+            "href" : "schedule/1ZB/paragraph/19",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20853,12 +24357,16 @@
           "number" : null,
           "title" : "Consultation about annual report",
           "ref" : "schedule-1ZB-part-1-crossheading-consultation-about-annual-report",
+          "id" : "schedule-1ZB-part-1-crossheading-consultation-about-annual-report",
+          "href" : "schedule/1ZB/part/1/crossheading/consultation-about-annual-report",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "20",
             "title" : "(1) In relation to each report made under paragraph 19,...",
             "ref" : "schedule-1ZB-paragraph-20",
+            "id" : "schedule-1ZB-paragraph-20",
+            "href" : "schedule/1ZB/paragraph/20",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20866,12 +24374,16 @@
           "number" : null,
           "title" : "Report on consultation",
           "ref" : "schedule-1ZB-part-1-crossheading-report-on-consultation",
+          "id" : "schedule-1ZB-part-1-crossheading-report-on-consultation",
+          "href" : "schedule/1ZB/part/1/crossheading/report-on-consultation",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "21",
             "title" : "(1) The PRA must publish a report about its consultation...",
             "ref" : "schedule-1ZB-paragraph-21",
+            "id" : "schedule-1ZB-paragraph-21",
+            "href" : "schedule/1ZB/paragraph/21",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20879,12 +24391,16 @@
           "number" : null,
           "title" : "Other reports",
           "ref" : "schedule-1ZB-part-1-crossheading-other-reports",
+          "id" : "schedule-1ZB-part-1-crossheading-other-reports",
+          "href" : "schedule/1ZB/part/1/crossheading/other-reports",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "21A",
             "title" : "(1) The Treasury may (subject to this paragraph) at any...",
             "ref" : "schedule-1ZB-paragraph-21A",
+            "id" : "schedule-1ZB-paragraph-21A",
+            "href" : "schedule/1ZB/paragraph/21A",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20892,18 +24408,24 @@
           "number" : null,
           "title" : "Accounts and audit",
           "ref" : "schedule-1ZB-part-1-crossheading-accounts-and-audit",
+          "id" : "schedule-1ZB-part-1-crossheading-accounts-and-audit",
+          "href" : "schedule/1ZB/part/1/crossheading/accounts-and-audit",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "22",
             "title" : "(1) The Treasury may— (a) require the PRA to comply...",
             "ref" : "schedule-1ZB-paragraph-22",
+            "id" : "schedule-1ZB-paragraph-22",
+            "href" : "schedule/1ZB/paragraph/22",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "23",
             "title" : "(1) The PRA must send a copy of its annual...",
             "ref" : "schedule-1ZB-paragraph-23",
+            "id" : "schedule-1ZB-paragraph-23",
+            "href" : "schedule/1ZB/paragraph/23",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -20912,18 +24434,24 @@
         "number" : "PART 2",
         "title" : "Status",
         "ref" : "schedule-1ZB-part-2",
+        "id" : "schedule-1ZB-part-2",
+        "href" : "schedule/1ZB/part/2",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Status",
           "ref" : "schedule-1ZB-part-2-crossheading-status",
+          "id" : "schedule-1ZB-part-2-crossheading-status",
+          "href" : "schedule/1ZB/part/2/crossheading/status",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "24",
             "title" : "In relation to any of its functions— ",
             "ref" : "schedule-1ZB-paragraph-24",
+            "id" : "schedule-1ZB-paragraph-24",
+            "href" : "schedule/1ZB/paragraph/24",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20931,18 +24459,24 @@
           "number" : null,
           "title" : "Exemption from requirement for use of  “limited” in name of PRA",
           "ref" : "schedule-1ZB-part-2-crossheading-exemption-from-requirement-for-use-of-limited-in-name-of-pra",
+          "id" : "schedule-1ZB-part-2-crossheading-exemption-from-requirement-for-use-of-limited-in-name-of-pra",
+          "href" : "schedule/1ZB/part/2/crossheading/exemption-from-requirement-for-use-of-limited-in-name-of-pra",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "25",
             "title" : "The PRA is to be exempt from the requirements of...",
             "ref" : "schedule-1ZB-paragraph-25",
+            "id" : "schedule-1ZB-paragraph-25",
+            "href" : "schedule/1ZB/paragraph/25",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "26",
             "title" : "If the Secretary of State is satisfied that any action...",
             "ref" : "schedule-1ZB-paragraph-26",
+            "id" : "schedule-1ZB-paragraph-26",
+            "href" : "schedule/1ZB/paragraph/26",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -20951,36 +24485,48 @@
         "number" : "PART 3",
         "title" : "Penalties and fees",
         "ref" : "schedule-1ZB-part-3",
+        "id" : "schedule-1ZB-part-3",
+        "href" : "schedule/1ZB/part/3",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Penalties",
           "ref" : "schedule-1ZB-part-3-crossheading-penalties",
+          "id" : "schedule-1ZB-part-3-crossheading-penalties",
+          "href" : "schedule/1ZB/part/3/crossheading/penalties",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "27",
             "title" : "In determining its policy with respect to the amounts of...",
             "ref" : "schedule-1ZB-paragraph-27",
+            "id" : "schedule-1ZB-paragraph-27",
+            "href" : "schedule/1ZB/paragraph/27",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "28",
             "title" : "(1) The PRA must in respect of each of its...",
             "ref" : "schedule-1ZB-paragraph-28",
+            "id" : "schedule-1ZB-paragraph-28",
+            "href" : "schedule/1ZB/paragraph/28",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "29",
             "title" : "(1) The PRA must prepare and operate a scheme (“...",
             "ref" : "schedule-1ZB-paragraph-29",
+            "id" : "schedule-1ZB-paragraph-29",
+            "href" : "schedule/1ZB/paragraph/29",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "30",
             "title" : "(1) The scheme details must be published by the PRA...",
             "ref" : "schedule-1ZB-paragraph-30",
+            "id" : "schedule-1ZB-paragraph-30",
+            "href" : "schedule/1ZB/paragraph/30",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -20988,12 +24534,16 @@
           "number" : null,
           "title" : "Fees",
           "ref" : "schedule-1ZB-part-3-crossheading-fees",
+          "id" : "schedule-1ZB-part-3-crossheading-fees",
+          "href" : "schedule/1ZB/part/3/crossheading/fees",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "31",
             "title" : "(1) The PRA may make rules providing for the payment...",
             "ref" : "schedule-1ZB-paragraph-31",
+            "id" : "schedule-1ZB-paragraph-31",
+            "href" : "schedule/1ZB/paragraph/31",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21001,12 +24551,16 @@
           "number" : null,
           "title" : "Services for which fees may not be charged",
           "ref" : "schedule-1ZB-part-3-crossheading-services-for-which-fees-may-not-be-charged",
+          "id" : "schedule-1ZB-part-3-crossheading-services-for-which-fees-may-not-be-charged",
+          "href" : "schedule/1ZB/part/3/crossheading/services-for-which-fees-may-not-be-charged",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "32",
             "title" : "The power conferred by paragraph 31 may not be used...",
             "ref" : "schedule-1ZB-paragraph-32",
+            "id" : "schedule-1ZB-paragraph-32",
+            "href" : "schedule/1ZB/paragraph/32",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -21015,18 +24569,24 @@
         "number" : "PART 4",
         "title" : "Miscellaneous",
         "ref" : "schedule-1ZB-part-4",
+        "id" : "schedule-1ZB-part-4",
+        "href" : "schedule/1ZB/part/4",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Exemption from liability in damages",
           "ref" : "schedule-1ZB-part-4-crossheading-exemption-from-liability-in-damages",
+          "id" : "schedule-1ZB-part-4-crossheading-exemption-from-liability-in-damages",
+          "href" : "schedule/1ZB/part/4/crossheading/exemption-from-liability-in-damages",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "33",
             "title" : "(1) None of the following is to be liable in...",
             "ref" : "schedule-1ZB-paragraph-33",
+            "id" : "schedule-1ZB-paragraph-33",
+            "href" : "schedule/1ZB/paragraph/33",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21034,12 +24594,16 @@
           "number" : null,
           "title" : "Accredited financial investigators",
           "ref" : "schedule-1ZB-part-4-crossheading-accredited-financial-investigators",
+          "id" : "schedule-1ZB-part-4-crossheading-accredited-financial-investigators",
+          "href" : "schedule/1ZB/part/4/crossheading/accredited-financial-investigators",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "34",
             "title" : "For the purposes of this Act anything done by an...",
             "ref" : "schedule-1ZB-paragraph-34",
+            "id" : "schedule-1ZB-paragraph-34",
+            "href" : "schedule/1ZB/paragraph/34",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21047,12 +24611,16 @@
           "number" : null,
           "title" : "Amounts required by rules to be paid to the PRA",
           "ref" : "schedule-1ZB-part-4-crossheading-amounts-required-by-rules-to-be-paid-to-the-pra",
+          "id" : "schedule-1ZB-part-4-crossheading-amounts-required-by-rules-to-be-paid-to-the-pra",
+          "href" : "schedule/1ZB/part/4/crossheading/amounts-required-by-rules-to-be-paid-to-the-pra",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "35",
             "title" : "Any amount (other than a fee) which is required by...",
             "ref" : "schedule-1ZB-paragraph-35",
+            "id" : "schedule-1ZB-paragraph-35",
+            "href" : "schedule/1ZB/paragraph/35",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21060,18 +24628,24 @@
           "number" : null,
           "title" : "Engagement with Parliamentary Committees",
           "ref" : "schedule-1ZB-part-4-crossheading-engagement-with-parliamentary-committees",
+          "id" : "schedule-1ZB-part-4-crossheading-engagement-with-parliamentary-committees",
+          "href" : "schedule/1ZB/part/4/crossheading/engagement-with-parliamentary-committees",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "36",
             "title" : "(1) This paragraph applies where the PRA issues a relevant...",
             "ref" : "schedule-1ZB-paragraph-36",
+            "id" : "schedule-1ZB-paragraph-36",
+            "href" : "schedule/1ZB/paragraph/36",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "37",
             "title" : "(1) This paragraph applies where— (a) the PRA issues a...",
             "ref" : "schedule-1ZB-paragraph-37",
+            "id" : "schedule-1ZB-paragraph-37",
+            "href" : "schedule/1ZB/paragraph/37",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -21081,24 +24655,32 @@
       "number" : "SCHEDULE 1A",
       "title" : "Further provision about the consumer financial education body",
       "ref" : "schedule-1A",
+      "id" : "schedule-1A",
+      "href" : "schedule/1A",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "part",
         "number" : "Part 1",
         "title" : "General",
         "ref" : "schedule-1A-part-1",
+        "id" : "schedule-1A-part-1",
+        "href" : "schedule/1A/part/1",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Ensuring exercise of consumer financial education function etc",
           "ref" : "schedule-1A-part-1-crossheading-ensuring-exercise-of-consumer-financial-education-function-etc",
+          "id" : "schedule-1A-part-1-crossheading-ensuring-exercise-of-consumer-financial-education-function-etc",
+          "href" : "schedule/1A/part/1/crossheading/ensuring-exercise-of-consumer-financial-education-function-etc",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "1",
             "title" : "(1) The FCA must take such steps as are necessary...",
             "ref" : "schedule-1A-paragraph-1",
+            "id" : "schedule-1A-paragraph-1",
+            "href" : "schedule/1A/paragraph/1",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21106,12 +24688,16 @@
           "number" : null,
           "title" : "Constitution",
           "ref" : "schedule-1A-part-1-crossheading-constitution",
+          "id" : "schedule-1A-part-1-crossheading-constitution",
+          "href" : "schedule/1A/part/1/crossheading/constitution",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "2",
             "title" : "(1) The constitution of the consumer financial education body must...",
             "ref" : "schedule-1A-paragraph-2",
+            "id" : "schedule-1A-paragraph-2",
+            "href" : "schedule/1A/paragraph/2",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21119,12 +24705,16 @@
           "number" : null,
           "title" : "Status",
           "ref" : "schedule-1A-part-1-crossheading-status",
+          "id" : "schedule-1A-part-1-crossheading-status",
+          "href" : "schedule/1A/part/1/crossheading/status",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "3",
             "title" : "(1) The consumer financial education body is not to be...",
             "ref" : "schedule-1A-paragraph-3",
+            "id" : "schedule-1A-paragraph-3",
+            "href" : "schedule/1A/paragraph/3",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21132,18 +24722,24 @@
           "number" : null,
           "title" : "Discharge of function by others",
           "ref" : "schedule-1A-part-1-crossheading-discharge-of-function-by-others",
+          "id" : "schedule-1A-part-1-crossheading-discharge-of-function-by-others",
+          "href" : "schedule/1A/part/1/crossheading/discharge-of-function-by-others",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "4",
             "title" : "(1) The consumer financial education body may discharge the consumer...",
             "ref" : "schedule-1A-paragraph-4",
+            "id" : "schedule-1A-paragraph-4",
+            "href" : "schedule/1A/paragraph/4",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "5",
             "title" : "(1) This paragraph applies if the consumer financial education body...",
             "ref" : "schedule-1A-paragraph-5",
+            "id" : "schedule-1A-paragraph-5",
+            "href" : "schedule/1A/paragraph/5",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21151,12 +24747,16 @@
           "number" : null,
           "title" : "Discharge of functions: considerations",
           "ref" : "schedule-1A-part-1-crossheading-market-confidence-and-financial-stability",
+          "id" : "schedule-1A-part-1-crossheading-market-confidence-and-financial-stability",
+          "href" : "schedule/1A/part/1/crossheading/market-confidence-and-financial-stability",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "6",
             "title" : "In discharging the consumer financial education function the consumer financial...",
             "ref" : "schedule-1A-paragraph-6",
+            "id" : "schedule-1A-paragraph-6",
+            "href" : "schedule/1A/paragraph/6",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21164,18 +24764,24 @@
           "number" : null,
           "title" : "Relationship with the FCA",
           "ref" : "schedule-1A-part-1-crossheading-relationship-with-the-fca",
+          "id" : "schedule-1A-part-1-crossheading-relationship-with-the-fca",
+          "href" : "schedule/1A/part/1/crossheading/relationship-with-the-fca",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "6A",
             "title" : "(1) The consumer financial education body and the FCA must...",
             "ref" : "schedule-1A-paragraph-6A",
+            "id" : "schedule-1A-paragraph-6A",
+            "href" : "schedule/1A/paragraph/6A",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "6B",
             "title" : "If the consumer financial education body considers that it has...",
             "ref" : "schedule-1A-paragraph-6B",
+            "id" : "schedule-1A-paragraph-6B",
+            "href" : "schedule/1A/paragraph/6B",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21183,12 +24789,16 @@
           "number" : null,
           "title" : "Budget",
           "ref" : "schedule-1A-part-1-crossheading-budget",
+          "id" : "schedule-1A-part-1-crossheading-budget",
+          "href" : "schedule/1A/part/1/crossheading/budget",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "7",
             "title" : "(1) The consumer financial education body must adopt an annual...",
             "ref" : "schedule-1A-paragraph-7",
+            "id" : "schedule-1A-paragraph-7",
+            "href" : "schedule/1A/paragraph/7",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21196,12 +24806,16 @@
           "number" : null,
           "title" : "Annual plan",
           "ref" : "schedule-1A-part-1-crossheading-annual-plan",
+          "id" : "schedule-1A-part-1-crossheading-annual-plan",
+          "href" : "schedule/1A/part/1/crossheading/annual-plan",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "8",
             "title" : "(1) The consumer financial education body must in respect of...",
             "ref" : "schedule-1A-paragraph-8",
+            "id" : "schedule-1A-paragraph-8",
+            "href" : "schedule/1A/paragraph/8",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21209,12 +24823,16 @@
           "number" : null,
           "title" : "Annual reports",
           "ref" : "schedule-1A-part-1-crossheading-annual-reports",
+          "id" : "schedule-1A-part-1-crossheading-annual-reports",
+          "href" : "schedule/1A/part/1/crossheading/annual-reports",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "9",
             "title" : "(1) At least once a year, the consumer financial education...",
             "ref" : "schedule-1A-paragraph-9",
+            "id" : "schedule-1A-paragraph-9",
+            "href" : "schedule/1A/paragraph/9",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21222,12 +24840,16 @@
           "number" : null,
           "title" : "Audit of accounts",
           "ref" : "schedule-1A-part-1-crossheading-audit-of-accounts",
+          "id" : "schedule-1A-part-1-crossheading-audit-of-accounts",
+          "href" : "schedule/1A/part/1/crossheading/audit-of-accounts",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "9A",
             "title" : "(1) The consumer financial education body must send a copy...",
             "ref" : "schedule-1A-paragraph-9A",
+            "id" : "schedule-1A-paragraph-9A",
+            "href" : "schedule/1A/paragraph/9A",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21235,12 +24857,16 @@
           "number" : null,
           "title" : "...",
           "ref" : "schedule-1A-part-1-crossheading-exemption-from-consumer-credit-rules",
+          "id" : "schedule-1A-part-1-crossheading-exemption-from-consumer-credit-rules",
+          "href" : "schedule/1A/part/1/crossheading/exemption-from-consumer-credit-rules",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "10",
             "title" : "(1) . . . . . . . . ....",
             "ref" : "schedule-1A-paragraph-10",
+            "id" : "schedule-1A-paragraph-10",
+            "href" : "schedule/1A/paragraph/10",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -21249,18 +24875,24 @@
         "number" : "Part 2",
         "title" : "Funding",
         "ref" : "schedule-1A-part-2",
+        "id" : "schedule-1A-part-2",
+        "href" : "schedule/1A/part/2",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Meaning of  “the relevant costs”",
           "ref" : "schedule-1A-part-2-crossheading-meaning-of-the-relevant-costs",
+          "id" : "schedule-1A-part-2-crossheading-meaning-of-the-relevant-costs",
+          "href" : "schedule/1A/part/2/crossheading/meaning-of-the-relevant-costs",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "11",
             "title" : "(1) In this Part of this Schedule “ the relevant...",
             "ref" : "schedule-1A-paragraph-11",
+            "id" : "schedule-1A-paragraph-11",
+            "href" : "schedule/1A/paragraph/11",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21268,12 +24900,16 @@
           "number" : null,
           "title" : "Funding of the relevant costs by authorised persons  , payment service providers or electronic money issuers",
           "ref" : "schedule-1A-part-2-crossheading-funding-of-the-relevant-costs-by-authorised-persons-or-payment-service-providers",
+          "id" : "schedule-1A-part-2-crossheading-funding-of-the-relevant-costs-by-authorised-persons-or-payment-service-providers",
+          "href" : "schedule/1A/part/2/crossheading/funding-of-the-relevant-costs-by-authorised-persons-or-payment-service-providers",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "12",
             "title" : "(1) For the purpose of meeting a proportion of the...",
             "ref" : "schedule-1A-paragraph-12",
+            "id" : "schedule-1A-paragraph-12",
+            "href" : "schedule/1A/paragraph/12",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21281,12 +24917,16 @@
           "number" : null,
           "title" : "Funding of the relevant costs by consumer credit licensees etc",
           "ref" : "schedule-1A-part-2-crossheading-funding-of-the-relevant-costs-by-consumer-credit-licensees-etc",
+          "id" : "schedule-1A-part-2-crossheading-funding-of-the-relevant-costs-by-consumer-credit-licensees-etc",
+          "href" : "schedule/1A/part/2/crossheading/funding-of-the-relevant-costs-by-consumer-credit-licensees-etc",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "13",
             "title" : "(1) For the purpose of meeting a proportion of the...",
             "ref" : "schedule-1A-paragraph-13",
+            "id" : "schedule-1A-paragraph-13",
+            "href" : "schedule/1A/paragraph/13",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21294,12 +24934,16 @@
           "number" : null,
           "title" : "Funding by grants or loans etc made by Treasury or Secretary of State",
           "ref" : "schedule-1A-part-2-crossheading-funding-by-grants-or-loans-etc-made-by-treasury-or-secretary-of-state",
+          "id" : "schedule-1A-part-2-crossheading-funding-by-grants-or-loans-etc-made-by-treasury-or-secretary-of-state",
+          "href" : "schedule/1A/part/2/crossheading/funding-by-grants-or-loans-etc-made-by-treasury-or-secretary-of-state",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "14",
             "title" : "(1) The Treasury or the Secretary of State may— ",
             "ref" : "schedule-1A-paragraph-14",
+            "id" : "schedule-1A-paragraph-14",
+            "href" : "schedule/1A/paragraph/14",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -21308,18 +24952,24 @@
         "number" : "Part 3",
         "title" : "Reviews",
         "ref" : "schedule-1A-part-3",
+        "id" : "schedule-1A-part-3",
+        "href" : "schedule/1A/part/3",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Reviews of economy etc of the consumer financial education body",
           "ref" : "schedule-1A-part-3-crossheading-reviews-of-economy-etc-of-the-consumer-financial-education-body",
+          "id" : "schedule-1A-part-3-crossheading-reviews-of-economy-etc-of-the-consumer-financial-education-body",
+          "href" : "schedule/1A/part/3/crossheading/reviews-of-economy-etc-of-the-consumer-financial-education-body",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "15",
             "title" : "(1) The FCA may appoint an independent person to conduct...",
             "ref" : "schedule-1A-paragraph-15",
+            "id" : "schedule-1A-paragraph-15",
+            "href" : "schedule/1A/paragraph/15",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21327,12 +24977,16 @@
           "number" : null,
           "title" : "Right to obtain documents and information",
           "ref" : "schedule-1A-part-3-crossheading-right-to-obtain-documents-and-information",
+          "id" : "schedule-1A-part-3-crossheading-right-to-obtain-documents-and-information",
+          "href" : "schedule/1A/part/3/crossheading/right-to-obtain-documents-and-information",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "16",
             "title" : "(1) A person conducting a review under paragraph 15— ",
             "ref" : "schedule-1A-paragraph-16",
+            "id" : "schedule-1A-paragraph-16",
+            "href" : "schedule/1A/paragraph/16",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -21342,24 +24996,32 @@
       "number" : "SCHEDULE 2",
       "title" : " Regulated Activities",
       "ref" : "schedule-2",
+      "id" : "schedule-2",
+      "href" : "schedule/2",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "part",
         "number" : "Part I",
         "title" : "Regulated activities: general",
         "ref" : "schedule-2-part-I",
+        "id" : "schedule-2-part-I",
+        "href" : "schedule/2/part/I",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : " General",
           "ref" : "schedule-2-part-I-crossheading-general",
+          "id" : "schedule-2-part-I-crossheading-general",
+          "href" : "schedule/2/part/I/crossheading/general",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "1",
             "title" : "The matters with respect to which provision may be made...",
             "ref" : "schedule-2-paragraph-1",
+            "id" : "schedule-2-paragraph-1",
+            "href" : "schedule/2/paragraph/1",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21367,12 +25029,16 @@
           "number" : null,
           "title" : " Dealing in investments",
           "ref" : "schedule-2-part-I-crossheading-dealing-in-investments",
+          "id" : "schedule-2-part-I-crossheading-dealing-in-investments",
+          "href" : "schedule/2/part/I/crossheading/dealing-in-investments",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "2",
             "title" : "(1) Buying, selling, subscribing for or underwriting investments or offering...",
             "ref" : "schedule-2-paragraph-2",
+            "id" : "schedule-2-paragraph-2",
+            "href" : "schedule/2/paragraph/2",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21380,12 +25046,16 @@
           "number" : null,
           "title" : " Arranging deals in investments",
           "ref" : "schedule-2-part-I-crossheading-arranging-deals-in-investments",
+          "id" : "schedule-2-part-I-crossheading-arranging-deals-in-investments",
+          "href" : "schedule/2/part/I/crossheading/arranging-deals-in-investments",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "3",
             "title" : "Making, or offering or agreeing to make— ",
             "ref" : "schedule-2-paragraph-3",
+            "id" : "schedule-2-paragraph-3",
+            "href" : "schedule/2/paragraph/3",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21393,12 +25063,16 @@
           "number" : null,
           "title" : " Deposit taking",
           "ref" : "schedule-2-part-I-crossheading-deposit-taking",
+          "id" : "schedule-2-part-I-crossheading-deposit-taking",
+          "href" : "schedule/2/part/I/crossheading/deposit-taking",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "4",
             "title" : "Accepting deposits. ",
             "ref" : "schedule-2-paragraph-4",
+            "id" : "schedule-2-paragraph-4",
+            "href" : "schedule/2/paragraph/4",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21406,12 +25080,16 @@
           "number" : null,
           "title" : " Safekeeping and administration of assets",
           "ref" : "schedule-2-part-I-crossheading-safekeeping-and-administration-of-assets",
+          "id" : "schedule-2-part-I-crossheading-safekeeping-and-administration-of-assets",
+          "href" : "schedule/2/part/I/crossheading/safekeeping-and-administration-of-assets",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "5",
             "title" : "(1) Safeguarding and administering assets belonging to another which consist...",
             "ref" : "schedule-2-paragraph-5",
+            "id" : "schedule-2-paragraph-5",
+            "href" : "schedule/2/paragraph/5",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21419,12 +25097,16 @@
           "number" : null,
           "title" : " Managing investments",
           "ref" : "schedule-2-part-I-crossheading-managing-investments",
+          "id" : "schedule-2-part-I-crossheading-managing-investments",
+          "href" : "schedule/2/part/I/crossheading/managing-investments",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "6",
             "title" : "Managing, or offering or agreeing to manage, assets belonging to...",
             "ref" : "schedule-2-paragraph-6",
+            "id" : "schedule-2-paragraph-6",
+            "href" : "schedule/2/paragraph/6",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21432,12 +25114,16 @@
           "number" : null,
           "title" : " Investment advice",
           "ref" : "schedule-2-part-I-crossheading-investment-advice",
+          "id" : "schedule-2-part-I-crossheading-investment-advice",
+          "href" : "schedule/2/part/I/crossheading/investment-advice",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "7",
             "title" : "Giving or offering or agreeing to give advice to persons...",
             "ref" : "schedule-2-paragraph-7",
+            "id" : "schedule-2-paragraph-7",
+            "href" : "schedule/2/paragraph/7",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21445,12 +25131,16 @@
           "number" : null,
           "title" : " Establishing collective investment schemes",
           "ref" : "schedule-2-part-I-crossheading-establishing-collective-investment-schemes",
+          "id" : "schedule-2-part-I-crossheading-establishing-collective-investment-schemes",
+          "href" : "schedule/2/part/I/crossheading/establishing-collective-investment-schemes",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "8",
             "title" : "Establishing, operating or winding up a collective investment scheme, including...",
             "ref" : "schedule-2-paragraph-8",
+            "id" : "schedule-2-paragraph-8",
+            "href" : "schedule/2/paragraph/8",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21458,12 +25148,16 @@
           "number" : null,
           "title" : " Using computer-based systems for giving investment instructions",
           "ref" : "schedule-2-part-I-crossheading-using-computerbased-systems-for-giving-investment-instructions",
+          "id" : "schedule-2-part-I-crossheading-using-computerbased-systems-for-giving-investment-instructions",
+          "href" : "schedule/2/part/I/crossheading/using-computerbased-systems-for-giving-investment-instructions",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "9",
             "title" : "(1) Sending on behalf of another person instructions relating to...",
             "ref" : "schedule-2-paragraph-9",
+            "id" : "schedule-2-paragraph-9",
+            "href" : "schedule/2/paragraph/9",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -21472,12 +25166,16 @@
         "number" : "Part 1A",
         "title" : "Regulated activities: reclaim funds",
         "ref" : "schedule-2-part-1A",
+        "id" : "schedule-2-part-1A",
+        "href" : "schedule/2/part/1A",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "9A",
           "title" : "Activities of reclaim funds",
           "ref" : "schedule-2-paragraph-9A",
+          "id" : "schedule-2-paragraph-9A",
+          "href" : "schedule/2/paragraph/9A",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -21485,18 +25183,24 @@
         "number" : "Part II",
         "title" : " Investments",
         "ref" : "schedule-2-part-II",
+        "id" : "schedule-2-part-II",
+        "href" : "schedule/2/part/II",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : " General",
           "ref" : "schedule-2-part-II-crossheading-general",
+          "id" : "schedule-2-part-II-crossheading-general",
+          "href" : "schedule/2/part/II/crossheading/general",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "10",
             "title" : "The matters with respect to which provision may be made...",
             "ref" : "schedule-2-paragraph-10",
+            "id" : "schedule-2-paragraph-10",
+            "href" : "schedule/2/paragraph/10",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21504,12 +25208,16 @@
           "number" : null,
           "title" : " Securities",
           "ref" : "schedule-2-part-II-crossheading-securities",
+          "id" : "schedule-2-part-II-crossheading-securities",
+          "href" : "schedule/2/part/II/crossheading/securities",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "11",
             "title" : "(1) Shares or stock in the share capital of a...",
             "ref" : "schedule-2-paragraph-11",
+            "id" : "schedule-2-paragraph-11",
+            "href" : "schedule/2/paragraph/11",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21517,12 +25225,16 @@
           "number" : null,
           "title" : " Instruments creating or acknowledging indebtedness",
           "ref" : "schedule-2-part-II-crossheading-instruments-creating-or-acknowledging-indebtedness",
+          "id" : "schedule-2-part-II-crossheading-instruments-creating-or-acknowledging-indebtedness",
+          "href" : "schedule/2/part/II/crossheading/instruments-creating-or-acknowledging-indebtedness",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "12",
             "title" : "Any of the following— (a) debentures; (b) debenture stock; ",
             "ref" : "schedule-2-paragraph-12",
+            "id" : "schedule-2-paragraph-12",
+            "href" : "schedule/2/paragraph/12",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21530,12 +25242,16 @@
           "number" : null,
           "title" : " Government and public securities",
           "ref" : "schedule-2-part-II-crossheading-government-and-public-securities",
+          "id" : "schedule-2-part-II-crossheading-government-and-public-securities",
+          "href" : "schedule/2/part/II/crossheading/government-and-public-securities",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "13",
             "title" : "(1) Loan stock, bonds and other instruments— ",
             "ref" : "schedule-2-paragraph-13",
+            "id" : "schedule-2-paragraph-13",
+            "href" : "schedule/2/paragraph/13",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21543,12 +25259,16 @@
           "number" : null,
           "title" : " Instruments giving entitlement to investments",
           "ref" : "schedule-2-part-II-crossheading-instruments-giving-entitlement-to-investments",
+          "id" : "schedule-2-part-II-crossheading-instruments-giving-entitlement-to-investments",
+          "href" : "schedule/2/part/II/crossheading/instruments-giving-entitlement-to-investments",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "14",
             "title" : "(1) Warrants or other instruments entitling the holder to subscribe...",
             "ref" : "schedule-2-paragraph-14",
+            "id" : "schedule-2-paragraph-14",
+            "href" : "schedule/2/paragraph/14",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21556,12 +25276,16 @@
           "number" : null,
           "title" : " Certificates representing securities",
           "ref" : "schedule-2-part-II-crossheading-certificates-representing-securities",
+          "id" : "schedule-2-part-II-crossheading-certificates-representing-securities",
+          "href" : "schedule/2/part/II/crossheading/certificates-representing-securities",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "15",
             "title" : "Certificates or other instruments which confer contractual or property rights—...",
             "ref" : "schedule-2-paragraph-15",
+            "id" : "schedule-2-paragraph-15",
+            "href" : "schedule/2/paragraph/15",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21569,12 +25293,16 @@
           "number" : null,
           "title" : " Units in collective investment schemes",
           "ref" : "schedule-2-part-II-crossheading-units-in-collective-investment-schemes",
+          "id" : "schedule-2-part-II-crossheading-units-in-collective-investment-schemes",
+          "href" : "schedule/2/part/II/crossheading/units-in-collective-investment-schemes",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "16",
             "title" : "(1) Shares in or securities of an open-ended investment company....",
             "ref" : "schedule-2-paragraph-16",
+            "id" : "schedule-2-paragraph-16",
+            "href" : "schedule/2/paragraph/16",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21582,12 +25310,16 @@
           "number" : null,
           "title" : " Options",
           "ref" : "schedule-2-part-II-crossheading-options",
+          "id" : "schedule-2-part-II-crossheading-options",
+          "href" : "schedule/2/part/II/crossheading/options",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "17",
             "title" : "Options to acquire or dispose of property. ",
             "ref" : "schedule-2-paragraph-17",
+            "id" : "schedule-2-paragraph-17",
+            "href" : "schedule/2/paragraph/17",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21595,12 +25327,16 @@
           "number" : null,
           "title" : " Futures",
           "ref" : "schedule-2-part-II-crossheading-futures",
+          "id" : "schedule-2-part-II-crossheading-futures",
+          "href" : "schedule/2/part/II/crossheading/futures",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "18",
             "title" : "Rights under a contract for the sale of a commodity...",
             "ref" : "schedule-2-paragraph-18",
+            "id" : "schedule-2-paragraph-18",
+            "href" : "schedule/2/paragraph/18",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21608,12 +25344,16 @@
           "number" : null,
           "title" : " Contracts for differences",
           "ref" : "schedule-2-part-II-crossheading-contracts-for-differences",
+          "id" : "schedule-2-part-II-crossheading-contracts-for-differences",
+          "href" : "schedule/2/part/II/crossheading/contracts-for-differences",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "19",
             "title" : "Rights under— (a) a contract for differences; or ",
             "ref" : "schedule-2-paragraph-19",
+            "id" : "schedule-2-paragraph-19",
+            "href" : "schedule/2/paragraph/19",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21621,12 +25361,16 @@
           "number" : null,
           "title" : " Contracts of insurance",
           "ref" : "schedule-2-part-II-crossheading-contracts-of-insurance",
+          "id" : "schedule-2-part-II-crossheading-contracts-of-insurance",
+          "href" : "schedule/2/part/II/crossheading/contracts-of-insurance",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "20",
             "title" : "Rights under a contract of insurance, including rights under contracts...",
             "ref" : "schedule-2-paragraph-20",
+            "id" : "schedule-2-paragraph-20",
+            "href" : "schedule/2/paragraph/20",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21634,12 +25378,16 @@
           "number" : null,
           "title" : " Participation in Lloyd’s syndicates",
           "ref" : "schedule-2-part-II-crossheading-participation-in-lloyds-syndicates",
+          "id" : "schedule-2-part-II-crossheading-participation-in-lloyds-syndicates",
+          "href" : "schedule/2/part/II/crossheading/participation-in-lloyds-syndicates",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "21",
             "title" : "(1) The underwriting capacity of a Lloyd’s syndicate. ",
             "ref" : "schedule-2-paragraph-21",
+            "id" : "schedule-2-paragraph-21",
+            "href" : "schedule/2/paragraph/21",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21647,12 +25395,16 @@
           "number" : null,
           "title" : " Deposits",
           "ref" : "schedule-2-part-II-crossheading-deposits",
+          "id" : "schedule-2-part-II-crossheading-deposits",
+          "href" : "schedule/2/part/II/crossheading/deposits",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "22",
             "title" : "Rights under any contract under which a sum of money...",
             "ref" : "schedule-2-paragraph-22",
+            "id" : "schedule-2-paragraph-22",
+            "href" : "schedule/2/paragraph/22",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21660,12 +25412,16 @@
           "number" : null,
           "title" : " Loans and other forms of credit",
           "ref" : "schedule-2-part-II-crossheading-loans-secured-on-land",
+          "id" : "schedule-2-part-II-crossheading-loans-secured-on-land",
+          "href" : "schedule/2/part/II/crossheading/loans-secured-on-land",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "23",
             "title" : "(1) Rights under any contract under which one person provides...",
             "ref" : "schedule-2-paragraph-23",
+            "id" : "schedule-2-paragraph-23",
+            "href" : "schedule/2/paragraph/23",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21673,12 +25429,16 @@
           "number" : null,
           "title" : "Other finance arrangements involving land",
           "ref" : "schedule-2-part-II-crossheading-other-finance-arrangements-involving-land",
+          "id" : "schedule-2-part-II-crossheading-other-finance-arrangements-involving-land",
+          "href" : "schedule/2/part/II/crossheading/other-finance-arrangements-involving-land",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "23A",
             "title" : "(1) Rights under any arrangement for the provision of finance...",
             "ref" : "schedule-2-paragraph-23A",
+            "id" : "schedule-2-paragraph-23A",
+            "href" : "schedule/2/paragraph/23A",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21686,12 +25446,16 @@
           "number" : null,
           "title" : "Contracts for hire of goods",
           "ref" : "schedule-2-part-II-crossheading-loans-secured-on-landn1",
+          "id" : "schedule-2-part-II-crossheading-loans-secured-on-landn1",
+          "href" : "schedule/2/part/II/crossheading/loans-secured-on-landn1",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "23B",
             "title" : "(1) Rights under a contract for the bailment or (in...",
             "ref" : "schedule-2-paragraph-23n1",
+            "id" : "schedule-2-paragraph-23n1",
+            "href" : "schedule/2/paragraph/23n1",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21699,12 +25463,16 @@
           "number" : null,
           "title" : " Rights in investments",
           "ref" : "schedule-2-part-II-crossheading-rights-in-investments",
+          "id" : "schedule-2-part-II-crossheading-rights-in-investments",
+          "href" : "schedule/2/part/II/crossheading/rights-in-investments",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "24",
             "title" : "Any right or interest in anything which is an investment...",
             "ref" : "schedule-2-paragraph-24",
+            "id" : "schedule-2-paragraph-24",
+            "href" : "schedule/2/paragraph/24",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -21713,30 +25481,40 @@
         "number" : "PART 2A",
         "title" : "Regulated activities relating to information about persons' financial standing",
         "ref" : "schedule-2-part-2A",
+        "id" : "schedule-2-part-2A",
+        "href" : "schedule/2/part/2A",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "24A",
           "title" : "<i>General</i>",
           "ref" : "schedule-2-paragraph-24A",
+          "id" : "schedule-2-paragraph-24A",
+          "href" : "schedule/2/paragraph/24A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "24B",
           "title" : "<i>Providing credit reference services</i>",
           "ref" : "schedule-2-paragraph-24B",
+          "id" : "schedule-2-paragraph-24B",
+          "href" : "schedule/2/paragraph/24B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "24C",
           "title" : "<i>Providing credit information services</i>",
           "ref" : "schedule-2-paragraph-24C",
+          "id" : "schedule-2-paragraph-24C",
+          "href" : "schedule/2/paragraph/24C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "24D",
           "title" : "Giving advice to a person other than a body corporate...",
           "ref" : "schedule-2-paragraph-24D",
+          "id" : "schedule-2-paragraph-24D",
+          "href" : "schedule/2/paragraph/24D",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -21744,30 +25522,40 @@
         "number" : "PART 2B",
         "title" : "Regulated activities relating to the setting of benchmarks",
         "ref" : "schedule-2-part-2B",
+        "id" : "schedule-2-part-2B",
+        "href" : "schedule/2/part/2B",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "24E",
           "title" : "General",
           "ref" : "schedule-2-paragraph-24E",
+          "id" : "schedule-2-paragraph-24E",
+          "href" : "schedule/2/paragraph/24E",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "24F",
           "title" : "Providing information",
           "ref" : "schedule-2-paragraph-24F",
+          "id" : "schedule-2-paragraph-24F",
+          "href" : "schedule/2/paragraph/24F",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "24G",
           "title" : "Administration",
           "ref" : "schedule-2-paragraph-24G",
+          "id" : "schedule-2-paragraph-24G",
+          "href" : "schedule/2/paragraph/24G",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "24H",
           "title" : "Determining or publishing benchmark or publishing connected information",
           "ref" : "schedule-2-paragraph-24H",
+          "id" : "schedule-2-paragraph-24H",
+          "href" : "schedule/2/paragraph/24H",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -21775,18 +25563,24 @@
         "number" : "Part III",
         "title" : " Supplemental Provisions",
         "ref" : "schedule-2-part-III",
+        "id" : "schedule-2-part-III",
+        "href" : "schedule/2/part/III",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : " The order-making power",
           "ref" : "schedule-2-part-III-crossheading-the-ordermaking-power",
+          "id" : "schedule-2-part-III-crossheading-the-ordermaking-power",
+          "href" : "schedule/2/part/III/crossheading/the-ordermaking-power",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "25",
             "title" : "(1) An order under section 22(1) or (1A) to (1B)...",
             "ref" : "schedule-2-paragraph-25",
+            "id" : "schedule-2-paragraph-25",
+            "href" : "schedule/2/paragraph/25",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21794,12 +25588,16 @@
           "number" : null,
           "title" : " Parliamentary control",
           "ref" : "schedule-2-part-III-crossheading-parliamentary-control",
+          "id" : "schedule-2-part-III-crossheading-parliamentary-control",
+          "href" : "schedule/2/part/III/crossheading/parliamentary-control",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "26",
             "title" : "(1) This paragraph applies to any order made under section...",
             "ref" : "schedule-2-paragraph-26",
+            "id" : "schedule-2-paragraph-26",
+            "href" : "schedule/2/paragraph/26",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21807,12 +25605,16 @@
           "number" : null,
           "title" : " Interpretation",
           "ref" : "schedule-2-part-III-crossheading-interpretation",
+          "id" : "schedule-2-part-III-crossheading-interpretation",
+          "href" : "schedule/2/part/III/crossheading/interpretation",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "27",
             "title" : "(1) In this Schedule— “buying” includes acquiring for valuable consideration;...",
             "ref" : "schedule-2-paragraph-27",
+            "id" : "schedule-2-paragraph-27",
+            "href" : "schedule/2/paragraph/27",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -21822,24 +25624,32 @@
       "number" : "SCHEDULE 2A",
       "title" : "Gibraltar-based persons carrying on activities in the UK",
       "ref" : "schedule-2A",
+      "id" : "schedule-2A",
+      "href" : "schedule/2A",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "part",
         "number" : "PART 1",
         "title" : "Interpretation etc",
         "ref" : "schedule-2A-part-1",
+        "id" : "schedule-2A-part-1",
+        "href" : "schedule/2A/part/1",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Gibraltar-based person",
           "ref" : "schedule-2A-part-1-crossheading-gibraltarbased-person",
+          "id" : "schedule-2A-part-1-crossheading-gibraltarbased-person",
+          "href" : "schedule/2A/part/1/crossheading/gibraltarbased-person",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "1",
             "title" : "(1) In this Act, “ Gibraltar-based person ” means a...",
             "ref" : "schedule-2A-paragraph-1",
+            "id" : "schedule-2A-paragraph-1",
+            "href" : "schedule/2A/paragraph/1",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21847,12 +25657,16 @@
           "number" : null,
           "title" : "Regulators",
           "ref" : "schedule-2A-part-1-crossheading-regulators",
+          "id" : "schedule-2A-part-1-crossheading-regulators",
+          "href" : "schedule/2A/part/1/crossheading/regulators",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "2",
             "title" : "(1) In this Schedule— “ the Gibraltar regulator ” means...",
             "ref" : "schedule-2A-paragraph-2",
+            "id" : "schedule-2A-paragraph-2",
+            "href" : "schedule/2A/paragraph/2",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21860,12 +25674,16 @@
           "number" : null,
           "title" : "Activities and branches",
           "ref" : "schedule-2A-part-1-crossheading-activities-and-branches",
+          "id" : "schedule-2A-part-1-crossheading-activities-and-branches",
+          "href" : "schedule/2A/part/1/crossheading/activities-and-branches",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "3",
             "title" : "(1) In this Schedule, “ approved activity ” means a...",
             "ref" : "schedule-2A-paragraph-3",
+            "id" : "schedule-2A-paragraph-3",
+            "href" : "schedule/2A/paragraph/3",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21873,12 +25691,16 @@
           "number" : null,
           "title" : "UK regulators' objectives",
           "ref" : "schedule-2A-part-1-crossheading-uk-regulators-objectives",
+          "id" : "schedule-2A-part-1-crossheading-uk-regulators-objectives",
+          "href" : "schedule/2A/part/1/crossheading/uk-regulators-objectives",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "4",
             "title" : "For the purposes of any provision of this Schedule which...",
             "ref" : "schedule-2A-paragraph-4",
+            "id" : "schedule-2A-paragraph-4",
+            "href" : "schedule/2A/paragraph/4",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -21887,18 +25709,24 @@
         "number" : "PART 2",
         "title" : "Approved activities",
         "ref" : "schedule-2A-part-2",
+        "id" : "schedule-2A-part-2",
+        "href" : "schedule/2A/part/2",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Approval of regulated activities",
           "ref" : "schedule-2A-part-2-crossheading-approval-of-regulated-activities",
+          "id" : "schedule-2A-part-2-crossheading-approval-of-regulated-activities",
+          "href" : "schedule/2A/part/2/crossheading/approval-of-regulated-activities",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "5",
             "title" : "(1) The Treasury may by regulations approve a regulated activity...",
             "ref" : "schedule-2A-paragraph-5",
+            "id" : "schedule-2A-paragraph-5",
+            "href" : "schedule/2A/paragraph/5",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21906,12 +25734,16 @@
           "number" : null,
           "title" : "Corresponding activities regulated in Gibraltar",
           "ref" : "schedule-2A-part-2-crossheading-corresponding-activities-regulated-in-gibraltar",
+          "id" : "schedule-2A-part-2-crossheading-corresponding-activities-regulated-in-gibraltar",
+          "href" : "schedule/2A/part/2/crossheading/corresponding-activities-regulated-in-gibraltar",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "6",
             "title" : "(1) The Treasury must by regulations make provision about how...",
             "ref" : "schedule-2A-paragraph-6",
+            "id" : "schedule-2A-paragraph-6",
+            "href" : "schedule/2A/paragraph/6",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21919,12 +25751,16 @@
           "number" : null,
           "title" : "Objectives",
           "ref" : "schedule-2A-part-2-crossheading-objectives",
+          "id" : "schedule-2A-part-2-crossheading-objectives",
+          "href" : "schedule/2A/part/2/crossheading/objectives",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "7",
             "title" : "(1) The Treasury may not make regulations under paragraph 5...",
             "ref" : "schedule-2A-paragraph-7",
+            "id" : "schedule-2A-paragraph-7",
+            "href" : "schedule/2A/paragraph/7",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21932,12 +25768,16 @@
           "number" : null,
           "title" : "Alignment of law and practice",
           "ref" : "schedule-2A-part-2-crossheading-alignment-of-law-and-practice",
+          "id" : "schedule-2A-part-2-crossheading-alignment-of-law-and-practice",
+          "href" : "schedule/2A/part/2/crossheading/alignment-of-law-and-practice",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "8",
             "title" : "(1) The Treasury may not approve a regulated activity under...",
             "ref" : "schedule-2A-paragraph-8",
+            "id" : "schedule-2A-paragraph-8",
+            "href" : "schedule/2A/paragraph/8",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21945,12 +25785,16 @@
           "number" : null,
           "title" : "Co-operation",
           "ref" : "schedule-2A-part-2-crossheading-cooperation",
+          "id" : "schedule-2A-part-2-crossheading-cooperation",
+          "href" : "schedule/2A/part/2/crossheading/cooperation",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "9",
             "title" : "(1) The Treasury may not approve a regulated activity under...",
             "ref" : "schedule-2A-paragraph-9",
+            "id" : "schedule-2A-paragraph-9",
+            "href" : "schedule/2A/paragraph/9",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21958,12 +25802,16 @@
           "number" : null,
           "title" : "Consultation",
           "ref" : "schedule-2A-part-2-crossheading-consultation",
+          "id" : "schedule-2A-part-2-crossheading-consultation",
+          "href" : "schedule/2A/part/2/crossheading/consultation",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "10",
             "title" : "Before making regulations under paragraph 5 or 6, the Treasury...",
             "ref" : "schedule-2A-paragraph-10",
+            "id" : "schedule-2A-paragraph-10",
+            "href" : "schedule/2A/paragraph/10",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -21971,12 +25819,16 @@
           "number" : null,
           "title" : "Withdrawal of approval",
           "ref" : "schedule-2A-part-2-crossheading-withdrawal-of-approval",
+          "id" : "schedule-2A-part-2-crossheading-withdrawal-of-approval",
+          "href" : "schedule/2A/part/2/crossheading/withdrawal-of-approval",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "11",
             "title" : "(1) The restrictions in paragraphs 7, 8 and 9 do...",
             "ref" : "schedule-2A-paragraph-11",
+            "id" : "schedule-2A-paragraph-11",
+            "href" : "schedule/2A/paragraph/11",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -21985,18 +25837,24 @@
         "number" : "PART 3",
         "title" : "Permission to carry on an approved activity",
         "ref" : "schedule-2A-part-3",
+        "id" : "schedule-2A-part-3",
+        "href" : "schedule/2A/part/3",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Obtaining permission to carry on an approved activity",
           "ref" : "schedule-2A-part-3-crossheading-obtaining-permission-to-carry-on-an-approved-activity",
+          "id" : "schedule-2A-part-3-crossheading-obtaining-permission-to-carry-on-an-approved-activity",
+          "href" : "schedule/2A/part/3/crossheading/obtaining-permission-to-carry-on-an-approved-activity",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "12",
             "title" : "(1) If the appropriate UK regulator receives a notification from...",
             "ref" : "schedule-2A-paragraph-12",
+            "id" : "schedule-2A-paragraph-12",
+            "href" : "schedule/2A/paragraph/12",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22004,12 +25862,16 @@
           "number" : null,
           "title" : "Schedule 2A permission",
           "ref" : "schedule-2A-part-3-crossheading-schedule-2a-permission",
+          "id" : "schedule-2A-part-3-crossheading-schedule-2a-permission",
+          "href" : "schedule/2A/part/3/crossheading/schedule-2a-permission",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "13",
             "title" : "(1) A Schedule 2A permission for a person to carry...",
             "ref" : "schedule-2A-paragraph-13",
+            "id" : "schedule-2A-paragraph-13",
+            "href" : "schedule/2A/paragraph/13",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22017,12 +25879,16 @@
           "number" : null,
           "title" : "The appropriate UK regulator",
           "ref" : "schedule-2A-part-3-crossheading-the-appropriate-uk-regulator",
+          "id" : "schedule-2A-part-3-crossheading-the-appropriate-uk-regulator",
+          "href" : "schedule/2A/part/3/crossheading/the-appropriate-uk-regulator",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "14",
             "title" : "In relation to a notification, “ the appropriate UK regulator...",
             "ref" : "schedule-2A-paragraph-14",
+            "id" : "schedule-2A-paragraph-14",
+            "href" : "schedule/2A/paragraph/14",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22030,12 +25896,16 @@
           "number" : null,
           "title" : "Notifying the appropriate UK regulator",
           "ref" : "schedule-2A-part-3-crossheading-notifying-the-appropriate-uk-regulator",
+          "id" : "schedule-2A-part-3-crossheading-notifying-the-appropriate-uk-regulator",
+          "href" : "schedule/2A/part/3/crossheading/notifying-the-appropriate-uk-regulator",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "15",
             "title" : "(1) A notification must— (a) name the Gibraltar-based person, ",
             "ref" : "schedule-2A-paragraph-15",
+            "id" : "schedule-2A-paragraph-15",
+            "href" : "schedule/2A/paragraph/15",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22043,12 +25913,16 @@
           "number" : null,
           "title" : "Considering a notification",
           "ref" : "schedule-2A-part-3-crossheading-considering-a-notification",
+          "id" : "schedule-2A-part-3-crossheading-considering-a-notification",
+          "href" : "schedule/2A/part/3/crossheading/considering-a-notification",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "16",
             "title" : "(1) Where the appropriate UK regulator receives a notification, it...",
             "ref" : "schedule-2A-paragraph-16",
+            "id" : "schedule-2A-paragraph-16",
+            "href" : "schedule/2A/paragraph/16",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22056,12 +25930,16 @@
           "number" : null,
           "title" : "Rejecting a notification",
           "ref" : "schedule-2A-part-3-crossheading-rejecting-a-notification",
+          "id" : "schedule-2A-part-3-crossheading-rejecting-a-notification",
+          "href" : "schedule/2A/part/3/crossheading/rejecting-a-notification",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "17",
             "title" : "(1) The appropriate UK regulator may not reject a notification...",
             "ref" : "schedule-2A-paragraph-17",
+            "id" : "schedule-2A-paragraph-17",
+            "href" : "schedule/2A/paragraph/17",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22069,12 +25947,16 @@
           "number" : null,
           "title" : "Duties to reject",
           "ref" : "schedule-2A-part-3-crossheading-duties-to-reject",
+          "id" : "schedule-2A-part-3-crossheading-duties-to-reject",
+          "href" : "schedule/2A/part/3/crossheading/duties-to-reject",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "18",
             "title" : "(1) The appropriate UK regulator must reject a notification if...",
             "ref" : "schedule-2A-paragraph-18",
+            "id" : "schedule-2A-paragraph-18",
+            "href" : "schedule/2A/paragraph/18",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22082,12 +25964,16 @@
           "number" : null,
           "title" : "Power to reject: prohibition order in respect of senior manager",
           "ref" : "schedule-2A-part-3-crossheading-power-to-reject-prohibition-order-in-respect-of-senior-manager",
+          "id" : "schedule-2A-part-3-crossheading-power-to-reject-prohibition-order-in-respect-of-senior-manager",
+          "href" : "schedule/2A/part/3/crossheading/power-to-reject-prohibition-order-in-respect-of-senior-manager",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "19",
             "title" : "(1) The appropriate UK regulator may reject a notification, so...",
             "ref" : "schedule-2A-paragraph-19",
+            "id" : "schedule-2A-paragraph-19",
+            "href" : "schedule/2A/paragraph/19",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22095,12 +25981,16 @@
           "number" : null,
           "title" : "Power to reject: loss of access right and serious threat to the UK",
           "ref" : "schedule-2A-part-3-crossheading-power-to-reject-loss-of-access-right-and-serious-threat-to-the-uk",
+          "id" : "schedule-2A-part-3-crossheading-power-to-reject-loss-of-access-right-and-serious-threat-to-the-uk",
+          "href" : "schedule/2A/part/3/crossheading/power-to-reject-loss-of-access-right-and-serious-threat-to-the-uk",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "20",
             "title" : "(1) The appropriate UK regulator may reject a notification if...",
             "ref" : "schedule-2A-paragraph-20",
+            "id" : "schedule-2A-paragraph-20",
+            "href" : "schedule/2A/paragraph/20",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -22109,18 +25999,24 @@
         "number" : "PART 4",
         "title" : "Variation of permission",
         "ref" : "schedule-2A-part-4",
+        "id" : "schedule-2A-part-4",
+        "href" : "schedule/2A/part/4",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Variation of permission",
           "ref" : "schedule-2A-part-4-crossheading-variation-of-permission",
+          "id" : "schedule-2A-part-4-crossheading-variation-of-permission",
+          "href" : "schedule/2A/part/4/crossheading/variation-of-permission",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "21",
             "title" : "(1) A Schedule 2A permission may be varied in accordance...",
             "ref" : "schedule-2A-paragraph-21",
+            "id" : "schedule-2A-paragraph-21",
+            "href" : "schedule/2A/paragraph/21",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22128,12 +26024,16 @@
           "number" : null,
           "title" : "Gibraltar regulator's initiative: notification",
           "ref" : "schedule-2A-part-4-crossheading-gibraltar-regulators-initiative-notification",
+          "id" : "schedule-2A-part-4-crossheading-gibraltar-regulators-initiative-notification",
+          "href" : "schedule/2A/part/4/crossheading/gibraltar-regulators-initiative-notification",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "22",
             "title" : "(1) If the appropriate UK regulator receives a notification from...",
             "ref" : "schedule-2A-paragraph-22",
+            "id" : "schedule-2A-paragraph-22",
+            "href" : "schedule/2A/paragraph/22",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22141,12 +26041,16 @@
           "number" : null,
           "title" : "Gibraltar regulator's initiative: the appropriate UK regulator",
           "ref" : "schedule-2A-part-4-crossheading-gibraltar-regulators-initiative-the-appropriate-uk-regulator",
+          "id" : "schedule-2A-part-4-crossheading-gibraltar-regulators-initiative-the-appropriate-uk-regulator",
+          "href" : "schedule/2A/part/4/crossheading/gibraltar-regulators-initiative-the-appropriate-uk-regulator",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "23",
             "title" : "In relation to a notification, “ the appropriate UK regulator...",
             "ref" : "schedule-2A-paragraph-23",
+            "id" : "schedule-2A-paragraph-23",
+            "href" : "schedule/2A/paragraph/23",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22154,12 +26058,16 @@
           "number" : null,
           "title" : "Gibraltar regulator's initiative: notifying the UK regulator",
           "ref" : "schedule-2A-part-4-crossheading-gibraltar-regulators-initiative-notifying-the-uk-regulator",
+          "id" : "schedule-2A-part-4-crossheading-gibraltar-regulators-initiative-notifying-the-uk-regulator",
+          "href" : "schedule/2A/part/4/crossheading/gibraltar-regulators-initiative-notifying-the-uk-regulator",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "24",
             "title" : "(1) A notification must— (a) state the desired variation, ",
             "ref" : "schedule-2A-paragraph-24",
+            "id" : "schedule-2A-paragraph-24",
+            "href" : "schedule/2A/paragraph/24",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22167,12 +26075,16 @@
           "number" : null,
           "title" : "Gibraltar regulator's initiative: considering a notification",
           "ref" : "schedule-2A-part-4-crossheading-gibraltar-regulators-initiative-considering-a-notification",
+          "id" : "schedule-2A-part-4-crossheading-gibraltar-regulators-initiative-considering-a-notification",
+          "href" : "schedule/2A/part/4/crossheading/gibraltar-regulators-initiative-considering-a-notification",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "25",
             "title" : "(1) Where the appropriate UK regulator receives a notification, it...",
             "ref" : "schedule-2A-paragraph-25",
+            "id" : "schedule-2A-paragraph-25",
+            "href" : "schedule/2A/paragraph/25",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22180,12 +26092,16 @@
           "number" : null,
           "title" : "Gibraltar regulator's initiative: rejecting a notification",
           "ref" : "schedule-2A-part-4-crossheading-gibraltar-regulators-initiative-rejecting-a-notification",
+          "id" : "schedule-2A-part-4-crossheading-gibraltar-regulators-initiative-rejecting-a-notification",
+          "href" : "schedule/2A/part/4/crossheading/gibraltar-regulators-initiative-rejecting-a-notification",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "26",
             "title" : "(1) The appropriate UK regulator may not reject a notification...",
             "ref" : "schedule-2A-paragraph-26",
+            "id" : "schedule-2A-paragraph-26",
+            "href" : "schedule/2A/paragraph/26",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22193,12 +26109,16 @@
           "number" : null,
           "title" : "UK regulator's initiative",
           "ref" : "schedule-2A-part-4-crossheading-uk-regulators-initiative",
+          "id" : "schedule-2A-part-4-crossheading-uk-regulators-initiative",
+          "href" : "schedule/2A/part/4/crossheading/uk-regulators-initiative",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "27",
             "title" : "(1) A UK regulator may exercise a power under this...",
             "ref" : "schedule-2A-paragraph-27",
+            "id" : "schedule-2A-paragraph-27",
+            "href" : "schedule/2A/paragraph/27",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22206,12 +26126,16 @@
           "number" : null,
           "title" : "Own-initiative conditions",
           "ref" : "schedule-2A-part-4-crossheading-owninitiative-conditions",
+          "id" : "schedule-2A-part-4-crossheading-owninitiative-conditions",
+          "href" : "schedule/2A/part/4/crossheading/owninitiative-conditions",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "28",
             "title" : "(1) For the purposes of this Schedule, “the own-initiative conditions”...",
             "ref" : "schedule-2A-paragraph-28",
+            "id" : "schedule-2A-paragraph-28",
+            "href" : "schedule/2A/paragraph/28",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22219,12 +26143,16 @@
           "number" : null,
           "title" : "UK regulator's initiative: procedure",
           "ref" : "schedule-2A-part-4-crossheading-uk-regulators-initiative-procedure",
+          "id" : "schedule-2A-part-4-crossheading-uk-regulators-initiative-procedure",
+          "href" : "schedule/2A/part/4/crossheading/uk-regulators-initiative-procedure",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "29",
             "title" : "(1) The variation of a Schedule 2A permission under paragraph...",
             "ref" : "schedule-2A-paragraph-29",
+            "id" : "schedule-2A-paragraph-29",
+            "href" : "schedule/2A/paragraph/29",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22232,12 +26160,16 @@
           "number" : null,
           "title" : "Right to refer matters to the Tribunal",
           "ref" : "schedule-2A-part-4-crossheading-right-to-refer-matters-to-the-tribunal",
+          "id" : "schedule-2A-part-4-crossheading-right-to-refer-matters-to-the-tribunal",
+          "href" : "schedule/2A/part/4/crossheading/right-to-refer-matters-to-the-tribunal",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "30",
             "title" : "A Gibraltar-based person who is aggrieved by the exercise by...",
             "ref" : "schedule-2A-paragraph-30",
+            "id" : "schedule-2A-paragraph-30",
+            "href" : "schedule/2A/paragraph/30",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -22246,18 +26178,24 @@
         "number" : "PART 5",
         "title" : "Cancellation of permission",
         "ref" : "schedule-2A-part-5",
+        "id" : "schedule-2A-part-5",
+        "href" : "schedule/2A/part/5",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Cancellation of permission",
           "ref" : "schedule-2A-part-5-crossheading-cancellation-of-permission",
+          "id" : "schedule-2A-part-5-crossheading-cancellation-of-permission",
+          "href" : "schedule/2A/part/5/crossheading/cancellation-of-permission",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "31",
             "title" : "A Schedule 2A permission may be cancelled in accordance with...",
             "ref" : "schedule-2A-paragraph-31",
+            "id" : "schedule-2A-paragraph-31",
+            "href" : "schedule/2A/paragraph/31",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22265,12 +26203,16 @@
           "number" : null,
           "title" : "Gibraltar regulator's initiative: notification",
           "ref" : "schedule-2A-part-5-crossheading-gibraltar-regulators-initiative-notification",
+          "id" : "schedule-2A-part-5-crossheading-gibraltar-regulators-initiative-notification",
+          "href" : "schedule/2A/part/5/crossheading/gibraltar-regulators-initiative-notification",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "32",
             "title" : "(1) If the appropriate UK regulator receives a notification from...",
             "ref" : "schedule-2A-paragraph-32",
+            "id" : "schedule-2A-paragraph-32",
+            "href" : "schedule/2A/paragraph/32",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22278,12 +26220,16 @@
           "number" : null,
           "title" : "Gibraltar regulator's initiative: the appropriate UK regulator",
           "ref" : "schedule-2A-part-5-crossheading-gibraltar-regulators-initiative-the-appropriate-uk-regulator",
+          "id" : "schedule-2A-part-5-crossheading-gibraltar-regulators-initiative-the-appropriate-uk-regulator",
+          "href" : "schedule/2A/part/5/crossheading/gibraltar-regulators-initiative-the-appropriate-uk-regulator",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "33",
             "title" : "In relation to a notification, “ the appropriate UK regulator...",
             "ref" : "schedule-2A-paragraph-33",
+            "id" : "schedule-2A-paragraph-33",
+            "href" : "schedule/2A/paragraph/33",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22291,12 +26237,16 @@
           "number" : null,
           "title" : "Gibraltar regulator's initiative: notifying the UK regulator",
           "ref" : "schedule-2A-part-5-crossheading-gibraltar-regulators-initiative-notifying-the-uk-regulator",
+          "id" : "schedule-2A-part-5-crossheading-gibraltar-regulators-initiative-notifying-the-uk-regulator",
+          "href" : "schedule/2A/part/5/crossheading/gibraltar-regulators-initiative-notifying-the-uk-regulator",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "34",
             "title" : "A notification must— (a) state the reason for requesting the...",
             "ref" : "schedule-2A-paragraph-34",
+            "id" : "schedule-2A-paragraph-34",
+            "href" : "schedule/2A/paragraph/34",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22304,12 +26254,16 @@
           "number" : null,
           "title" : "Gibraltar regulator's initiative: considering a notification",
           "ref" : "schedule-2A-part-5-crossheading-gibraltar-regulators-initiative-considering-a-notification",
+          "id" : "schedule-2A-part-5-crossheading-gibraltar-regulators-initiative-considering-a-notification",
+          "href" : "schedule/2A/part/5/crossheading/gibraltar-regulators-initiative-considering-a-notification",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "35",
             "title" : "(1) Where the appropriate UK regulator receives a notification, it...",
             "ref" : "schedule-2A-paragraph-35",
+            "id" : "schedule-2A-paragraph-35",
+            "href" : "schedule/2A/paragraph/35",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22317,12 +26271,16 @@
           "number" : null,
           "title" : "Gibraltar regulator's initiative: rejecting a notification",
           "ref" : "schedule-2A-part-5-crossheading-gibraltar-regulators-initiative-rejecting-a-notification",
+          "id" : "schedule-2A-part-5-crossheading-gibraltar-regulators-initiative-rejecting-a-notification",
+          "href" : "schedule/2A/part/5/crossheading/gibraltar-regulators-initiative-rejecting-a-notification",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "36",
             "title" : "(1) The appropriate UK regulator may not reject a notification...",
             "ref" : "schedule-2A-paragraph-36",
+            "id" : "schedule-2A-paragraph-36",
+            "href" : "schedule/2A/paragraph/36",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22330,12 +26288,16 @@
           "number" : null,
           "title" : "UK regulator's initiative",
           "ref" : "schedule-2A-part-5-crossheading-uk-regulators-initiative",
+          "id" : "schedule-2A-part-5-crossheading-uk-regulators-initiative",
+          "href" : "schedule/2A/part/5/crossheading/uk-regulators-initiative",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "37",
             "title" : "(1) The FCA may cancel a Schedule 2A permission where...",
             "ref" : "schedule-2A-paragraph-37",
+            "id" : "schedule-2A-paragraph-37",
+            "href" : "schedule/2A/paragraph/37",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22343,12 +26305,16 @@
           "number" : null,
           "title" : "UK regulator's initiative: procedure",
           "ref" : "schedule-2A-part-5-crossheading-uk-regulators-initiative-procedure",
+          "id" : "schedule-2A-part-5-crossheading-uk-regulators-initiative-procedure",
+          "href" : "schedule/2A/part/5/crossheading/uk-regulators-initiative-procedure",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "38",
             "title" : "(1) If a UK regulator proposes to cancel a Gibraltar-based...",
             "ref" : "schedule-2A-paragraph-38",
+            "id" : "schedule-2A-paragraph-38",
+            "href" : "schedule/2A/paragraph/38",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22356,12 +26322,16 @@
           "number" : null,
           "title" : "Right to refer matters to the Tribunal",
           "ref" : "schedule-2A-part-5-crossheading-right-to-refer-matters-to-the-tribunal",
+          "id" : "schedule-2A-part-5-crossheading-right-to-refer-matters-to-the-tribunal",
+          "href" : "schedule/2A/part/5/crossheading/right-to-refer-matters-to-the-tribunal",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "39",
             "title" : "If a UK regulator gives a Gibraltar-based person a decision...",
             "ref" : "schedule-2A-paragraph-39",
+            "id" : "schedule-2A-paragraph-39",
+            "href" : "schedule/2A/paragraph/39",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -22370,18 +26340,24 @@
         "number" : "PART 6",
         "title" : "Requirements",
         "ref" : "schedule-2A-part-6",
+        "id" : "schedule-2A-part-6",
+        "href" : "schedule/2A/part/6",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Requirements",
           "ref" : "schedule-2A-part-6-crossheading-requirements",
+          "id" : "schedule-2A-part-6-crossheading-requirements",
+          "href" : "schedule/2A/part/6/crossheading/requirements",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "40",
             "title" : "(1) A requirement may be imposed on a Gibraltar-based person...",
             "ref" : "schedule-2A-paragraph-40",
+            "id" : "schedule-2A-paragraph-40",
+            "href" : "schedule/2A/paragraph/40",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22389,12 +26365,16 @@
           "number" : null,
           "title" : "Imposing requirements in connection with Part 3 or 4 notification",
           "ref" : "schedule-2A-part-6-crossheading-imposing-requirements-in-connection-with-part-3-or-4-notification",
+          "id" : "schedule-2A-part-6-crossheading-imposing-requirements-in-connection-with-part-3-or-4-notification",
+          "href" : "schedule/2A/part/6/crossheading/imposing-requirements-in-connection-with-part-3-or-4-notification",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "41",
             "title" : "(1) This paragraph applies where a UK regulator has received—...",
             "ref" : "schedule-2A-paragraph-41",
+            "id" : "schedule-2A-paragraph-41",
+            "href" : "schedule/2A/paragraph/41",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22402,12 +26382,16 @@
           "number" : null,
           "title" : "Imposing requirements in connection with Part 3 or 4 notification: procedure",
           "ref" : "schedule-2A-part-6-crossheading-imposing-requirements-in-connection-with-part-3-or-4-notification-procedure",
+          "id" : "schedule-2A-part-6-crossheading-imposing-requirements-in-connection-with-part-3-or-4-notification-procedure",
+          "href" : "schedule/2A/part/6/crossheading/imposing-requirements-in-connection-with-part-3-or-4-notification-procedure",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "42",
             "title" : "(1) If a UK regulator proposes to impose a requirement...",
             "ref" : "schedule-2A-paragraph-42",
+            "id" : "schedule-2A-paragraph-42",
+            "href" : "schedule/2A/paragraph/42",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22415,12 +26399,16 @@
           "number" : null,
           "title" : "Right to refer matters to the Tribunal",
           "ref" : "schedule-2A-part-6-crossheading-right-to-refer-matters-to-the-tribunal",
+          "id" : "schedule-2A-part-6-crossheading-right-to-refer-matters-to-the-tribunal",
+          "href" : "schedule/2A/part/6/crossheading/right-to-refer-matters-to-the-tribunal",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "43",
             "title" : "If a UK regulator gives a Gibraltar-based person a decision...",
             "ref" : "schedule-2A-paragraph-43",
+            "id" : "schedule-2A-paragraph-43",
+            "href" : "schedule/2A/paragraph/43",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22428,12 +26416,16 @@
           "number" : null,
           "title" : "Gibraltar regulator's initiative: notification",
           "ref" : "schedule-2A-part-6-crossheading-gibraltar-regulators-initiative-notification",
+          "id" : "schedule-2A-part-6-crossheading-gibraltar-regulators-initiative-notification",
+          "href" : "schedule/2A/part/6/crossheading/gibraltar-regulators-initiative-notification",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "44",
             "title" : "(1) If the appropriate UK regulator receives a notification from...",
             "ref" : "schedule-2A-paragraph-44",
+            "id" : "schedule-2A-paragraph-44",
+            "href" : "schedule/2A/paragraph/44",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22441,12 +26433,16 @@
           "number" : null,
           "title" : "Gibraltar regulator's initiative: the appropriate UK regulator",
           "ref" : "schedule-2A-part-6-crossheading-gibraltar-regulators-initiative-the-appropriate-uk-regulator",
+          "id" : "schedule-2A-part-6-crossheading-gibraltar-regulators-initiative-the-appropriate-uk-regulator",
+          "href" : "schedule/2A/part/6/crossheading/gibraltar-regulators-initiative-the-appropriate-uk-regulator",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "45",
             "title" : "In relation to a notification, “ the appropriate UK regulator...",
             "ref" : "schedule-2A-paragraph-45",
+            "id" : "schedule-2A-paragraph-45",
+            "href" : "schedule/2A/paragraph/45",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22454,12 +26450,16 @@
           "number" : null,
           "title" : "Gibraltar regulator's initiative: notifying the UK regulator",
           "ref" : "schedule-2A-part-6-crossheading-gibraltar-regulators-initiative-notifying-the-uk-regulator",
+          "id" : "schedule-2A-part-6-crossheading-gibraltar-regulators-initiative-notifying-the-uk-regulator",
+          "href" : "schedule/2A/part/6/crossheading/gibraltar-regulators-initiative-notifying-the-uk-regulator",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "46",
             "title" : "A notification must— (a) state the requirement to be imposed...",
             "ref" : "schedule-2A-paragraph-46",
+            "id" : "schedule-2A-paragraph-46",
+            "href" : "schedule/2A/paragraph/46",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22467,12 +26467,16 @@
           "number" : null,
           "title" : "Gibraltar regulator's initiative: considering a notification",
           "ref" : "schedule-2A-part-6-crossheading-gibraltar-regulators-initiative-considering-a-notification",
+          "id" : "schedule-2A-part-6-crossheading-gibraltar-regulators-initiative-considering-a-notification",
+          "href" : "schedule/2A/part/6/crossheading/gibraltar-regulators-initiative-considering-a-notification",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "47",
             "title" : "(1) Where the appropriate UK regulator receives a notification, it...",
             "ref" : "schedule-2A-paragraph-47",
+            "id" : "schedule-2A-paragraph-47",
+            "href" : "schedule/2A/paragraph/47",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22480,12 +26484,16 @@
           "number" : null,
           "title" : "Gibraltar regulator's initiative: rejecting a notification",
           "ref" : "schedule-2A-part-6-crossheading-gibraltar-regulators-initiative-rejecting-a-notification",
+          "id" : "schedule-2A-part-6-crossheading-gibraltar-regulators-initiative-rejecting-a-notification",
+          "href" : "schedule/2A/part/6/crossheading/gibraltar-regulators-initiative-rejecting-a-notification",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "48",
             "title" : "(1) The appropriate UK regulator may not reject a notification...",
             "ref" : "schedule-2A-paragraph-48",
+            "id" : "schedule-2A-paragraph-48",
+            "href" : "schedule/2A/paragraph/48",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22493,12 +26501,16 @@
           "number" : null,
           "title" : "UK regulator's initiative: imposing, varying and cancelling requirements",
           "ref" : "schedule-2A-part-6-crossheading-uk-regulators-initiative-imposing-varying-and-cancelling-requirements",
+          "id" : "schedule-2A-part-6-crossheading-uk-regulators-initiative-imposing-varying-and-cancelling-requirements",
+          "href" : "schedule/2A/part/6/crossheading/uk-regulators-initiative-imposing-varying-and-cancelling-requirements",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "49",
             "title" : "(1) A UK regulator may exercise the powers under this...",
             "ref" : "schedule-2A-paragraph-49",
+            "id" : "schedule-2A-paragraph-49",
+            "href" : "schedule/2A/paragraph/49",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22506,12 +26518,16 @@
           "number" : null,
           "title" : "UK regulator's initiative: procedure for imposing or varying requirements",
           "ref" : "schedule-2A-part-6-crossheading-uk-regulators-initiative-procedure-for-imposing-or-varying-requirements",
+          "id" : "schedule-2A-part-6-crossheading-uk-regulators-initiative-procedure-for-imposing-or-varying-requirements",
+          "href" : "schedule/2A/part/6/crossheading/uk-regulators-initiative-procedure-for-imposing-or-varying-requirements",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "50",
             "title" : "(1) The imposition or variation of a requirement under paragraph...",
             "ref" : "schedule-2A-paragraph-50",
+            "id" : "schedule-2A-paragraph-50",
+            "href" : "schedule/2A/paragraph/50",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22519,12 +26535,16 @@
           "number" : null,
           "title" : "UK regulator's initiative: procedure for cancellation",
           "ref" : "schedule-2A-part-6-crossheading-uk-regulators-initiative-procedure-for-cancellation",
+          "id" : "schedule-2A-part-6-crossheading-uk-regulators-initiative-procedure-for-cancellation",
+          "href" : "schedule/2A/part/6/crossheading/uk-regulators-initiative-procedure-for-cancellation",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "51",
             "title" : "(1) If a UK regulator proposes to exercise a power...",
             "ref" : "schedule-2A-paragraph-51",
+            "id" : "schedule-2A-paragraph-51",
+            "href" : "schedule/2A/paragraph/51",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22532,12 +26552,16 @@
           "number" : null,
           "title" : "Right to refer matters to the Tribunal",
           "ref" : "schedule-2A-part-6-crossheading-right-to-refer-matters-to-the-tribunal-n1",
+          "id" : "schedule-2A-part-6-crossheading-right-to-refer-matters-to-the-tribunal-n1",
+          "href" : "schedule/2A/part/6/crossheading/right-to-refer-matters-to-the-tribunal-n1",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "52",
             "title" : "A Gibraltar-based person who is aggrieved by the exercise by...",
             "ref" : "schedule-2A-paragraph-52",
+            "id" : "schedule-2A-paragraph-52",
+            "href" : "schedule/2A/paragraph/52",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22545,12 +26569,16 @@
           "number" : null,
           "title" : "Assets requirements",
           "ref" : "schedule-2A-part-6-crossheading-assets-requirements",
+          "id" : "schedule-2A-part-6-crossheading-assets-requirements",
+          "href" : "schedule/2A/part/6/crossheading/assets-requirements",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "53",
             "title" : "(1) This paragraph makes provision about a requirement imposed on...",
             "ref" : "schedule-2A-paragraph-53",
+            "id" : "schedule-2A-paragraph-53",
+            "href" : "schedule/2A/paragraph/53",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22558,12 +26586,16 @@
           "number" : null,
           "title" : "Further provision about requirements",
           "ref" : "schedule-2A-part-6-crossheading-further-provision-about-requirements",
+          "id" : "schedule-2A-part-6-crossheading-further-provision-about-requirements",
+          "href" : "schedule/2A/part/6/crossheading/further-provision-about-requirements",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "54",
             "title" : "(1) A requirement imposed on a Gibraltar-based person under this...",
             "ref" : "schedule-2A-paragraph-54",
+            "id" : "schedule-2A-paragraph-54",
+            "href" : "schedule/2A/paragraph/54",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22571,12 +26603,16 @@
           "number" : null,
           "title" : "Contravention of requirement imposed under this Part",
           "ref" : "schedule-2A-part-6-crossheading-contravention-of-requirement-imposed-under-this-part",
+          "id" : "schedule-2A-part-6-crossheading-contravention-of-requirement-imposed-under-this-part",
+          "href" : "schedule/2A/part/6/crossheading/contravention-of-requirement-imposed-under-this-part",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "55",
             "title" : "(1) Contravention of a requirement imposed under this Part of...",
             "ref" : "schedule-2A-paragraph-55",
+            "id" : "schedule-2A-paragraph-55",
+            "href" : "schedule/2A/paragraph/55",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -22585,18 +26621,24 @@
         "number" : "PART 7",
         "title" : "Changes",
         "ref" : "schedule-2A-part-7",
+        "id" : "schedule-2A-part-7",
+        "href" : "schedule/2A/part/7",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Duty to notify UK regulators of changes",
           "ref" : "schedule-2A-part-7-crossheading-duty-to-notify-uk-regulators-of-changes",
+          "id" : "schedule-2A-part-7-crossheading-duty-to-notify-uk-regulators-of-changes",
+          "href" : "schedule/2A/part/7/crossheading/duty-to-notify-uk-regulators-of-changes",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "56",
             "title" : "(1) A UK regulator may direct that a change relating...",
             "ref" : "schedule-2A-paragraph-56",
+            "id" : "schedule-2A-paragraph-56",
+            "href" : "schedule/2A/paragraph/56",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -22605,18 +26647,24 @@
         "number" : "PART 8",
         "title" : "UK regulators' directions about information",
         "ref" : "schedule-2A-part-8",
+        "id" : "schedule-2A-part-8",
+        "href" : "schedule/2A/part/8",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Directions about information to be included in notifications",
           "ref" : "schedule-2A-part-8-crossheading-directions-about-information-to-be-included-in-notifications",
+          "id" : "schedule-2A-part-8-crossheading-directions-about-information-to-be-included-in-notifications",
+          "href" : "schedule/2A/part/8/crossheading/directions-about-information-to-be-included-in-notifications",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "57",
             "title" : "(1) A UK regulator may direct that a notification for...",
             "ref" : "schedule-2A-paragraph-57",
+            "id" : "schedule-2A-paragraph-57",
+            "href" : "schedule/2A/paragraph/57",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -22625,18 +26673,24 @@
         "number" : "PART 9",
         "title" : "Transition on withdrawal of approval of regulated activity etc",
         "ref" : "schedule-2A-part-9",
+        "id" : "schedule-2A-part-9",
+        "href" : "schedule/2A/part/9",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Transition on withdrawal of approval of regulated activity",
           "ref" : "schedule-2A-part-9-crossheading-transition-on-withdrawal-of-approval-of-regulated-activity",
+          "id" : "schedule-2A-part-9-crossheading-transition-on-withdrawal-of-approval-of-regulated-activity",
+          "href" : "schedule/2A/part/9/crossheading/transition-on-withdrawal-of-approval-of-regulated-activity",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "58",
             "title" : "(1) Sub-paragraph (2) applies where— (a) the Treasury withdraw their...",
             "ref" : "schedule-2A-paragraph-58",
+            "id" : "schedule-2A-paragraph-58",
+            "href" : "schedule/2A/paragraph/58",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22644,12 +26698,16 @@
           "number" : null,
           "title" : "Transition on Gibraltar activity ceasing to be corresponding activity",
           "ref" : "schedule-2A-part-9-crossheading-transition-on-gibraltar-activity-ceasing-to-be-corresponding-activity",
+          "id" : "schedule-2A-part-9-crossheading-transition-on-gibraltar-activity-ceasing-to-be-corresponding-activity",
+          "href" : "schedule/2A/part/9/crossheading/transition-on-gibraltar-activity-ceasing-to-be-corresponding-activity",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "59",
             "title" : "(1) Sub-paragraph (2) applies where— (a) the Treasury provide that...",
             "ref" : "schedule-2A-paragraph-59",
+            "id" : "schedule-2A-paragraph-59",
+            "href" : "schedule/2A/paragraph/59",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22657,12 +26715,16 @@
           "number" : null,
           "title" : "Restricting transitional permission",
           "ref" : "schedule-2A-part-9-crossheading-restricting-transitional-permission",
+          "id" : "schedule-2A-part-9-crossheading-restricting-transitional-permission",
+          "href" : "schedule/2A/part/9/crossheading/restricting-transitional-permission",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "60",
             "title" : "(1) Sub-paragraph (2) applies where— (a) by virtue of paragraph...",
             "ref" : "schedule-2A-paragraph-60",
+            "id" : "schedule-2A-paragraph-60",
+            "href" : "schedule/2A/paragraph/60",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22670,12 +26732,16 @@
           "number" : null,
           "title" : "Directions about protected contracts",
           "ref" : "schedule-2A-part-9-crossheading-directions-about-protected-contracts",
+          "id" : "schedule-2A-part-9-crossheading-directions-about-protected-contracts",
+          "href" : "schedule/2A/part/9/crossheading/directions-about-protected-contracts",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "61",
             "title" : "(1) A UK regulator may direct that a contract specified...",
             "ref" : "schedule-2A-paragraph-61",
+            "id" : "schedule-2A-paragraph-61",
+            "href" : "schedule/2A/paragraph/61",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22683,12 +26749,16 @@
           "number" : null,
           "title" : "Right to refer matters to the Tribunal",
           "ref" : "schedule-2A-part-9-crossheading-right-to-refer-matters-to-the-tribunal",
+          "id" : "schedule-2A-part-9-crossheading-right-to-refer-matters-to-the-tribunal",
+          "href" : "schedule/2A/part/9/crossheading/right-to-refer-matters-to-the-tribunal",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "62",
             "title" : "Where a person in respect of whom a decision under...",
             "ref" : "schedule-2A-paragraph-62",
+            "id" : "schedule-2A-paragraph-62",
+            "href" : "schedule/2A/paragraph/62",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22696,12 +26766,16 @@
           "number" : null,
           "title" : "Further powers",
           "ref" : "schedule-2A-part-9-crossheading-further-powers",
+          "id" : "schedule-2A-part-9-crossheading-further-powers",
+          "href" : "schedule/2A/part/9/crossheading/further-powers",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "63",
             "title" : "(1) The Treasury may by regulations extend the period under...",
             "ref" : "schedule-2A-paragraph-63",
+            "id" : "schedule-2A-paragraph-63",
+            "href" : "schedule/2A/paragraph/63",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -22710,18 +26784,24 @@
         "number" : "PART 10",
         "title" : "Transition on cancellation of UK or Gibraltar permission",
         "ref" : "schedule-2A-part-10",
+        "id" : "schedule-2A-part-10",
+        "href" : "schedule/2A/part/10",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Transition on cancellation of Schedule 2A permission",
           "ref" : "schedule-2A-part-10-crossheading-transition-on-cancellation-of-schedule-2a-permission",
+          "id" : "schedule-2A-part-10-crossheading-transition-on-cancellation-of-schedule-2a-permission",
+          "href" : "schedule/2A/part/10/crossheading/transition-on-cancellation-of-schedule-2a-permission",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "64",
             "title" : "(1) Sub-paragraphs (2), (4) and (5) apply where— ",
             "ref" : "schedule-2A-paragraph-64",
+            "id" : "schedule-2A-paragraph-64",
+            "href" : "schedule/2A/paragraph/64",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22729,12 +26809,16 @@
           "number" : null,
           "title" : "Transition on cancellation of Gibraltar permission",
           "ref" : "schedule-2A-part-10-crossheading-transition-on-cancellation-of-gibraltar-permission",
+          "id" : "schedule-2A-part-10-crossheading-transition-on-cancellation-of-gibraltar-permission",
+          "href" : "schedule/2A/part/10/crossheading/transition-on-cancellation-of-gibraltar-permission",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "65",
             "title" : "(1) Sub-paragraphs (2) and (4) apply where the Gibraltar regulator—...",
             "ref" : "schedule-2A-paragraph-65",
+            "id" : "schedule-2A-paragraph-65",
+            "href" : "schedule/2A/paragraph/65",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22742,12 +26826,16 @@
           "number" : null,
           "title" : "The appropriate UK regulator",
           "ref" : "schedule-2A-part-10-crossheading-the-appropriate-uk-regulator",
+          "id" : "schedule-2A-part-10-crossheading-the-appropriate-uk-regulator",
+          "href" : "schedule/2A/part/10/crossheading/the-appropriate-uk-regulator",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "66",
             "title" : "(1) In this Part of this Schedule, “ the appropriate...",
             "ref" : "schedule-2A-paragraph-66",
+            "id" : "schedule-2A-paragraph-66",
+            "href" : "schedule/2A/paragraph/66",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22755,12 +26843,16 @@
           "number" : null,
           "title" : "Directions about protected contracts",
           "ref" : "schedule-2A-part-10-crossheading-directions-about-protected-contracts",
+          "id" : "schedule-2A-part-10-crossheading-directions-about-protected-contracts",
+          "href" : "schedule/2A/part/10/crossheading/directions-about-protected-contracts",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "67",
             "title" : "(1) A UK regulator may direct that a contract specified...",
             "ref" : "schedule-2A-paragraph-67",
+            "id" : "schedule-2A-paragraph-67",
+            "href" : "schedule/2A/paragraph/67",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22768,12 +26860,16 @@
           "number" : null,
           "title" : "End of transition",
           "ref" : "schedule-2A-part-10-crossheading-end-of-transition",
+          "id" : "schedule-2A-part-10-crossheading-end-of-transition",
+          "href" : "schedule/2A/part/10/crossheading/end-of-transition",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "68",
             "title" : "(1) A Gibraltar-based person ceases to be treated as having...",
             "ref" : "schedule-2A-paragraph-68",
+            "id" : "schedule-2A-paragraph-68",
+            "href" : "schedule/2A/paragraph/68",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22781,12 +26877,16 @@
           "number" : null,
           "title" : "End of transition: procedure",
           "ref" : "schedule-2A-part-10-crossheading-end-of-transition-procedure",
+          "id" : "schedule-2A-part-10-crossheading-end-of-transition-procedure",
+          "href" : "schedule/2A/part/10/crossheading/end-of-transition-procedure",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "69",
             "title" : "(1) If a UK regulator proposes to specify or vary...",
             "ref" : "schedule-2A-paragraph-69",
+            "id" : "schedule-2A-paragraph-69",
+            "href" : "schedule/2A/paragraph/69",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22794,12 +26894,16 @@
           "number" : null,
           "title" : "Right to refer matters to the Tribunal",
           "ref" : "schedule-2A-part-10-crossheading-right-to-refer-matters-to-the-tribunal",
+          "id" : "schedule-2A-part-10-crossheading-right-to-refer-matters-to-the-tribunal",
+          "href" : "schedule/2A/part/10/crossheading/right-to-refer-matters-to-the-tribunal",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "70",
             "title" : "If a UK regulator gives a Gibraltar-based person a decision...",
             "ref" : "schedule-2A-paragraph-70",
+            "id" : "schedule-2A-paragraph-70",
+            "href" : "schedule/2A/paragraph/70",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -22808,18 +26912,24 @@
         "number" : "PART 11",
         "title" : "Policy statements",
         "ref" : "schedule-2A-part-11",
+        "id" : "schedule-2A-part-11",
+        "href" : "schedule/2A/part/11",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Policy statements",
           "ref" : "schedule-2A-part-11-crossheading-policy-statements",
+          "id" : "schedule-2A-part-11-crossheading-policy-statements",
+          "href" : "schedule/2A/part/11/crossheading/policy-statements",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "71",
             "title" : "(1) Each UK regulator must prepare and issue a statement...",
             "ref" : "schedule-2A-paragraph-71",
+            "id" : "schedule-2A-paragraph-71",
+            "href" : "schedule/2A/paragraph/71",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22827,12 +26937,16 @@
           "number" : null,
           "title" : "Policy statements: procedure",
           "ref" : "schedule-2A-part-11-crossheading-policy-statements-procedure",
+          "id" : "schedule-2A-part-11-crossheading-policy-statements-procedure",
+          "href" : "schedule/2A/part/11/crossheading/policy-statements-procedure",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "72",
             "title" : "(1) Before issuing a statement under paragraph 71(1) or (2),...",
             "ref" : "schedule-2A-paragraph-72",
+            "id" : "schedule-2A-paragraph-72",
+            "href" : "schedule/2A/paragraph/72",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -22841,18 +26955,24 @@
         "number" : "PART 12",
         "title" : "Consultation etc by UK regulators",
         "ref" : "schedule-2A-part-12",
+        "id" : "schedule-2A-part-12",
+        "href" : "schedule/2A/part/12",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "FCA's duties to consult the PRA",
           "ref" : "schedule-2A-part-12-crossheading-fcas-duties-to-consult-the-pra",
+          "id" : "schedule-2A-part-12-crossheading-fcas-duties-to-consult-the-pra",
+          "href" : "schedule/2A/part/12/crossheading/fcas-duties-to-consult-the-pra",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "73",
             "title" : "(1) The FCA must consult the PRA before— ",
             "ref" : "schedule-2A-paragraph-73",
+            "id" : "schedule-2A-paragraph-73",
+            "href" : "schedule/2A/paragraph/73",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22860,12 +26980,16 @@
           "number" : null,
           "title" : "FCA's duties to obtain consent from the PRA",
           "ref" : "schedule-2A-part-12-crossheading-fcas-duties-to-obtain-consent-from-the-pra",
+          "id" : "schedule-2A-part-12-crossheading-fcas-duties-to-obtain-consent-from-the-pra",
+          "href" : "schedule/2A/part/12/crossheading/fcas-duties-to-obtain-consent-from-the-pra",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "74",
             "title" : "(1) The FCA must obtain the PRA's consent before exercising...",
             "ref" : "schedule-2A-paragraph-74",
+            "id" : "schedule-2A-paragraph-74",
+            "href" : "schedule/2A/paragraph/74",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22873,12 +26997,16 @@
           "number" : null,
           "title" : "FCA's duties to inform the PRA",
           "ref" : "schedule-2A-part-12-crossheading-fcas-duties-to-inform-the-pra",
+          "id" : "schedule-2A-part-12-crossheading-fcas-duties-to-inform-the-pra",
+          "href" : "schedule/2A/part/12/crossheading/fcas-duties-to-inform-the-pra",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "75",
             "title" : "(1) The FCA must inform the PRA in writing without...",
             "ref" : "schedule-2A-paragraph-75",
+            "id" : "schedule-2A-paragraph-75",
+            "href" : "schedule/2A/paragraph/75",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22886,12 +27014,16 @@
           "number" : null,
           "title" : "PRA's duties to consult the FCA",
           "ref" : "schedule-2A-part-12-crossheading-pras-duties-to-consult-the-fca",
+          "id" : "schedule-2A-part-12-crossheading-pras-duties-to-consult-the-fca",
+          "href" : "schedule/2A/part/12/crossheading/pras-duties-to-consult-the-fca",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "76",
             "title" : "(1) The PRA must consult the FCA before— ",
             "ref" : "schedule-2A-paragraph-76",
+            "id" : "schedule-2A-paragraph-76",
+            "href" : "schedule/2A/paragraph/76",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22899,12 +27031,16 @@
           "number" : null,
           "title" : "PRA's duty to obtain consent from the FCA",
           "ref" : "schedule-2A-part-12-crossheading-pras-duty-to-obtain-consent-from-the-fca",
+          "id" : "schedule-2A-part-12-crossheading-pras-duty-to-obtain-consent-from-the-fca",
+          "href" : "schedule/2A/part/12/crossheading/pras-duty-to-obtain-consent-from-the-fca",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "77",
             "title" : "(1) The PRA must obtain the FCA's consent before exercising...",
             "ref" : "schedule-2A-paragraph-77",
+            "id" : "schedule-2A-paragraph-77",
+            "href" : "schedule/2A/paragraph/77",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22912,12 +27048,16 @@
           "number" : null,
           "title" : "PRA's duties to inform the FCA",
           "ref" : "schedule-2A-part-12-crossheading-pras-duties-to-inform-the-fca",
+          "id" : "schedule-2A-part-12-crossheading-pras-duties-to-inform-the-fca",
+          "href" : "schedule/2A/part/12/crossheading/pras-duties-to-inform-the-fca",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "78",
             "title" : "(1) When the PRA receives a notification for the purposes...",
             "ref" : "schedule-2A-paragraph-78",
+            "id" : "schedule-2A-paragraph-78",
+            "href" : "schedule/2A/paragraph/78",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22925,12 +27065,16 @@
           "number" : null,
           "title" : "UK regulators' duties to inform the Gibraltar regulator",
           "ref" : "schedule-2A-part-12-crossheading-uk-regulators-duties-to-inform-the-gibraltar-regulator",
+          "id" : "schedule-2A-part-12-crossheading-uk-regulators-duties-to-inform-the-gibraltar-regulator",
+          "href" : "schedule/2A/part/12/crossheading/uk-regulators-duties-to-inform-the-gibraltar-regulator",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "79",
             "title" : "(1) A UK regulator must inform the Gibraltar regulator in...",
             "ref" : "schedule-2A-paragraph-79",
+            "id" : "schedule-2A-paragraph-79",
+            "href" : "schedule/2A/paragraph/79",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -22939,18 +27083,24 @@
         "number" : "PART 13",
         "title" : "Co-operation and Assistance",
         "ref" : "schedule-2A-part-13",
+        "id" : "schedule-2A-part-13",
+        "href" : "schedule/2A/part/13",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Duties to co-operate",
           "ref" : "schedule-2A-part-13-crossheading-duties-to-cooperate",
+          "id" : "schedule-2A-part-13-crossheading-duties-to-cooperate",
+          "href" : "schedule/2A/part/13/crossheading/duties-to-cooperate",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "80",
             "title" : "(1) Each of the FCA, the PRA and the scheme...",
             "ref" : "schedule-2A-paragraph-80",
+            "id" : "schedule-2A-paragraph-80",
+            "href" : "schedule/2A/paragraph/80",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22958,12 +27108,16 @@
           "number" : null,
           "title" : "Publication and review of arrangements for co-operation",
           "ref" : "schedule-2A-part-13-crossheading-publication-and-review-of-arrangements-for-cooperation",
+          "id" : "schedule-2A-part-13-crossheading-publication-and-review-of-arrangements-for-cooperation",
+          "href" : "schedule/2A/part/13/crossheading/publication-and-review-of-arrangements-for-cooperation",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "81",
             "title" : "(1) Each of the FCA, the PRA and the scheme...",
             "ref" : "schedule-2A-paragraph-81",
+            "id" : "schedule-2A-paragraph-81",
+            "href" : "schedule/2A/paragraph/81",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -22971,12 +27125,16 @@
           "number" : null,
           "title" : "Provision of reports to assist the Treasury",
           "ref" : "schedule-2A-part-13-crossheading-provision-of-reports-to-assist-the-treasury",
+          "id" : "schedule-2A-part-13-crossheading-provision-of-reports-to-assist-the-treasury",
+          "href" : "schedule/2A/part/13/crossheading/provision-of-reports-to-assist-the-treasury",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "82",
             "title" : "(1) A UK regulator or the scheme manager must, on...",
             "ref" : "schedule-2A-paragraph-82",
+            "id" : "schedule-2A-paragraph-82",
+            "href" : "schedule/2A/paragraph/82",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -22985,18 +27143,24 @@
         "number" : "PART 14",
         "title" : "Special cases",
         "ref" : "schedule-2A-part-14",
+        "id" : "schedule-2A-part-14",
+        "href" : "schedule/2A/part/14",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Gibraltar-based individuals carrying on insurance distribution activities",
           "ref" : "schedule-2A-part-14-crossheading-gibraltarbased-individuals-carrying-on-insurance-distribution-activities",
+          "id" : "schedule-2A-part-14-crossheading-gibraltarbased-individuals-carrying-on-insurance-distribution-activities",
+          "href" : "schedule/2A/part/14/crossheading/gibraltarbased-individuals-carrying-on-insurance-distribution-activities",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "83",
             "title" : "(1) For the purposes of paragraph 1, an individual without...",
             "ref" : "schedule-2A-paragraph-83",
+            "id" : "schedule-2A-paragraph-83",
+            "href" : "schedule/2A/paragraph/83",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -23006,24 +27170,32 @@
       "number" : "SCHEDULE 3",
       "title" : " EEA Passport Rights",
       "ref" : "schedule-3",
+      "id" : "schedule-3",
+      "href" : "schedule/3",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "part",
         "number" : "Part I",
         "title" : " Defined terms",
         "ref" : "schedule-3-part-I",
+        "id" : "schedule-3-part-I",
+        "href" : "schedule/3/part/I",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : " The single market directives",
           "ref" : "schedule-3-part-I-crossheading-the-single-market-directives",
+          "id" : "schedule-3-part-I-crossheading-the-single-market-directives",
+          "href" : "schedule/3/part/I/crossheading/the-single-market-directives",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "1",
             "title" : "“The single market directives” means— (a) the capital requirements directive...",
             "ref" : "schedule-3-paragraph-1",
+            "id" : "schedule-3-paragraph-1",
+            "href" : "schedule/3/paragraph/1",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23031,12 +27203,16 @@
           "number" : null,
           "title" : " The banking co-ordination directives",
           "ref" : "schedule-3-part-I-crossheading-the-banking-coordination-directives",
+          "id" : "schedule-3-part-I-crossheading-the-banking-coordination-directives",
+          "href" : "schedule/3/part/I/crossheading/the-banking-coordination-directives",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "2",
             "title" : "”The banking consolidation directive” means Directive 2006/48/ EC of the...",
             "ref" : "schedule-3-paragraph-2",
+            "id" : "schedule-3-paragraph-2",
+            "href" : "schedule/3/paragraph/2",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23044,12 +27220,16 @@
           "number" : null,
           "title" : " The Solvency 2 Directive",
           "ref" : "schedule-3-part-I-crossheading-the-insurance-directives",
+          "id" : "schedule-3-part-I-crossheading-the-insurance-directives",
+          "href" : "schedule/3/part/I/crossheading/the-insurance-directives",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "3",
             "title" : "“The Solvency 2 Directive” means Directive 2009/138/EC of the European...",
             "ref" : "schedule-3-paragraph-3",
+            "id" : "schedule-3-paragraph-3",
+            "href" : "schedule/3/paragraph/3",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23057,12 +27237,16 @@
           "number" : null,
           "title" : "The reinsurance directive",
           "ref" : "schedule-3-part-I-crossheading-the-reinsurance-directive",
+          "id" : "schedule-3-part-I-crossheading-the-reinsurance-directive",
+          "href" : "schedule/3/part/I/crossheading/the-reinsurance-directive",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "3A",
             "title" : "“ The reinsurance directive ” means Directive 2005/68/ EC of...",
             "ref" : "schedule-3-paragraph-3A",
+            "id" : "schedule-3-paragraph-3A",
+            "href" : "schedule/3/paragraph/3A",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23070,12 +27254,16 @@
           "number" : null,
           "title" : " The investment services directive",
           "ref" : "schedule-3-part-I-crossheading-the-investment-services-directive",
+          "id" : "schedule-3-part-I-crossheading-the-investment-services-directive",
+          "href" : "schedule/3/part/I/crossheading/the-investment-services-directive",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "4",
             "title" : ". . . . . . . . . ....",
             "ref" : "schedule-3-paragraph-4",
+            "id" : "schedule-3-paragraph-4",
+            "href" : "schedule/3/paragraph/4",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23083,12 +27271,16 @@
           "number" : null,
           "title" : "The insurance distribution directive",
           "ref" : "schedule-3-part-I-crossheading-the-insurance-mediation-directive",
+          "id" : "schedule-3-part-I-crossheading-the-insurance-mediation-directive",
+          "href" : "schedule/3/part/I/crossheading/the-insurance-mediation-directive",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "4A",
             "title" : "“The insurance distribution directive” means Directive (EU) 2016/97 of the...",
             "ref" : "schedule-3-paragraph-4A",
+            "id" : "schedule-3-paragraph-4A",
+            "href" : "schedule/3/paragraph/4A",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23096,12 +27288,16 @@
           "number" : null,
           "title" : "The UCITS directive",
           "ref" : "schedule-3-part-I-crossheading-the-ucits-directive",
+          "id" : "schedule-3-part-I-crossheading-the-ucits-directive",
+          "href" : "schedule/3/part/I/crossheading/the-ucits-directive",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "4B",
             "title" : "“ The UCITS directive ” means the Directive of the...",
             "ref" : "schedule-3-paragraph-4B",
+            "id" : "schedule-3-paragraph-4B",
+            "href" : "schedule/3/paragraph/4B",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23109,18 +27305,24 @@
           "number" : null,
           "title" : "The markets in financial instruments directive",
           "ref" : "schedule-3-part-I-crossheading-the-markets-in-financial-instruments-directive",
+          "id" : "schedule-3-part-I-crossheading-the-markets-in-financial-instruments-directive",
+          "href" : "schedule/3/part/I/crossheading/the-markets-in-financial-instruments-directive",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "4C",
             "title" : "“The markets in financial instruments directive” means Directive 2014/65/EU of...",
             "ref" : "schedule-3-paragraph-4C",
+            "id" : "schedule-3-paragraph-4C",
+            "href" : "schedule/3/paragraph/4C",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "4D",
             "title" : "The emission allowance auctioning regulation",
             "ref" : "schedule-3-paragraph-4D",
+            "id" : "schedule-3-paragraph-4D",
+            "href" : "schedule/3/paragraph/4D",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23128,12 +27330,16 @@
           "number" : null,
           "title" : "The alternative investment fund managers directive",
           "ref" : "schedule-3-part-I-crossheading-the-alternative-investment-fund-managers-directive",
+          "id" : "schedule-3-part-I-crossheading-the-alternative-investment-fund-managers-directive",
+          "href" : "schedule/3/part/I/crossheading/the-alternative-investment-fund-managers-directive",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "4E",
             "title" : "“The alternative investment fund managers directive” means Directive 2011/61/ EU...",
             "ref" : "schedule-3-paragraph-4E",
+            "id" : "schedule-3-paragraph-4E",
+            "href" : "schedule/3/paragraph/4E",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23141,12 +27347,16 @@
           "number" : null,
           "title" : "The mortgages directive",
           "ref" : "schedule-3-part-I-crossheading-the-mortgages-directive",
+          "id" : "schedule-3-part-I-crossheading-the-mortgages-directive",
+          "href" : "schedule/3/part/I/crossheading/the-mortgages-directive",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "4F",
             "title" : "“The mortgages directive” means Directive 2014/17/ EU of the European...",
             "ref" : "schedule-3-paragraph-4F",
+            "id" : "schedule-3-paragraph-4F",
+            "href" : "schedule/3/paragraph/4F",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23154,18 +27364,24 @@
           "number" : null,
           "title" : " EEA firm",
           "ref" : "schedule-3-part-I-crossheading-eea-firm",
+          "id" : "schedule-3-part-I-crossheading-eea-firm",
+          "href" : "schedule/3/part/I/crossheading/eea-firm",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "5",
             "title" : "“EEA firm” means any of the following if it does...",
             "ref" : "schedule-3-paragraph-5",
+            "id" : "schedule-3-paragraph-5",
+            "href" : "schedule/3/paragraph/5",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "5A",
             "title" : "In paragraph 5, “ relevant office ” means— ",
             "ref" : "schedule-3-paragraph-5A",
+            "id" : "schedule-3-paragraph-5A",
+            "href" : "schedule/3/paragraph/5A",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23173,12 +27389,16 @@
           "number" : null,
           "title" : " EEA authorisation",
           "ref" : "schedule-3-part-I-crossheading-eea-authorisation",
+          "id" : "schedule-3-part-I-crossheading-eea-authorisation",
+          "href" : "schedule/3/part/I/crossheading/eea-authorisation",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "6",
             "title" : "“ EEA authorisation ” means— (a) in relation to an...",
             "ref" : "schedule-3-paragraph-6",
+            "id" : "schedule-3-paragraph-6",
+            "href" : "schedule/3/paragraph/6",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23186,18 +27406,24 @@
           "number" : null,
           "title" : " EEA right",
           "ref" : "schedule-3-part-I-crossheading-eea-right",
+          "id" : "schedule-3-part-I-crossheading-eea-right",
+          "href" : "schedule/3/part/I/crossheading/eea-right",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "7",
             "title" : "“EEA right” means the entitlement of a person to establish...",
             "ref" : "schedule-3-paragraph-7",
+            "id" : "schedule-3-paragraph-7",
+            "href" : "schedule/3/paragraph/7",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "7A",
             "title" : "In paragraph 7, “ relevant office ” means— ",
             "ref" : "schedule-3-paragraph-7A",
+            "id" : "schedule-3-paragraph-7A",
+            "href" : "schedule/3/paragraph/7A",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23205,12 +27431,16 @@
           "number" : null,
           "title" : " EEA State",
           "ref" : "schedule-3-part-I-crossheading-eea-state",
+          "id" : "schedule-3-part-I-crossheading-eea-state",
+          "href" : "schedule/3/part/I/crossheading/eea-state",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "8",
             "title" : "“ EEA State ” has the meaning given by Schedule...",
             "ref" : "schedule-3-paragraph-8",
+            "id" : "schedule-3-paragraph-8",
+            "href" : "schedule/3/paragraph/8",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23218,12 +27448,16 @@
           "number" : null,
           "title" : " Home state regulator",
           "ref" : "schedule-3-part-I-crossheading-home-state-regulator",
+          "id" : "schedule-3-part-I-crossheading-home-state-regulator",
+          "href" : "schedule/3/part/I/crossheading/home-state-regulator",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "9",
             "title" : "“Home state regulator” means the competent authority (within the meaning...",
             "ref" : "schedule-3-paragraph-9",
+            "id" : "schedule-3-paragraph-9",
+            "href" : "schedule/3/paragraph/9",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23231,18 +27465,24 @@
           "number" : null,
           "title" : " UK firm",
           "ref" : "schedule-3-part-I-crossheading-uk-firm",
+          "id" : "schedule-3-part-I-crossheading-uk-firm",
+          "href" : "schedule/3/part/I/crossheading/uk-firm",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "10",
             "title" : "“UK firm” means a person whose relevant office is in...",
             "ref" : "schedule-3-paragraph-10",
+            "id" : "schedule-3-paragraph-10",
+            "href" : "schedule/3/paragraph/10",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "10A",
             "title" : "In paragraph 10, “ relevant office ” means— ",
             "ref" : "schedule-3-paragraph-10A",
+            "id" : "schedule-3-paragraph-10A",
+            "href" : "schedule/3/paragraph/10A",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23250,12 +27490,16 @@
           "number" : null,
           "title" : "UK investment firm",
           "ref" : "schedule-3-part-I-crossheading-uk-investment-firm",
+          "id" : "schedule-3-part-I-crossheading-uk-investment-firm",
+          "href" : "schedule/3/part/I/crossheading/uk-investment-firm",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "10B",
             "title" : "” UK investment firm” means a UK firm— ",
             "ref" : "schedule-3-paragraph-10B",
+            "id" : "schedule-3-paragraph-10B",
+            "href" : "schedule/3/paragraph/10B",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23263,12 +27507,16 @@
           "number" : null,
           "title" : " Host state regulator",
           "ref" : "schedule-3-part-I-crossheading-host-state-regulator",
+          "id" : "schedule-3-part-I-crossheading-host-state-regulator",
+          "href" : "schedule/3/part/I/crossheading/host-state-regulator",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "11",
             "title" : "“Host state regulator” means the competent authority (within the meaning...",
             "ref" : "schedule-3-paragraph-11",
+            "id" : "schedule-3-paragraph-11",
+            "href" : "schedule/3/paragraph/11",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23276,12 +27524,16 @@
           "number" : null,
           "title" : "Tied agent",
           "ref" : "schedule-3-part-I-crossheading-tied-agent",
+          "id" : "schedule-3-part-I-crossheading-tied-agent",
+          "href" : "schedule/3/part/I/crossheading/tied-agent",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "11A",
             "title" : "”Tied agent” has the meaning given in Article 4.1.29 of...",
             "ref" : "schedule-3-paragraph-11A",
+            "id" : "schedule-3-paragraph-11A",
+            "href" : "schedule/3/paragraph/11A",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23289,12 +27541,16 @@
           "number" : null,
           "title" : "Management company",
           "ref" : "schedule-3-part-I-crossheading-management-company",
+          "id" : "schedule-3-part-I-crossheading-management-company",
+          "href" : "schedule/3/part/I/crossheading/management-company",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "11B",
             "title" : "“ Management company ” has the meaning given in Article...",
             "ref" : "schedule-3-paragraph-11B",
+            "id" : "schedule-3-paragraph-11B",
+            "href" : "schedule/3/paragraph/11B",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23302,12 +27558,16 @@
           "number" : null,
           "title" : "UCITS",
           "ref" : "schedule-3-part-I-crossheading-ucits",
+          "id" : "schedule-3-part-I-crossheading-ucits",
+          "href" : "schedule/3/part/I/crossheading/ucits",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "11C",
             "title" : "“ UCITS ” has the meaning given in Article 1.2...",
             "ref" : "schedule-3-paragraph-11C",
+            "id" : "schedule-3-paragraph-11C",
+            "href" : "schedule/3/paragraph/11C",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23315,12 +27575,16 @@
           "number" : null,
           "title" : "EEAAIFM",
           "ref" : "schedule-3-part-I-crossheading-eea-aifm",
+          "id" : "schedule-3-part-I-crossheading-eea-aifm",
+          "href" : "schedule/3/part/I/crossheading/eea-aifm",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "11D",
             "title" : "“ EEA AIFM ” means an EEA firm falling within...",
             "ref" : "schedule-3-paragraph-11D",
+            "id" : "schedule-3-paragraph-11D",
+            "href" : "schedule/3/paragraph/11D",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -23329,18 +27593,24 @@
         "number" : "Part II",
         "title" : " Exercise of Passport Rights by EEA Firms",
         "ref" : "schedule-3-part-II",
+        "id" : "schedule-3-part-II",
+        "href" : "schedule/3/part/II",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : " Firms qualifying for authorisation",
           "ref" : "schedule-3-part-II-crossheading-firms-qualifying-for-authorisation",
+          "id" : "schedule-3-part-II-crossheading-firms-qualifying-for-authorisation",
+          "href" : "schedule/3/part/II/crossheading/firms-qualifying-for-authorisation",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "12",
             "title" : "(1) Once an EEA firm which is seeking to establish...",
             "ref" : "schedule-3-paragraph-12",
+            "id" : "schedule-3-paragraph-12",
+            "href" : "schedule/3/paragraph/12",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23348,12 +27618,16 @@
           "number" : null,
           "title" : " Establishment",
           "ref" : "schedule-3-part-II-crossheading-establishment",
+          "id" : "schedule-3-part-II-crossheading-establishment",
+          "href" : "schedule/3/part/II/crossheading/establishment",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "13",
             "title" : "(1) If the firm falls within paragraph 5(a), (b), (c),...",
             "ref" : "schedule-3-paragraph-13",
+            "id" : "schedule-3-paragraph-13",
+            "href" : "schedule/3/paragraph/13",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23361,12 +27635,16 @@
           "number" : null,
           "title" : " Services",
           "ref" : "schedule-3-part-II-crossheading-services",
+          "id" : "schedule-3-part-II-crossheading-services",
+          "href" : "schedule/3/part/II/crossheading/services",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "14",
             "title" : "(1) The service conditions are that— (a) the firm has...",
             "ref" : "schedule-3-paragraph-14",
+            "id" : "schedule-3-paragraph-14",
+            "href" : "schedule/3/paragraph/14",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23374,18 +27652,24 @@
           "number" : null,
           "title" : " Grant of permission",
           "ref" : "schedule-3-part-II-crossheading-grant-of-permission",
+          "id" : "schedule-3-part-II-crossheading-grant-of-permission",
+          "href" : "schedule/3/part/II/crossheading/grant-of-permission",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "15",
             "title" : "(1) On qualifying for authorisation as a result of paragraph...",
             "ref" : "schedule-3-paragraph-15",
+            "id" : "schedule-3-paragraph-15",
+            "href" : "schedule/3/paragraph/15",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "15ZA",
             "title" : "Grant of permission: bidding for emission allowances",
             "ref" : "schedule-3-paragraph-15ZA",
+            "id" : "schedule-3-paragraph-15ZA",
+            "href" : "schedule/3/paragraph/15ZA",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23393,24 +27677,32 @@
           "number" : null,
           "title" : "\n\t\t\t\tPower to restrict permission of management companies",
           "ref" : "schedule-3-part-II-crossheading-power-to-restrict-permission-of-management-companies",
+          "id" : "schedule-3-part-II-crossheading-power-to-restrict-permission-of-management-companies",
+          "href" : "schedule/3/part/II/crossheading/power-to-restrict-permission-of-management-companies",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "15A",
             "title" : "Application for approval to manage UCITS",
             "ref" : "schedule-3-paragraph-15A",
+            "id" : "schedule-3-paragraph-15A",
+            "href" : "schedule/3/paragraph/15A",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "15B",
             "title" : "Representations and references to the Tribunal",
             "ref" : "schedule-3-paragraph-15B",
+            "id" : "schedule-3-paragraph-15B",
+            "href" : "schedule/3/paragraph/15B",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "15C",
             "title" : "Information to home state regulator",
             "ref" : "schedule-3-paragraph-15C",
+            "id" : "schedule-3-paragraph-15C",
+            "href" : "schedule/3/paragraph/15C",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23418,12 +27710,16 @@
           "number" : null,
           "title" : " Effect of carrying on regulated activity when not qualified for authorisation",
           "ref" : "schedule-3-part-II-crossheading-effect-of-carrying-on-regulated-activity-when-not-qualified-for-authorisation",
+          "id" : "schedule-3-part-II-crossheading-effect-of-carrying-on-regulated-activity-when-not-qualified-for-authorisation",
+          "href" : "schedule/3/part/II/crossheading/effect-of-carrying-on-regulated-activity-when-not-qualified-for-authorisation",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "16",
             "title" : "(1) This paragraph applies to an EEA firm which is...",
             "ref" : "schedule-3-paragraph-16",
+            "id" : "schedule-3-paragraph-16",
+            "href" : "schedule/3/paragraph/16",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23431,12 +27727,16 @@
           "number" : null,
           "title" : " Continuing regulation of European Economic AreaEEA firms",
           "ref" : "schedule-3-part-II-crossheading-continuing-regulation-of-eea-firms",
+          "id" : "schedule-3-part-II-crossheading-continuing-regulation-of-eea-firms",
+          "href" : "schedule/3/part/II/crossheading/continuing-regulation-of-eea-firms",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "17",
             "title" : "Regulations may— (za) require the FCA and the PRA to...",
             "ref" : "schedule-3-paragraph-17",
+            "id" : "schedule-3-paragraph-17",
+            "href" : "schedule/3/paragraph/17",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23444,12 +27744,16 @@
           "number" : null,
           "title" : " Giving up right to authorisation",
           "ref" : "schedule-3-part-II-crossheading-giving-up-right-to-authorisation",
+          "id" : "schedule-3-part-II-crossheading-giving-up-right-to-authorisation",
+          "href" : "schedule/3/part/II/crossheading/giving-up-right-to-authorisation",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "18",
             "title" : "Regulations may provide that in prescribed circumstances an EEA firm...",
             "ref" : "schedule-3-paragraph-18",
+            "id" : "schedule-3-paragraph-18",
+            "href" : "schedule/3/paragraph/18",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -23458,18 +27762,24 @@
         "number" : "Part III",
         "title" : " Exercise of Passport Rights by UK Firms",
         "ref" : "schedule-3-part-III",
+        "id" : "schedule-3-part-III",
+        "href" : "schedule/3/part/III",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Meaning of  “the appropriate UK regulator”",
           "ref" : "schedule-3-part-II-crossheading-meaning-of-the-appropriate-uk-regulator",
+          "id" : "schedule-3-part-II-crossheading-meaning-of-the-appropriate-uk-regulator",
+          "href" : "schedule/3/part/II/crossheading/meaning-of-the-appropriate-uk-regulator",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "18A",
             "title" : "In this Part of this Schedule “ the appropriate UK...",
             "ref" : "schedule-3-paragraph-18A",
+            "id" : "schedule-3-paragraph-18A",
+            "href" : "schedule/3/paragraph/18A",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23477,12 +27787,16 @@
           "number" : null,
           "title" : " Establishment",
           "ref" : "schedule-3-part-III-crossheading-establishment",
+          "id" : "schedule-3-part-III-crossheading-establishment",
+          "href" : "schedule/3/part/III/crossheading/establishment",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "19",
             "title" : "(1) Subject to sub-paragraphs (5ZA) , (5ZB) , (5A) and...",
             "ref" : "schedule-3-paragraph-19",
+            "id" : "schedule-3-paragraph-19",
+            "href" : "schedule/3/paragraph/19",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23490,18 +27804,24 @@
           "number" : null,
           "title" : " Services",
           "ref" : "schedule-3-part-III-crossheading-services",
+          "id" : "schedule-3-part-III-crossheading-services",
+          "href" : "schedule/3/part/III/crossheading/services",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "20",
             "title" : "(1) Subject to sub-paragraphs (4D) to (4I), a UK firm...",
             "ref" : "schedule-3-paragraph-20",
+            "id" : "schedule-3-paragraph-20",
+            "href" : "schedule/3/paragraph/20",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "20ZA",
             "title" : "Information for host state regulator",
             "ref" : "schedule-3-paragraph-20ZA",
+            "id" : "schedule-3-paragraph-20ZA",
+            "href" : "schedule/3/paragraph/20ZA",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23509,18 +27829,24 @@
           "number" : null,
           "title" : "Tied agents",
           "ref" : "schedule-3-part-III-crossheading-tied-agents",
+          "id" : "schedule-3-part-III-crossheading-tied-agents",
+          "href" : "schedule/3/part/III/crossheading/tied-agents",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "20A",
             "title" : "(1) If a UK investment firm or UK credit institution...",
             "ref" : "schedule-3-paragraph-20A",
+            "id" : "schedule-3-paragraph-20A",
+            "href" : "schedule/3/paragraph/20A",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "20B",
             "title" : "Notice of intention to market a UCITS ",
             "ref" : "schedule-3-paragraph-20B",
+            "id" : "schedule-3-paragraph-20B",
+            "href" : "schedule/3/paragraph/20B",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23528,12 +27854,16 @@
           "number" : null,
           "title" : "Notice of intention to market an Alternative Investment FundAIF",
           "ref" : "schedule-3-part-III-crossheading-notice-of-intention-to-market-an-aif",
+          "id" : "schedule-3-part-III-crossheading-notice-of-intention-to-market-an-aif",
+          "href" : "schedule/3/part/III/crossheading/notice-of-intention-to-market-an-aif",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "20C",
             "title" : "(1) A full-scope UK AIFM may not exercise in the...",
             "ref" : "schedule-3-paragraph-20C",
+            "id" : "schedule-3-paragraph-20C",
+            "href" : "schedule/3/paragraph/20C",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23541,12 +27871,16 @@
           "number" : null,
           "title" : " Offence relating to exercise of passport rights",
           "ref" : "schedule-3-part-III-crossheading-offence-relating-to-exercise-of-passport-rights",
+          "id" : "schedule-3-part-III-crossheading-offence-relating-to-exercise-of-passport-rights",
+          "href" : "schedule/3/part/III/crossheading/offence-relating-to-exercise-of-passport-rights",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "21",
             "title" : "(1) If a UK firm which is not an authorised...",
             "ref" : "schedule-3-paragraph-21",
+            "id" : "schedule-3-paragraph-21",
+            "href" : "schedule/3/paragraph/21",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23554,24 +27888,32 @@
           "number" : null,
           "title" : " Continuing regulation of United KingdomUK firms",
           "ref" : "schedule-3-part-III-crossheading-continuing-regulation-of-uk-firms",
+          "id" : "schedule-3-part-III-crossheading-continuing-regulation-of-uk-firms",
+          "href" : "schedule/3/part/III/crossheading/continuing-regulation-of-uk-firms",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "22",
             "title" : "(1) Regulations may make such provision as the Treasury consider...",
             "ref" : "schedule-3-paragraph-22",
+            "id" : "schedule-3-paragraph-22",
+            "href" : "schedule/3/paragraph/22",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "23",
             "title" : "(1) Sub-paragraphs (2) and (2A) apply if a UK firm—...",
             "ref" : "schedule-3-paragraph-23",
+            "id" : "schedule-3-paragraph-23",
+            "href" : "schedule/3/paragraph/23",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "24",
             "title" : "(1) Sub-paragraph (2) applies if a UK firm— ",
             "ref" : "schedule-3-paragraph-24",
+            "id" : "schedule-3-paragraph-24",
+            "href" : "schedule/3/paragraph/24",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23579,12 +27921,16 @@
           "number" : null,
           "title" : "Arrangements between FCA and PRA",
           "ref" : "schedule-3-part-III-crossheading-arrangements-between-fca-and-pra",
+          "id" : "schedule-3-part-III-crossheading-arrangements-between-fca-and-pra",
+          "href" : "schedule/3/part/III/crossheading/arrangements-between-fca-and-pra",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "24A",
             "title" : "(1) The regulators may make arrangements about— ",
             "ref" : "schedule-3-paragraph-24A",
+            "id" : "schedule-3-paragraph-24A",
+            "href" : "schedule/3/paragraph/24A",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23592,30 +27938,40 @@
           "number" : null,
           "title" : "Information to be included in the public record",
           "ref" : "schedule-3-part-III-crossheading-information-to-be-included-in-the-public-record",
+          "id" : "schedule-3-part-III-crossheading-information-to-be-included-in-the-public-record",
+          "href" : "schedule/3/part/III/crossheading/information-to-be-included-in-the-public-record",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "25",
             "title" : "The FCA must include in the record that it maintains...",
             "ref" : "schedule-3-paragraph-25",
+            "id" : "schedule-3-paragraph-25",
+            "href" : "schedule/3/paragraph/25",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "26",
             "title" : "UK management companies: delegation of functions",
             "ref" : "schedule-3-paragraph-26",
+            "id" : "schedule-3-paragraph-26",
+            "href" : "schedule/3/paragraph/26",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "27",
             "title" : "UK management companies: withdrawal of authorisation",
             "ref" : "schedule-3-paragraph-27",
+            "id" : "schedule-3-paragraph-27",
+            "href" : "schedule/3/paragraph/27",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "28",
             "title" : "Management companies: request for information",
             "ref" : "schedule-3-paragraph-28",
+            "id" : "schedule-3-paragraph-28",
+            "href" : "schedule/3/paragraph/28",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -23623,12 +27979,16 @@
           "number" : null,
           "title" : "Full-scope United KingdomUKAlternative Investment Fund ManagersAIFMs: notification of breach by host state regulator",
           "ref" : "schedule-3-part-III-crossheading-fullscope-ukaifms-notification-of-breach-by-host-state-regulator",
+          "id" : "schedule-3-part-III-crossheading-fullscope-ukaifms-notification-of-breach-by-host-state-regulator",
+          "href" : "schedule/3/part/III/crossheading/fullscope-ukaifms-notification-of-breach-by-host-state-regulator",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "29",
             "title" : "If a host state regulator informs the FCA in accordance...",
             "ref" : "schedule-3-paragraph-29",
+            "id" : "schedule-3-paragraph-29",
+            "href" : "schedule/3/paragraph/29",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -23638,18 +27998,24 @@
       "number" : "SCHEDULE 4",
       "title" : " Treaty Rights",
       "ref" : "schedule-4",
+      "id" : "schedule-4",
+      "href" : "schedule/4",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : " Definitions",
         "ref" : "schedule-4-crossheading-definitions",
+        "id" : "schedule-4-crossheading-definitions",
+        "href" : "schedule/4/crossheading/definitions",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "1",
           "title" : "(1) In this Schedule— . . . . . ....",
           "ref" : "schedule-4-paragraph-1",
+          "id" : "schedule-4-paragraph-1",
+          "href" : "schedule/4/paragraph/1",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -23657,12 +28023,16 @@
         "number" : null,
         "title" : " Firms qualifying for authorisation",
         "ref" : "schedule-4-crossheading-firms-qualifying-for-authorisation",
+        "id" : "schedule-4-crossheading-firms-qualifying-for-authorisation",
+        "href" : "schedule/4/crossheading/firms-qualifying-for-authorisation",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "2",
           "title" : "Once a Treaty firm which is seeking to carry on...",
           "ref" : "schedule-4-paragraph-2",
+          "id" : "schedule-4-paragraph-2",
+          "href" : "schedule/4/paragraph/2",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -23670,12 +28040,16 @@
         "number" : null,
         "title" : " Exercise of Treaty rights",
         "ref" : "schedule-4-crossheading-exercise-of-treaty-rights",
+        "id" : "schedule-4-crossheading-exercise-of-treaty-rights",
+        "href" : "schedule/4/crossheading/exercise-of-treaty-rights",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "3",
           "title" : "(1) The conditions are that— (a) the firm has received...",
           "ref" : "schedule-4-paragraph-3",
+          "id" : "schedule-4-paragraph-3",
+          "href" : "schedule/4/paragraph/3",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -23683,12 +28057,16 @@
         "number" : null,
         "title" : "Notification between UK regulators",
         "ref" : "schedule-4-crossheading-notification-between-uk-regulators",
+        "id" : "schedule-4-crossheading-notification-between-uk-regulators",
+        "href" : "schedule/4/crossheading/notification-between-uk-regulators",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "3A",
           "title" : "Regulations may require the PRA and the FCA to notify...",
           "ref" : "schedule-4-paragraph-3A",
+          "id" : "schedule-4-paragraph-3A",
+          "href" : "schedule/4/paragraph/3A",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -23696,12 +28074,16 @@
         "number" : null,
         "title" : " Permission",
         "ref" : "schedule-4-crossheading-permission",
+        "id" : "schedule-4-crossheading-permission",
+        "href" : "schedule/4/crossheading/permission",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "4",
           "title" : "(1) On qualifying for authorisation under this Schedule, a Treaty...",
           "ref" : "schedule-4-paragraph-4",
+          "id" : "schedule-4-paragraph-4",
+          "href" : "schedule/4/paragraph/4",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -23709,12 +28091,16 @@
         "number" : null,
         "title" : " Notice to  United KingdomUK regulator ",
         "ref" : "schedule-4-crossheading-notice-to-authority",
+        "id" : "schedule-4-crossheading-notice-to-authority",
+        "href" : "schedule/4/crossheading/notice-to-authority",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "5",
           "title" : "(1) Sub-paragraph (2) applies to a Treaty firm which— ",
           "ref" : "schedule-4-paragraph-5",
+          "id" : "schedule-4-paragraph-5",
+          "href" : "schedule/4/paragraph/5",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -23722,12 +28108,16 @@
         "number" : null,
         "title" : " Offences",
         "ref" : "schedule-4-crossheading-offences",
+        "id" : "schedule-4-crossheading-offences",
+        "href" : "schedule/4/crossheading/offences",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "6",
           "title" : "(1) A person who contravenes paragraph 5(2) is guilty of...",
           "ref" : "schedule-4-paragraph-6",
+          "id" : "schedule-4-paragraph-6",
+          "href" : "schedule/4/paragraph/6",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -23736,18 +28126,24 @@
       "number" : "SCHEDULE 5",
       "title" : " Persons Concerned in Collective Investment Schemes",
       "ref" : "schedule-5",
+      "id" : "schedule-5",
+      "href" : "schedule/5",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : " Authorisation",
         "ref" : "schedule-5-crossheading-authorisation",
+        "id" : "schedule-5-crossheading-authorisation",
+        "href" : "schedule/5/crossheading/authorisation",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "1",
           "title" : "(1) A person who for the time being is an...",
           "ref" : "schedule-5-paragraph-1",
+          "id" : "schedule-5-paragraph-1",
+          "href" : "schedule/5/paragraph/1",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -23755,12 +28151,16 @@
         "number" : null,
         "title" : " Permission",
         "ref" : "schedule-5-crossheading-permission",
+        "id" : "schedule-5-crossheading-permission",
+        "href" : "schedule/5/crossheading/permission",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "2",
           "title" : "(1) A person authorised as a result of paragraph 1(1)...",
           "ref" : "schedule-5-paragraph-2",
+          "id" : "schedule-5-paragraph-2",
+          "href" : "schedule/5/paragraph/2",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -23769,18 +28169,24 @@
       "number" : "SCHEDULE 6",
       "title" : " Threshold Conditions",
       "ref" : "schedule-6",
+      "id" : "schedule-6",
+      "href" : "schedule/6",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "part",
         "number" : "PART 1",
         "title" : "Introduction",
         "ref" : "schedule-6-part-1",
+        "id" : "schedule-6-part-1",
+        "href" : "schedule/6/part/1",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "1A",
           "title" : "(1) In this Schedule— “assets” includes contingent assets; “consolidated supervision”...",
           "ref" : "schedule-6-paragraph-1A",
+          "id" : "schedule-6-paragraph-1A",
+          "href" : "schedule/6/paragraph/1A",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -23788,48 +28194,64 @@
         "number" : "PART 1B",
         "title" : "Part 4A permission: authorised persons who are not PRA-authorised persons",
         "ref" : "schedule-6-part-1B",
+        "id" : "schedule-6-part-1B",
+        "href" : "schedule/6/part/1B",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "2A",
           "title" : "Introduction",
           "ref" : "schedule-6-paragraph-2A",
+          "id" : "schedule-6-paragraph-2A",
+          "href" : "schedule/6/paragraph/2A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "2B",
           "title" : "Location of offices",
           "ref" : "schedule-6-paragraph-2B",
+          "id" : "schedule-6-paragraph-2B",
+          "href" : "schedule/6/paragraph/2B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "2C",
           "title" : "Effective supervision",
           "ref" : "schedule-6-paragraph-2C",
+          "id" : "schedule-6-paragraph-2C",
+          "href" : "schedule/6/paragraph/2C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "2D",
           "title" : "Appropriate resources",
           "ref" : "schedule-6-paragraph-2D",
+          "id" : "schedule-6-paragraph-2D",
+          "href" : "schedule/6/paragraph/2D",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "2E",
           "title" : "Suitability",
           "ref" : "schedule-6-paragraph-2E",
+          "id" : "schedule-6-paragraph-2E",
+          "href" : "schedule/6/paragraph/2E",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "2F",
           "title" : "Business model",
           "ref" : "schedule-6-paragraph-2F",
+          "id" : "schedule-6-paragraph-2F",
+          "href" : "schedule/6/paragraph/2F",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "2G",
           "title" : "Interpretation",
           "ref" : "schedule-6-paragraph-2G",
+          "id" : "schedule-6-paragraph-2G",
+          "href" : "schedule/6/paragraph/2G",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -23837,36 +28259,48 @@
         "number" : "PART 1C",
         "title" : "Part 4A permission: conditions for which FCA is responsible in relation to PRA-authorised persons",
         "ref" : "schedule-6-part-1C",
+        "id" : "schedule-6-part-1C",
+        "href" : "schedule/6/part/1C",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "3A",
           "title" : "Introduction",
           "ref" : "schedule-6-paragraph-3A",
+          "id" : "schedule-6-paragraph-3A",
+          "href" : "schedule/6/paragraph/3A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "3B",
           "title" : "Effective supervision",
           "ref" : "schedule-6-paragraph-3B",
+          "id" : "schedule-6-paragraph-3B",
+          "href" : "schedule/6/paragraph/3B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "3C",
           "title" : "Appropriate non-financial resources",
           "ref" : "schedule-6-paragraph-3C",
+          "id" : "schedule-6-paragraph-3C",
+          "href" : "schedule/6/paragraph/3C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "3D",
           "title" : "Suitability",
           "ref" : "schedule-6-paragraph-3D",
+          "id" : "schedule-6-paragraph-3D",
+          "href" : "schedule/6/paragraph/3D",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "3E",
           "title" : "Business model",
           "ref" : "schedule-6-paragraph-3E",
+          "id" : "schedule-6-paragraph-3E",
+          "href" : "schedule/6/paragraph/3E",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -23874,42 +28308,56 @@
         "number" : "PART 1D",
         "title" : "Part 4A permission: conditions for which the PRA is responsible in relation to insurers etc.",
         "ref" : "schedule-6-part-1D",
+        "id" : "schedule-6-part-1D",
+        "href" : "schedule/6/part/1D",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "4A",
           "title" : "Introduction",
           "ref" : "schedule-6-paragraph-4A",
+          "id" : "schedule-6-paragraph-4A",
+          "href" : "schedule/6/paragraph/4A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "4B",
           "title" : "Legal status",
           "ref" : "schedule-6-paragraph-4B",
+          "id" : "schedule-6-paragraph-4B",
+          "href" : "schedule/6/paragraph/4B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "4C",
           "title" : "Location of offices",
           "ref" : "schedule-6-paragraph-4C",
+          "id" : "schedule-6-paragraph-4C",
+          "href" : "schedule/6/paragraph/4C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "4D",
           "title" : "Business to be conducted in a prudent manner",
           "ref" : "schedule-6-paragraph-4D",
+          "id" : "schedule-6-paragraph-4D",
+          "href" : "schedule/6/paragraph/4D",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "4E",
           "title" : "Suitability",
           "ref" : "schedule-6-paragraph-4E",
+          "id" : "schedule-6-paragraph-4E",
+          "href" : "schedule/6/paragraph/4E",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "4F",
           "title" : "Effective supervision",
           "ref" : "schedule-6-paragraph-4F",
+          "id" : "schedule-6-paragraph-4F",
+          "href" : "schedule/6/paragraph/4F",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -23917,42 +28365,56 @@
         "number" : "PART 1E",
         "title" : "Part 4A permission: conditions for which the PRA is responsible in relation to other PRA-authorised persons",
         "ref" : "schedule-6-part-1E",
+        "id" : "schedule-6-part-1E",
+        "href" : "schedule/6/part/1E",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "5A",
           "title" : "Introduction",
           "ref" : "schedule-6-paragraph-5A",
+          "id" : "schedule-6-paragraph-5A",
+          "href" : "schedule/6/paragraph/5A",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "5B",
           "title" : "Legal status",
           "ref" : "schedule-6-paragraph-5B",
+          "id" : "schedule-6-paragraph-5B",
+          "href" : "schedule/6/paragraph/5B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "5C",
           "title" : "Location of offices",
           "ref" : "schedule-6-paragraph-5C",
+          "id" : "schedule-6-paragraph-5C",
+          "href" : "schedule/6/paragraph/5C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "5D",
           "title" : "Business to be conducted in a prudent manner",
           "ref" : "schedule-6-paragraph-5D",
+          "id" : "schedule-6-paragraph-5D",
+          "href" : "schedule/6/paragraph/5D",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "5E",
           "title" : "Suitability",
           "ref" : "schedule-6-paragraph-5E",
+          "id" : "schedule-6-paragraph-5E",
+          "href" : "schedule/6/paragraph/5E",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "5F",
           "title" : "Effective supervision",
           "ref" : "schedule-6-paragraph-5F",
+          "id" : "schedule-6-paragraph-5F",
+          "href" : "schedule/6/paragraph/5F",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -23960,12 +28422,16 @@
         "number" : "PART 1F",
         "title" : "Authorisation under Schedule 3",
         "ref" : "schedule-6-part-1F",
+        "id" : "schedule-6-part-1F",
+        "href" : "schedule/6/part/1F",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "6A",
           "title" : "(1) In relation to an EEA firm qualifying for authorisation...",
           "ref" : "schedule-6-paragraph-6A",
+          "id" : "schedule-6-paragraph-6A",
+          "href" : "schedule/6/paragraph/6A",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -23973,12 +28439,16 @@
         "number" : "PART 1G",
         "title" : "Authorisation under Schedule 4",
         "ref" : "schedule-6-part-1G",
+        "id" : "schedule-6-part-1G",
+        "href" : "schedule/6/part/1G",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "7A",
           "title" : "(1) In relation to a person who qualifies for authorisation...",
           "ref" : "schedule-6-paragraph-7A",
+          "id" : "schedule-6-paragraph-7A",
+          "href" : "schedule/6/paragraph/7A",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -23986,18 +28456,24 @@
         "number" : "Part II",
         "title" : " Authorisation",
         "ref" : "schedule-6-part-II",
+        "id" : "schedule-6-part-II",
+        "href" : "schedule/6/part/II",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : " Authorisation under Schedule 3",
           "ref" : "schedule-6-part-II-crossheading-authorisation-under-schedule-3",
+          "id" : "schedule-6-part-II-crossheading-authorisation-under-schedule-3",
+          "href" : "schedule/6/part/II/crossheading/authorisation-under-schedule-3",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "...",
             "title" : " Authorisation",
             "ref" : "schedule-6-paragraph-6",
+            "id" : "schedule-6-paragraph-6",
+            "href" : "schedule/6/paragraph/6",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -24006,18 +28482,24 @@
         "number" : "Part III",
         "title" : " Additional Conditions",
         "ref" : "schedule-6-part-III",
+        "id" : "schedule-6-part-III",
+        "href" : "schedule/6/part/III",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "8",
           "title" : "(1) If this paragraph applies to the person concerned, he...",
           "ref" : "schedule-6-paragraph-8",
+          "id" : "schedule-6-paragraph-8",
+          "href" : "schedule/6/paragraph/8",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "9",
           "title" : "The Treasury may by order— (a) vary or remove any...",
           "ref" : "schedule-6-paragraph-9",
+          "id" : "schedule-6-paragraph-9",
+          "href" : "schedule/6/paragraph/9",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -24026,18 +28508,24 @@
       "number" : "SCHEDULE 6A",
       "title" : "Variation or cancellation of Part 4A permission on initiative of FCA: additional power",
       "ref" : "schedule-6A",
+      "id" : "schedule-6A",
+      "href" : "schedule/6A",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : "Additional power",
         "ref" : "schedule-6A-crossheading-additional-power",
+        "id" : "schedule-6A-crossheading-additional-power",
+        "href" : "schedule/6A/crossheading/additional-power",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "1",
           "title" : "(1) If it appears to the FCA that an FCA-authorised...",
           "ref" : "schedule-6A-paragraph-1",
+          "id" : "schedule-6A-paragraph-1",
+          "href" : "schedule/6A/paragraph/1",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24045,12 +28533,16 @@
         "number" : null,
         "title" : "Procedure etc",
         "ref" : "schedule-6A-crossheading-procedure-etc",
+        "id" : "schedule-6A-crossheading-procedure-etc",
+        "href" : "schedule/6A/crossheading/procedure-etc",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "2",
           "title" : "(1) The FCA may exercise its power under paragraph 1...",
           "ref" : "schedule-6A-paragraph-2",
+          "id" : "schedule-6A-paragraph-2",
+          "href" : "schedule/6A/paragraph/2",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24058,12 +28550,16 @@
         "number" : null,
         "title" : "Notice of decision",
         "ref" : "schedule-6A-crossheading-notice-of-decision",
+        "id" : "schedule-6A-crossheading-notice-of-decision",
+        "href" : "schedule/6A/crossheading/notice-of-decision",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "3",
           "title" : "(1) Where the FCA decides to vary or cancel an...",
           "ref" : "schedule-6A-paragraph-3",
+          "id" : "schedule-6A-paragraph-3",
+          "href" : "schedule/6A/paragraph/3",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24071,12 +28567,16 @@
         "number" : null,
         "title" : "Application for decision to be annulled",
         "ref" : "schedule-6A-crossheading-application-for-decision-to-be-annulled",
+        "id" : "schedule-6A-crossheading-application-for-decision-to-be-annulled",
+        "href" : "schedule/6A/crossheading/application-for-decision-to-be-annulled",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "4",
           "title" : "(1) This paragraph applies where the FCA decides to vary...",
           "ref" : "schedule-6A-paragraph-4",
+          "id" : "schedule-6A-paragraph-4",
+          "href" : "schedule/6A/paragraph/4",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24084,12 +28584,16 @@
         "number" : null,
         "title" : "Annulment etc",
         "ref" : "schedule-6A-crossheading-annulment-etc",
+        "id" : "schedule-6A-crossheading-annulment-etc",
+        "href" : "schedule/6A/crossheading/annulment-etc",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "5",
           "title" : "(1) This paragraph applies where the FCA receives an application...",
           "ref" : "schedule-6A-paragraph-5",
+          "id" : "schedule-6A-paragraph-5",
+          "href" : "schedule/6A/paragraph/5",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24097,12 +28601,16 @@
         "number" : null,
         "title" : "Effect",
         "ref" : "schedule-6A-crossheading-effect",
+        "id" : "schedule-6A-crossheading-effect",
+        "href" : "schedule/6A/crossheading/effect",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "6",
           "title" : "(1) Where the FCA— (a) varies or cancels an authorised...",
           "ref" : "schedule-6A-paragraph-6",
+          "id" : "schedule-6A-paragraph-6",
+          "href" : "schedule/6A/paragraph/6",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24110,12 +28618,16 @@
         "number" : null,
         "title" : "Right to refer matter to Tribunal",
         "ref" : "schedule-6A-crossheading-right-to-refer-matter-to-tribunal",
+        "id" : "schedule-6A-crossheading-right-to-refer-matter-to-tribunal",
+        "href" : "schedule/6A/crossheading/right-to-refer-matter-to-tribunal",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "7",
           "title" : "(1) This paragraph applies where the FCA— ",
           "ref" : "schedule-6A-paragraph-7",
+          "id" : "schedule-6A-paragraph-7",
+          "href" : "schedule/6A/paragraph/7",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24123,12 +28635,16 @@
         "number" : null,
         "title" : "Supplementary",
         "ref" : "schedule-6A-crossheading-supplementary",
+        "id" : "schedule-6A-crossheading-supplementary",
+        "href" : "schedule/6A/crossheading/supplementary",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "8",
           "title" : "(1) Nothing in this Schedule affects the generality of any...",
           "ref" : "schedule-6A-paragraph-8",
+          "id" : "schedule-6A-paragraph-8",
+          "href" : "schedule/6A/paragraph/8",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -24137,84 +28653,112 @@
       "number" : "SCHEDULE 6B",
       "title" : "Designated activities",
       "ref" : "schedule-6B",
+      "id" : "schedule-6B",
+      "href" : "schedule/6B",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "1",
         "title" : "Introductory",
         "ref" : "schedule-6B-paragraph-1",
+        "id" : "schedule-6B-paragraph-1",
+        "href" : "schedule/6B/paragraph/1",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "2",
         "title" : "Derivatives",
         "ref" : "schedule-6B-paragraph-2",
+        "id" : "schedule-6B-paragraph-2",
+        "href" : "schedule/6B/paragraph/2",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "3",
         "title" : "Holding positions in commodity derivatives. ",
         "ref" : "schedule-6B-paragraph-3",
+        "id" : "schedule-6B-paragraph-3",
+        "href" : "schedule/6B/paragraph/3",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "4",
         "title" : "Short selling",
         "ref" : "schedule-6B-paragraph-4",
+        "id" : "schedule-6B-paragraph-4",
+        "href" : "schedule/6B/paragraph/4",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "5",
         "title" : "Securitisation",
         "ref" : "schedule-6B-paragraph-5",
+        "id" : "schedule-6B-paragraph-5",
+        "href" : "schedule/6B/paragraph/5",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "6",
         "title" : "Selling a securitisation position to a retail client located in...",
         "ref" : "schedule-6B-paragraph-6",
+        "id" : "schedule-6B-paragraph-6",
+        "href" : "schedule/6B/paragraph/6",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "7",
         "title" : "Financial markets",
         "ref" : "schedule-6B-paragraph-7",
+        "id" : "schedule-6B-paragraph-7",
+        "href" : "schedule/6B/paragraph/7",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "8",
         "title" : "Applying for, securing or maintaining the admission of securities to...",
         "ref" : "schedule-6B-paragraph-8",
+        "id" : "schedule-6B-paragraph-8",
+        "href" : "schedule/6B/paragraph/8",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "9",
         "title" : "Using a benchmark",
         "ref" : "schedule-6B-paragraph-9",
+        "id" : "schedule-6B-paragraph-9",
+        "href" : "schedule/6B/paragraph/9",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "10",
         "title" : "Determining the amount payable under an instrument or financial contract...",
         "ref" : "schedule-6B-paragraph-10",
+        "id" : "schedule-6B-paragraph-10",
+        "href" : "schedule/6B/paragraph/10",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "11",
         "title" : "Measuring the performance of an investment fund through a benchmark....",
         "ref" : "schedule-6B-paragraph-11",
+        "id" : "schedule-6B-paragraph-11",
+        "href" : "schedule/6B/paragraph/11",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "12",
         "title" : "Contributing to a benchmark",
         "ref" : "schedule-6B-paragraph-12",
+        "id" : "schedule-6B-paragraph-12",
+        "href" : "schedule/6B/paragraph/12",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "13",
         "title" : "Contributing data to a regulated benchmark administrator for the purpose...",
         "ref" : "schedule-6B-paragraph-13",
+        "id" : "schedule-6B-paragraph-13",
+        "href" : "schedule/6B/paragraph/13",
         "extent" : [ "E", "W", "S", "NI" ]
       } ]
     }, {
@@ -24222,24 +28766,32 @@
       "number" : "SCHEDULE 7",
       "title" : null,
       "ref" : "schedule-7",
+      "id" : "schedule-7",
+      "href" : "schedule/7",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "part",
         "number" : "The Authority as Competent Authority for Part VI",
         "title" : null,
         "ref" : "schedule-7-part-1",
+        "id" : "schedule-7-part-1",
+        "href" : "schedule/7/part/1",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : " General",
           "ref" : "schedule-7-part-1-crossheading-general",
+          "id" : "schedule-7-part-1-crossheading-general",
+          "href" : "schedule/7/part/1/crossheading/general",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "1",
             "title" : ". . . . . . . . . ....",
             "ref" : "schedule-7-paragraph-1",
+            "id" : "schedule-7-paragraph-1",
+            "href" : "schedule/7/paragraph/1",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -24247,12 +28799,16 @@
           "number" : null,
           "title" : " The Authority’s general functions",
           "ref" : "schedule-7-part-1-crossheading-the-authoritys-general-functions",
+          "id" : "schedule-7-part-1-crossheading-the-authoritys-general-functions",
+          "href" : "schedule/7/part/1/crossheading/the-authoritys-general-functions",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "2",
             "title" : ". . . . . . . . . ....",
             "ref" : "schedule-7-paragraph-2",
+            "id" : "schedule-7-paragraph-2",
+            "href" : "schedule/7/paragraph/2",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -24260,12 +28816,16 @@
           "number" : null,
           "title" : " Duty to consult",
           "ref" : "schedule-7-part-1-crossheading-duty-to-consult",
+          "id" : "schedule-7-part-1-crossheading-duty-to-consult",
+          "href" : "schedule/7/part/1/crossheading/duty-to-consult",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "3",
             "title" : ". . . . . . . . . ....",
             "ref" : "schedule-7-paragraph-3",
+            "id" : "schedule-7-paragraph-3",
+            "href" : "schedule/7/paragraph/3",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -24273,12 +28833,16 @@
           "number" : null,
           "title" : " Rules",
           "ref" : "schedule-7-part-1-crossheading-rules",
+          "id" : "schedule-7-part-1-crossheading-rules",
+          "href" : "schedule/7/part/1/crossheading/rules",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "4",
             "title" : ". . . . . . . . . ....",
             "ref" : "schedule-7-paragraph-4",
+            "id" : "schedule-7-paragraph-4",
+            "href" : "schedule/7/paragraph/4",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -24286,12 +28850,16 @@
           "number" : null,
           "title" : " Statements of policy",
           "ref" : "schedule-7-part-1-crossheading-statements-of-policy",
+          "id" : "schedule-7-part-1-crossheading-statements-of-policy",
+          "href" : "schedule/7/part/1/crossheading/statements-of-policy",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "5",
             "title" : ". . . . . . . . . ....",
             "ref" : "schedule-7-paragraph-5",
+            "id" : "schedule-7-paragraph-5",
+            "href" : "schedule/7/paragraph/5",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -24299,12 +28867,16 @@
           "number" : null,
           "title" : " Penalties",
           "ref" : "schedule-7-part-1-crossheading-penalties",
+          "id" : "schedule-7-part-1-crossheading-penalties",
+          "href" : "schedule/7/part/1/crossheading/penalties",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "6",
             "title" : ". . . . . . . . . ....",
             "ref" : "schedule-7-paragraph-6",
+            "id" : "schedule-7-paragraph-6",
+            "href" : "schedule/7/paragraph/6",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -24312,12 +28884,16 @@
           "number" : null,
           "title" : " Fees",
           "ref" : "schedule-7-part-1-crossheading-fees",
+          "id" : "schedule-7-part-1-crossheading-fees",
+          "href" : "schedule/7/part/1/crossheading/fees",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "7",
             "title" : ". . . . . . . . . ....",
             "ref" : "schedule-7-paragraph-7",
+            "id" : "schedule-7-paragraph-7",
+            "href" : "schedule/7/paragraph/7",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -24325,12 +28901,16 @@
           "number" : null,
           "title" : " Exemption from liability in damages",
           "ref" : "schedule-7-part-1-crossheading-exemption-from-liability-in-damages",
+          "id" : "schedule-7-part-1-crossheading-exemption-from-liability-in-damages",
+          "href" : "schedule/7/part/1/crossheading/exemption-from-liability-in-damages",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "8",
             "title" : ". . . . . . . . . ....",
             "ref" : "schedule-7-paragraph-8",
+            "id" : "schedule-7-paragraph-8",
+            "href" : "schedule/7/paragraph/8",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -24340,24 +28920,32 @@
       "number" : "SCHEDULE 8",
       "title" : null,
       "ref" : "schedule-8",
+      "id" : "schedule-8",
+      "href" : "schedule/8",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "part",
         "number" : "Transfer of functions under Part VI",
         "title" : null,
         "ref" : "schedule-8-part-1",
+        "id" : "schedule-8-part-1",
+        "href" : "schedule/8/part/1",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : " The power to transfer",
           "ref" : "schedule-8-part-1-crossheading-the-power-to-transfer",
+          "id" : "schedule-8-part-1-crossheading-the-power-to-transfer",
+          "href" : "schedule/8/part/1/crossheading/the-power-to-transfer",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "1",
             "title" : ". . . . . . . . . ....",
             "ref" : "schedule-8-paragraph-1",
+            "id" : "schedule-8-paragraph-1",
+            "href" : "schedule/8/paragraph/1",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -24365,18 +28953,24 @@
           "number" : null,
           "title" : " Supplemental",
           "ref" : "schedule-8-part-1-crossheading-supplemental",
+          "id" : "schedule-8-part-1-crossheading-supplemental",
+          "href" : "schedule/8/part/1/crossheading/supplemental",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "2",
             "title" : ". . . . . . . . . ....",
             "ref" : "schedule-8-paragraph-2",
+            "id" : "schedule-8-paragraph-2",
+            "href" : "schedule/8/paragraph/2",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "3",
             "title" : ". . . . . . . . . ....",
             "ref" : "schedule-8-paragraph-3",
+            "id" : "schedule-8-paragraph-3",
+            "href" : "schedule/8/paragraph/3",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -24386,18 +28980,24 @@
       "number" : "SCHEDULE 9",
       "title" : null,
       "ref" : "schedule-9",
+      "id" : "schedule-9",
+      "href" : "schedule/9",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : " General application of Part VI",
         "ref" : "schedule-9-crossheading-general-application-of-part-vi",
+        "id" : "schedule-9-crossheading-general-application-of-part-vi",
+        "href" : "schedule/9/crossheading/general-application-of-part-vi",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "1",
           "title" : "The provisions of Part VI apply in relation to a...",
           "ref" : "schedule-9-paragraph-1",
+          "id" : "schedule-9-paragraph-1",
+          "href" : "schedule/9/paragraph/1",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24405,12 +29005,16 @@
         "number" : null,
         "title" : " References to listing particulars",
         "ref" : "schedule-9-crossheading-references-to-listing-particulars",
+        "id" : "schedule-9-crossheading-references-to-listing-particulars",
+        "href" : "schedule/9/crossheading/references-to-listing-particulars",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "2",
           "title" : "(1) Any reference to listing particulars is to be read...",
           "ref" : "schedule-9-paragraph-2",
+          "id" : "schedule-9-paragraph-2",
+          "href" : "schedule/9/paragraph/2",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24418,12 +29022,16 @@
         "number" : null,
         "title" : " General duty of disclosure",
         "ref" : "schedule-9-crossheading-general-duty-of-disclosure",
+        "id" : "schedule-9-crossheading-general-duty-of-disclosure",
+        "href" : "schedule/9/crossheading/general-duty-of-disclosure",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "3",
           "title" : "(1) In section 80(1), for “section 79” substitute “ section...",
           "ref" : "schedule-9-paragraph-3",
+          "id" : "schedule-9-paragraph-3",
+          "href" : "schedule/9/paragraph/3",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24431,12 +29039,16 @@
         "number" : null,
         "title" : " Supplementary prospectuses",
         "ref" : "schedule-9-crossheading-supplementary-prospectuses",
+        "id" : "schedule-9-crossheading-supplementary-prospectuses",
+        "href" : "schedule/9/crossheading/supplementary-prospectuses",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "4",
           "title" : "In section 81(1), for “section 79 and before the commencement...",
           "ref" : "schedule-9-paragraph-4",
+          "id" : "schedule-9-paragraph-4",
+          "href" : "schedule/9/paragraph/4",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24444,12 +29056,16 @@
         "number" : null,
         "title" : " Exemption from liability for compensation",
         "ref" : "schedule-9-crossheading-exemption-from-liability-for-compensation",
+        "id" : "schedule-9-crossheading-exemption-from-liability-for-compensation",
+        "href" : "schedule/9/crossheading/exemption-from-liability-for-compensation",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "5",
           "title" : "(1) In paragraphs 1(3) and 2(3) of Schedule 10, for...",
           "ref" : "schedule-9-paragraph-5",
+          "id" : "schedule-9-paragraph-5",
+          "href" : "schedule/9/paragraph/5",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24457,12 +29073,16 @@
         "number" : null,
         "title" : " Advertisements",
         "ref" : "schedule-9-crossheading-advertisements",
+        "id" : "schedule-9-crossheading-advertisements",
+        "href" : "schedule/9/crossheading/advertisements",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "6",
           "title" : "In section 98(1), for “If listing particulars are, or are...",
           "ref" : "schedule-9-paragraph-6",
+          "id" : "schedule-9-paragraph-6",
+          "href" : "schedule/9/paragraph/6",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24470,12 +29090,16 @@
         "number" : null,
         "title" : " Fees",
         "ref" : "schedule-9-crossheading-fees",
+        "id" : "schedule-9-crossheading-fees",
+        "href" : "schedule/9/crossheading/fees",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "7",
           "title" : "Listing rules made under section 99 may require the payment...",
           "ref" : "schedule-9-paragraph-7",
+          "id" : "schedule-9-paragraph-7",
+          "href" : "schedule/9/paragraph/7",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -24484,18 +29108,24 @@
       "number" : "SCHEDULE 10",
       "title" : " Compensation: Exemptions",
       "ref" : "schedule-10",
+      "id" : "schedule-10",
+      "href" : "schedule/10",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : " Statements believed to be true",
         "ref" : "schedule-10-crossheading-statements-believed-to-be-true",
+        "id" : "schedule-10-crossheading-statements-believed-to-be-true",
+        "href" : "schedule/10/crossheading/statements-believed-to-be-true",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "1",
           "title" : "(1) In this paragraph “statement” means— (a) any untrue or...",
           "ref" : "schedule-10-paragraph-1",
+          "id" : "schedule-10-paragraph-1",
+          "href" : "schedule/10/paragraph/1",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24503,12 +29133,16 @@
         "number" : null,
         "title" : " Statements by experts",
         "ref" : "schedule-10-crossheading-statements-by-experts",
+        "id" : "schedule-10-crossheading-statements-by-experts",
+        "href" : "schedule/10/crossheading/statements-by-experts",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "2",
           "title" : "(1) In this paragraph “statement” means a statement included in...",
           "ref" : "schedule-10-paragraph-2",
+          "id" : "schedule-10-paragraph-2",
+          "href" : "schedule/10/paragraph/2",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24516,12 +29150,16 @@
         "number" : null,
         "title" : " Corrections of statements",
         "ref" : "schedule-10-crossheading-corrections-of-statements",
+        "id" : "schedule-10-crossheading-corrections-of-statements",
+        "href" : "schedule/10/crossheading/corrections-of-statements",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "3",
           "title" : "(1) In this paragraph “statement” has the same meaning as...",
           "ref" : "schedule-10-paragraph-3",
+          "id" : "schedule-10-paragraph-3",
+          "href" : "schedule/10/paragraph/3",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24529,12 +29167,16 @@
         "number" : null,
         "title" : " Corrections of statements by experts",
         "ref" : "schedule-10-crossheading-corrections-of-statements-by-experts",
+        "id" : "schedule-10-crossheading-corrections-of-statements-by-experts",
+        "href" : "schedule/10/crossheading/corrections-of-statements-by-experts",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "4",
           "title" : "(1) In this paragraph “statement” has the same meaning as...",
           "ref" : "schedule-10-paragraph-4",
+          "id" : "schedule-10-paragraph-4",
+          "href" : "schedule/10/paragraph/4",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24542,12 +29184,16 @@
         "number" : null,
         "title" : " Official statements",
         "ref" : "schedule-10-crossheading-official-statements",
+        "id" : "schedule-10-crossheading-official-statements",
+        "href" : "schedule/10/crossheading/official-statements",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "5",
           "title" : "A person does not incur any liability under section 90(1)...",
           "ref" : "schedule-10-paragraph-5",
+          "id" : "schedule-10-paragraph-5",
+          "href" : "schedule/10/paragraph/5",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24555,12 +29201,16 @@
         "number" : null,
         "title" : " False or misleading information known about",
         "ref" : "schedule-10-crossheading-false-or-misleading-information-known-about",
+        "id" : "schedule-10-crossheading-false-or-misleading-information-known-about",
+        "href" : "schedule/10/crossheading/false-or-misleading-information-known-about",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "6",
           "title" : "A person does not incur any liability under section 90(1)...",
           "ref" : "schedule-10-paragraph-6",
+          "id" : "schedule-10-paragraph-6",
+          "href" : "schedule/10/paragraph/6",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24568,12 +29218,16 @@
         "number" : null,
         "title" : " Belief that supplementary listing particulars not called for",
         "ref" : "schedule-10-crossheading-belief-that-supplementary-listing-particulars-not-called-for",
+        "id" : "schedule-10-crossheading-belief-that-supplementary-listing-particulars-not-called-for",
+        "href" : "schedule/10/crossheading/belief-that-supplementary-listing-particulars-not-called-for",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "7",
           "title" : "A person does not incur any liability under section 90(4)...",
           "ref" : "schedule-10-paragraph-7",
+          "id" : "schedule-10-paragraph-7",
+          "href" : "schedule/10/paragraph/7",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24581,12 +29235,16 @@
         "number" : null,
         "title" : " Meaning of “expert”",
         "ref" : "schedule-10-crossheading-meaning-of-expert",
+        "id" : "schedule-10-crossheading-meaning-of-expert",
+        "href" : "schedule/10/crossheading/meaning-of-expert",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "8",
           "title" : "“Expert” includes any engineer, valuer, accountant or other person whose...",
           "ref" : "schedule-10-paragraph-8",
+          "id" : "schedule-10-paragraph-8",
+          "href" : "schedule/10/paragraph/8",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -24595,24 +29253,32 @@
       "number" : "SCHEDULE 10A",
       "title" : "LIABILITY OF ISSUERS IN CONNECTION WITH PUBLISHED INFORMATION",
       "ref" : "schedule-10A",
+      "id" : "schedule-10A",
+      "href" : "schedule/10A",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "part",
         "number" : "PART 1",
         "title" : "SCOPE OF THIS SCHEDULE",
         "ref" : "schedule-10A-part-1",
+        "id" : "schedule-10A-part-1",
+        "href" : "schedule/10A/part/1",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "1",
           "title" : "Securities to which this Schedule applies",
           "ref" : "schedule-10A-paragraph-1",
+          "id" : "schedule-10A-paragraph-1",
+          "href" : "schedule/10A/paragraph/1",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "2",
           "title" : "Published information to which this Schedule applies",
           "ref" : "schedule-10A-paragraph-2",
+          "id" : "schedule-10A-paragraph-2",
+          "href" : "schedule/10A/paragraph/2",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24620,36 +29286,48 @@
         "number" : "PART 2",
         "title" : "LIABILITY IN CONNECTION WITH PUBLISHED INFORMATION",
         "ref" : "schedule-10A-part-2",
+        "id" : "schedule-10A-part-2",
+        "href" : "schedule/10A/part/2",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "3",
           "title" : "Liability of issuer for misleading statement or dishonest omission",
           "ref" : "schedule-10A-paragraph-3",
+          "id" : "schedule-10A-paragraph-3",
+          "href" : "schedule/10A/paragraph/3",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "4",
           "title" : "An issuer of securities to which this Schedule applies is...",
           "ref" : "schedule-10A-paragraph-4",
+          "id" : "schedule-10A-paragraph-4",
+          "href" : "schedule/10A/paragraph/4",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "5",
           "title" : "Liability of issuer for dishonest delay in publishing information",
           "ref" : "schedule-10A-paragraph-5",
+          "id" : "schedule-10A-paragraph-5",
+          "href" : "schedule/10A/paragraph/5",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "6",
           "title" : "Meaning of dishonesty",
           "ref" : "schedule-10A-paragraph-6",
+          "id" : "schedule-10A-paragraph-6",
+          "href" : "schedule/10A/paragraph/6",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "7",
           "title" : "Exclusion of certain other liabilities",
           "ref" : "schedule-10A-paragraph-7",
+          "id" : "schedule-10A-paragraph-7",
+          "href" : "schedule/10A/paragraph/7",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24657,12 +29335,16 @@
         "number" : "PART 3",
         "title" : "SUPPLEMENTARY PROVISIONS",
         "ref" : "schedule-10A-part-3",
+        "id" : "schedule-10A-part-3",
+        "href" : "schedule/10A/part/3",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "8",
           "title" : "Interpretation",
           "ref" : "schedule-10A-paragraph-8",
+          "id" : "schedule-10A-paragraph-8",
+          "href" : "schedule/10A/paragraph/8",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -24671,18 +29353,24 @@
       "number" : "SCHEDULE 11",
       "title" : null,
       "ref" : "schedule-11",
+      "id" : "schedule-11",
+      "href" : "schedule/11",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : " The general rule",
         "ref" : "schedule-11-crossheading-the-general-rule",
+        "id" : "schedule-11-crossheading-the-general-rule",
+        "href" : "schedule/11/crossheading/the-general-rule",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "1",
           "title" : "(1) A person offers securities to the public in the...",
           "ref" : "schedule-11-paragraph-1",
+          "id" : "schedule-11-paragraph-1",
+          "href" : "schedule/11/paragraph/1",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24690,12 +29378,16 @@
         "number" : null,
         "title" : " Exempt offers",
         "ref" : "schedule-11-crossheading-exempt-offers",
+        "id" : "schedule-11-crossheading-exempt-offers",
+        "href" : "schedule/11/crossheading/exempt-offers",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "2",
           "title" : "(1) For the purposes of this Schedule, an offer of...",
           "ref" : "schedule-11-paragraph-2",
+          "id" : "schedule-11-paragraph-2",
+          "href" : "schedule/11/paragraph/2",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24703,12 +29395,16 @@
         "number" : null,
         "title" : " Offers for business purposes",
         "ref" : "schedule-11-crossheading-offers-for-business-purposes",
+        "id" : "schedule-11-crossheading-offers-for-business-purposes",
+        "href" : "schedule/11/crossheading/offers-for-business-purposes",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "3",
           "title" : "The securities are offered to persons— (a) whose ordinary activities...",
           "ref" : "schedule-11-paragraph-3",
+          "id" : "schedule-11-paragraph-3",
+          "href" : "schedule/11/paragraph/3",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24716,12 +29412,16 @@
         "number" : null,
         "title" : " Offers to limited numbers",
         "ref" : "schedule-11-crossheading-offers-to-limited-numbers",
+        "id" : "schedule-11-crossheading-offers-to-limited-numbers",
+        "href" : "schedule/11/crossheading/offers-to-limited-numbers",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "4",
           "title" : "(1) The securities are offered to no more than fifty...",
           "ref" : "schedule-11-paragraph-4",
+          "id" : "schedule-11-paragraph-4",
+          "href" : "schedule/11/paragraph/4",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24729,12 +29429,16 @@
         "number" : null,
         "title" : " Clubs and associations",
         "ref" : "schedule-11-crossheading-clubs-and-associations",
+        "id" : "schedule-11-crossheading-clubs-and-associations",
+        "href" : "schedule/11/crossheading/clubs-and-associations",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "5",
           "title" : "The securities are offered to the members of a club...",
           "ref" : "schedule-11-paragraph-5",
+          "id" : "schedule-11-paragraph-5",
+          "href" : "schedule/11/paragraph/5",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24742,12 +29446,16 @@
         "number" : null,
         "title" : " Restricted circles",
         "ref" : "schedule-11-crossheading-restricted-circles",
+        "id" : "schedule-11-crossheading-restricted-circles",
+        "href" : "schedule/11/crossheading/restricted-circles",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "6",
           "title" : "(1) The securities are offered to a restricted circle of...",
           "ref" : "schedule-11-paragraph-6",
+          "id" : "schedule-11-paragraph-6",
+          "href" : "schedule/11/paragraph/6",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24755,12 +29463,16 @@
         "number" : null,
         "title" : " Underwriting agreements",
         "ref" : "schedule-11-crossheading-underwriting-agreements",
+        "id" : "schedule-11-crossheading-underwriting-agreements",
+        "href" : "schedule/11/crossheading/underwriting-agreements",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "7",
           "title" : "The securities are offered in connection with a genuine invitation...",
           "ref" : "schedule-11-paragraph-7",
+          "id" : "schedule-11-paragraph-7",
+          "href" : "schedule/11/paragraph/7",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24768,12 +29480,16 @@
         "number" : null,
         "title" : " Offers to public authorities",
         "ref" : "schedule-11-crossheading-offers-to-public-authorities",
+        "id" : "schedule-11-crossheading-offers-to-public-authorities",
+        "href" : "schedule/11/crossheading/offers-to-public-authorities",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "8",
           "title" : "(1) The securities are offered to a public authority. ",
           "ref" : "schedule-11-paragraph-8",
+          "id" : "schedule-11-paragraph-8",
+          "href" : "schedule/11/paragraph/8",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24781,12 +29497,16 @@
         "number" : null,
         "title" : " Maximum consideration",
         "ref" : "schedule-11-crossheading-maximum-consideration",
+        "id" : "schedule-11-crossheading-maximum-consideration",
+        "href" : "schedule/11/crossheading/maximum-consideration",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "9",
           "title" : "(1) The total consideration payable for the securities cannot exceed...",
           "ref" : "schedule-11-paragraph-9",
+          "id" : "schedule-11-paragraph-9",
+          "href" : "schedule/11/paragraph/9",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24794,12 +29514,16 @@
         "number" : null,
         "title" : " Minimum consideration",
         "ref" : "schedule-11-crossheading-minimum-consideration",
+        "id" : "schedule-11-crossheading-minimum-consideration",
+        "href" : "schedule/11/crossheading/minimum-consideration",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "10",
           "title" : "(1) The minimum consideration which may be paid by any...",
           "ref" : "schedule-11-paragraph-10",
+          "id" : "schedule-11-paragraph-10",
+          "href" : "schedule/11/paragraph/10",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24807,12 +29531,16 @@
         "number" : null,
         "title" : " Securities denominated in euros",
         "ref" : "schedule-11-crossheading-securities-denominated-in-euros",
+        "id" : "schedule-11-crossheading-securities-denominated-in-euros",
+        "href" : "schedule/11/crossheading/securities-denominated-in-euros",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "11",
           "title" : "(1) The securities are denominated in amounts of at least...",
           "ref" : "schedule-11-paragraph-11",
+          "id" : "schedule-11-paragraph-11",
+          "href" : "schedule/11/paragraph/11",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24820,12 +29548,16 @@
         "number" : null,
         "title" : " Takeovers",
         "ref" : "schedule-11-crossheading-takeovers",
+        "id" : "schedule-11-crossheading-takeovers",
+        "href" : "schedule/11/crossheading/takeovers",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "12",
           "title" : "(1) The securities are offered in connection with a takeover...",
           "ref" : "schedule-11-paragraph-12",
+          "id" : "schedule-11-paragraph-12",
+          "href" : "schedule/11/paragraph/12",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24833,12 +29565,16 @@
         "number" : null,
         "title" : " Mergers",
         "ref" : "schedule-11-crossheading-mergers",
+        "id" : "schedule-11-crossheading-mergers",
+        "href" : "schedule/11/crossheading/mergers",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "13",
           "title" : "The securities are offered in connection with a merger (within...",
           "ref" : "schedule-11-paragraph-13",
+          "id" : "schedule-11-paragraph-13",
+          "href" : "schedule/11/paragraph/13",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24846,12 +29582,16 @@
         "number" : null,
         "title" : " Free shares",
         "ref" : "schedule-11-crossheading-free-shares",
+        "id" : "schedule-11-crossheading-free-shares",
+        "href" : "schedule/11/crossheading/free-shares",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "14",
           "title" : "(1) The securities are shares and are offered free of...",
           "ref" : "schedule-11-paragraph-14",
+          "id" : "schedule-11-paragraph-14",
+          "href" : "schedule/11/paragraph/14",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24859,12 +29599,16 @@
         "number" : null,
         "title" : " Exchange of shares",
         "ref" : "schedule-11-crossheading-exchange-of-shares",
+        "id" : "schedule-11-crossheading-exchange-of-shares",
+        "href" : "schedule/11/crossheading/exchange-of-shares",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "15",
           "title" : "The securities— (a) are shares, or investments of a specified...",
           "ref" : "schedule-11-paragraph-15",
+          "id" : "schedule-11-paragraph-15",
+          "href" : "schedule/11/paragraph/15",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24872,12 +29616,16 @@
         "number" : null,
         "title" : " Qualifying persons",
         "ref" : "schedule-11-crossheading-qualifying-persons",
+        "id" : "schedule-11-crossheading-qualifying-persons",
+        "href" : "schedule/11/crossheading/qualifying-persons",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "16",
           "title" : "(1) The securities are issued by a body corporate and...",
           "ref" : "schedule-11-paragraph-16",
+          "id" : "schedule-11-paragraph-16",
+          "href" : "schedule/11/paragraph/16",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24885,12 +29633,16 @@
         "number" : null,
         "title" : " Convertible securities",
         "ref" : "schedule-11-crossheading-convertible-securities",
+        "id" : "schedule-11-crossheading-convertible-securities",
+        "href" : "schedule/11/crossheading/convertible-securities",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "17",
           "title" : "(1) The securities result from the conversion of convertible securities...",
           "ref" : "schedule-11-paragraph-17",
+          "id" : "schedule-11-paragraph-17",
+          "href" : "schedule/11/paragraph/17",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24898,12 +29650,16 @@
         "number" : null,
         "title" : " Charities",
         "ref" : "schedule-11-crossheading-charities",
+        "id" : "schedule-11-crossheading-charities",
+        "href" : "schedule/11/crossheading/charities",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "18",
           "title" : "The securities are issued by— (a) a charity within the...",
           "ref" : "schedule-11-paragraph-18",
+          "id" : "schedule-11-paragraph-18",
+          "href" : "schedule/11/paragraph/18",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24911,12 +29667,16 @@
         "number" : null,
         "title" : " Building societies etc.",
         "ref" : "schedule-11-crossheading-building-societies-etc",
+        "id" : "schedule-11-crossheading-building-societies-etc",
+        "href" : "schedule/11/crossheading/building-societies-etc",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "19",
           "title" : "The securities offered are shares which are issued by, or...",
           "ref" : "schedule-11-paragraph-19",
+          "id" : "schedule-11-paragraph-19",
+          "href" : "schedule/11/paragraph/19",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24924,12 +29684,16 @@
         "number" : null,
         "title" : " Euro-securities",
         "ref" : "schedule-11-crossheading-eurosecurities",
+        "id" : "schedule-11-crossheading-eurosecurities",
+        "href" : "schedule/11/crossheading/eurosecurities",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "20",
           "title" : "(1) The securities offered are Euro-securities and no advertisement relating...",
           "ref" : "schedule-11-paragraph-20",
+          "id" : "schedule-11-paragraph-20",
+          "href" : "schedule/11/paragraph/20",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24937,12 +29701,16 @@
         "number" : null,
         "title" : " Same class securities",
         "ref" : "schedule-11-crossheading-same-class-securities",
+        "id" : "schedule-11-crossheading-same-class-securities",
+        "href" : "schedule/11/crossheading/same-class-securities",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "21",
           "title" : "The securities are of the same class, and were issued...",
           "ref" : "schedule-11-paragraph-21",
+          "id" : "schedule-11-paragraph-21",
+          "href" : "schedule/11/paragraph/21",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24950,12 +29718,16 @@
         "number" : null,
         "title" : " Short date securities",
         "ref" : "schedule-11-crossheading-short-date-securities",
+        "id" : "schedule-11-crossheading-short-date-securities",
+        "href" : "schedule/11/crossheading/short-date-securities",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "22",
           "title" : "The securities are investments of a specified kind with a...",
           "ref" : "schedule-11-paragraph-22",
+          "id" : "schedule-11-paragraph-22",
+          "href" : "schedule/11/paragraph/22",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24963,12 +29735,16 @@
         "number" : null,
         "title" : " Government and public securities",
         "ref" : "schedule-11-crossheading-government-and-public-securities",
+        "id" : "schedule-11-crossheading-government-and-public-securities",
+        "href" : "schedule/11/crossheading/government-and-public-securities",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "23",
           "title" : "(1) The securities are investments of a specified kind creating...",
           "ref" : "schedule-11-paragraph-23",
+          "id" : "schedule-11-paragraph-23",
+          "href" : "schedule/11/paragraph/23",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24976,18 +29752,24 @@
         "number" : null,
         "title" : " Non-transferable securities",
         "ref" : "schedule-11-crossheading-nontransferable-securities",
+        "id" : "schedule-11-crossheading-nontransferable-securities",
+        "href" : "schedule/11/crossheading/nontransferable-securities",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "24",
           "title" : "The securities are not transferable. ",
           "ref" : "schedule-11-paragraph-24",
+          "id" : "schedule-11-paragraph-24",
+          "href" : "schedule/11/paragraph/24",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "24A",
           "title" : "<i>Units in a collective investment scheme</i>",
           "ref" : "schedule-11-paragraph-24A",
+          "id" : "schedule-11-paragraph-24A",
+          "href" : "schedule/11/paragraph/24A",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -24995,12 +29777,16 @@
         "number" : null,
         "title" : " General definitions",
         "ref" : "schedule-11-crossheading-general-definitions",
+        "id" : "schedule-11-crossheading-general-definitions",
+        "href" : "schedule/11/crossheading/general-definitions",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "25",
           "title" : "For the purposes of this Schedule— “shares” has such meaning...",
           "ref" : "schedule-11-paragraph-25",
+          "id" : "schedule-11-paragraph-25",
+          "href" : "schedule/11/paragraph/25",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -25009,48 +29795,64 @@
       "number" : "SCHEDULE 11A",
       "title" : "TRANSFERABLE SECURITIES",
       "ref" : "schedule-11A",
+      "id" : "schedule-11A",
+      "href" : "schedule/11A",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "part",
         "number" : "PART 1",
         "title" : null,
         "ref" : "schedule-11A-part-1",
+        "id" : "schedule-11A-part-1",
+        "href" : "schedule/11A/part/1",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "1",
           "title" : "Units (within the meaning in section 237(2)) in an open-ended...",
           "ref" : "schedule-11A-paragraph-1",
+          "id" : "schedule-11A-paragraph-1",
+          "href" : "schedule/11A/paragraph/1",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "2",
           "title" : "Non-equity transferable securities issued by (a) the government of an...",
           "ref" : "schedule-11A-paragraph-2",
+          "id" : "schedule-11A-paragraph-2",
+          "href" : "schedule/11A/paragraph/2",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "3",
           "title" : "Shares in the share capital of the central bank of...",
           "ref" : "schedule-11A-paragraph-3",
+          "id" : "schedule-11A-paragraph-3",
+          "href" : "schedule/11A/paragraph/3",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "4",
           "title" : "Transferable securities unconditionally and irrevocably guaranteed by the government, or...",
           "ref" : "schedule-11A-paragraph-4",
+          "id" : "schedule-11A-paragraph-4",
+          "href" : "schedule/11A/paragraph/4",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "5",
           "title" : "(1) Non-equity transferable securities, issued in a continuous or repeated...",
           "ref" : "schedule-11A-paragraph-5",
+          "id" : "schedule-11A-paragraph-5",
+          "href" : "schedule/11A/paragraph/5",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "6",
           "title" : "Non-fungible shares of capital— (a) the main purpose of which...",
           "ref" : "schedule-11A-paragraph-6",
+          "id" : "schedule-11A-paragraph-6",
+          "href" : "schedule/11A/paragraph/6",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -25058,24 +29860,32 @@
         "number" : "PART 2",
         "title" : null,
         "ref" : "schedule-11A-part-2",
+        "id" : "schedule-11A-part-2",
+        "href" : "schedule/11A/part/2",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "7",
           "title" : "(1) Transferable securities issued by a body specified in sub-paragraph...",
           "ref" : "schedule-11A-paragraph-7",
+          "id" : "schedule-11A-paragraph-7",
+          "href" : "schedule/11A/paragraph/7",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "8",
           "title" : "(1) Non-equity transferable securities, issued in a continuous or repeated...",
           "ref" : "schedule-11A-paragraph-8",
+          "id" : "schedule-11A-paragraph-8",
+          "href" : "schedule/11A/paragraph/8",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "9",
           "title" : "(1) Transferable securities included in an offer where the total...",
           "ref" : "schedule-11A-paragraph-9",
+          "id" : "schedule-11A-paragraph-9",
+          "href" : "schedule/11A/paragraph/9",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -25084,48 +29894,64 @@
       "number" : "SCHEDULE 11B",
       "title" : "CONNECTED PERSONS",
       "ref" : "schedule-11B",
+      "id" : "schedule-11B",
+      "href" : "schedule/11B",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "part",
         "number" : "PART 1",
         "title" : "MEANING OF  “CONNECTED PERSON”",
         "ref" : "schedule-11B-part-1",
+        "id" : "schedule-11B-part-1",
+        "href" : "schedule/11B/part/1",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "1",
           "title" : "Introduction",
           "ref" : "schedule-11B-paragraph-1",
+          "id" : "schedule-11B-paragraph-1",
+          "href" : "schedule/11B/paragraph/1",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "2",
           "title" : "Meaning of  “connected person”",
           "ref" : "schedule-11B-paragraph-2",
+          "id" : "schedule-11B-paragraph-2",
+          "href" : "schedule/11B/paragraph/2",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "3",
           "title" : "Family members",
           "ref" : "schedule-11B-paragraph-3",
+          "id" : "schedule-11B-paragraph-3",
+          "href" : "schedule/11B/paragraph/3",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "4",
           "title" : "Associated bodies corporate",
           "ref" : "schedule-11B-paragraph-4",
+          "id" : "schedule-11B-paragraph-4",
+          "href" : "schedule/11B/paragraph/4",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "5",
           "title" : "Control of a body corporate",
           "ref" : "schedule-11B-paragraph-5",
+          "id" : "schedule-11B-paragraph-5",
+          "href" : "schedule/11B/paragraph/5",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "6",
           "title" : "Supplementary provisions",
           "ref" : "schedule-11B-paragraph-6",
+          "id" : "schedule-11B-paragraph-6",
+          "href" : "schedule/11B/paragraph/6",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -25133,42 +29959,56 @@
         "number" : "PART 2",
         "title" : "CONNECTED PERSONS: REFERENCES TO AN INTEREST IN SHARES OR DEBENTURES",
         "ref" : "schedule-11B-part-2",
+        "id" : "schedule-11B-part-2",
+        "href" : "schedule/11B/part/2",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "7",
           "title" : "Introduction",
           "ref" : "schedule-11B-paragraph-7",
+          "id" : "schedule-11B-paragraph-7",
+          "href" : "schedule/11B/paragraph/7",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "8",
           "title" : "General provisions",
           "ref" : "schedule-11B-paragraph-8",
+          "id" : "schedule-11B-paragraph-8",
+          "href" : "schedule/11B/paragraph/8",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "9",
           "title" : "Rights to acquire shares",
           "ref" : "schedule-11B-paragraph-9",
+          "id" : "schedule-11B-paragraph-9",
+          "href" : "schedule/11B/paragraph/9",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "10",
           "title" : "Right to exercise or control exercise of rights",
           "ref" : "schedule-11B-paragraph-10",
+          "id" : "schedule-11B-paragraph-10",
+          "href" : "schedule/11B/paragraph/10",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "11",
           "title" : "Bodies corporate",
           "ref" : "schedule-11B-paragraph-11",
+          "id" : "schedule-11B-paragraph-11",
+          "href" : "schedule/11B/paragraph/11",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "12",
           "title" : "Trusts",
           "ref" : "schedule-11B-paragraph-12",
+          "id" : "schedule-11B-paragraph-12",
+          "href" : "schedule/11B/paragraph/12",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -25177,30 +30017,40 @@
       "number" : "SCHEDULE 12",
       "title" : " Transfer schemes: certificates",
       "ref" : "schedule-12",
+      "id" : "schedule-12",
+      "href" : "schedule/12",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "part",
         "number" : "Part I",
         "title" : " Insurance Business Transfer Schemes",
         "ref" : "schedule-12-part-I",
+        "id" : "schedule-12-part-I",
+        "href" : "schedule/12/part/I",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "1",
           "title" : "For the purposes of section 111(2) the appropriate certificate, in...",
           "ref" : "schedule-12-paragraph-1",
+          "id" : "schedule-12-paragraph-1",
+          "href" : "schedule/12/paragraph/1",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "pblock",
           "number" : null,
           "title" : " Certificates as to margin of solvency",
           "ref" : "schedule-12-part-I-crossheading-certificates-as-to-margin-of-solvency",
+          "id" : "schedule-12-part-I-crossheading-certificates-as-to-margin-of-solvency",
+          "href" : "schedule/12/part/I/crossheading/certificates-as-to-margin-of-solvency",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "2",
             "title" : "(1) A certificate under this paragraph is to be given—...",
             "ref" : "schedule-12-paragraph-2",
+            "id" : "schedule-12-paragraph-2",
+            "href" : "schedule/12/paragraph/2",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -25208,12 +30058,16 @@
           "number" : null,
           "title" : " Certificates as to  consultation ",
           "ref" : "schedule-12-part-I-crossheading-certificates-as-to-consent",
+          "id" : "schedule-12-part-I-crossheading-certificates-as-to-consent",
+          "href" : "schedule/12/part/I/crossheading/certificates-as-to-consent",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "3",
             "title" : "A certificate under this paragraph is one given by the...",
             "ref" : "schedule-12-paragraph-3",
+            "id" : "schedule-12-paragraph-3",
+            "href" : "schedule/12/paragraph/3",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -25221,12 +30075,16 @@
           "number" : null,
           "title" : "Certificates as to consent",
           "ref" : "schedule-12-part-i-crossheading-certificates-as-to-consent",
+          "id" : "schedule-12-part-i-crossheading-certificates-as-to-consent",
+          "href" : "schedule/12/part/i/crossheading/certificates-as-to-consent",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "3A",
             "title" : "A certificate under this paragraph is one given by the...",
             "ref" : "schedule-12-paragraph-3A",
+            "id" : "schedule-12-paragraph-3A",
+            "href" : "schedule/12/paragraph/3A",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -25234,12 +30092,16 @@
           "number" : null,
           "title" : " Certificates as to long-term business",
           "ref" : "schedule-12-part-I-crossheading-certificates-as-to-longterm-business",
+          "id" : "schedule-12-part-I-crossheading-certificates-as-to-longterm-business",
+          "href" : "schedule/12/part/I/crossheading/certificates-as-to-longterm-business",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "4",
             "title" : "A certificate under this paragraph is one given by the...",
             "ref" : "schedule-12-paragraph-4",
+            "id" : "schedule-12-paragraph-4",
+            "href" : "schedule/12/paragraph/4",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -25247,12 +30109,16 @@
           "number" : null,
           "title" : " Certificates as to general business",
           "ref" : "schedule-12-part-I-crossheading-certificates-as-to-general-business",
+          "id" : "schedule-12-part-I-crossheading-certificates-as-to-general-business",
+          "href" : "schedule/12/part/I/crossheading/certificates-as-to-general-business",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "5",
             "title" : "A certificate under this paragraph is one given by the...",
             "ref" : "schedule-12-paragraph-5",
+            "id" : "schedule-12-paragraph-5",
+            "href" : "schedule/12/paragraph/5",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -25260,12 +30126,16 @@
           "number" : null,
           "title" : "Certificates as to legality and as to consent",
           "ref" : "schedule-12-part-I-crossheading-certificates-as-to-legality-and-as-to-consent",
+          "id" : "schedule-12-part-I-crossheading-certificates-as-to-legality-and-as-to-consent",
+          "href" : "schedule/12/part/I/crossheading/certificates-as-to-legality-and-as-to-consent",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "5A",
             "title" : "(1) The certificates under this paragraph are to be given—...",
             "ref" : "schedule-12-paragraph-5A",
+            "id" : "schedule-12-paragraph-5A",
+            "href" : "schedule/12/paragraph/5A",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -25273,12 +30143,16 @@
           "number" : null,
           "title" : " Interpretation of Part I",
           "ref" : "schedule-12-part-I-crossheading-interpretation-of-part-i",
+          "id" : "schedule-12-part-I-crossheading-interpretation-of-part-i",
+          "href" : "schedule/12/part/I/crossheading/interpretation-of-part-i",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "6",
             "title" : "(1) “ State of the commitment ”, in relation to...",
             "ref" : "schedule-12-paragraph-6",
+            "id" : "schedule-12-paragraph-6",
+            "href" : "schedule/12/paragraph/6",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -25287,24 +30161,32 @@
         "number" : "Part II",
         "title" : " Banking Business Transfer Schemes",
         "ref" : "schedule-12-part-II",
+        "id" : "schedule-12-part-II",
+        "href" : "schedule/12/part/II",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "7",
           "title" : "For the purposes of section 111(2) the appropriate certificate, in...",
           "ref" : "schedule-12-paragraph-7",
+          "id" : "schedule-12-paragraph-7",
+          "href" : "schedule/12/paragraph/7",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "pblock",
           "number" : null,
           "title" : " Certificates as to financial resources",
           "ref" : "schedule-12-part-II-crossheading-certificates-as-to-financial-resources",
+          "id" : "schedule-12-part-II-crossheading-certificates-as-to-financial-resources",
+          "href" : "schedule/12/part/II/crossheading/certificates-as-to-financial-resources",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "8",
             "title" : "(1) A certificate under this paragraph is one given by...",
             "ref" : "schedule-12-paragraph-8",
+            "id" : "schedule-12-paragraph-8",
+            "href" : "schedule/12/paragraph/8",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -25312,12 +30194,16 @@
           "number" : null,
           "title" : " Certificates as to consent of home state regulator",
           "ref" : "schedule-12-part-II-crossheading-certificates-as-to-consent-of-home-state-regulator",
+          "id" : "schedule-12-part-II-crossheading-certificates-as-to-consent-of-home-state-regulator",
+          "href" : "schedule/12/part/II/crossheading/certificates-as-to-consent-of-home-state-regulator",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "9",
             "title" : "A certificate under this paragraph is one given by the...",
             "ref" : "schedule-12-paragraph-9",
+            "id" : "schedule-12-paragraph-9",
+            "href" : "schedule/12/paragraph/9",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -25326,12 +30212,16 @@
         "number" : "Part 2A",
         "title" : "Reclaim fund business transfer schemes",
         "ref" : "schedule-12-part-2A",
+        "id" : "schedule-12-part-2A",
+        "href" : "schedule/12/part/2A",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "9A",
           "title" : "Certificate as to financial resources",
           "ref" : "schedule-12-paragraph-9A",
+          "id" : "schedule-12-paragraph-9A",
+          "href" : "schedule/12/paragraph/9A",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -25339,24 +30229,32 @@
         "number" : "PART 2B",
         "title" : "Ring-fencing transfer schemes",
         "ref" : "schedule-12-part-2B",
+        "id" : "schedule-12-part-2B",
+        "href" : "schedule/12/part/2B",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "9B",
           "title" : "Appropriate certificates",
           "ref" : "schedule-12-paragraph-9B",
+          "id" : "schedule-12-paragraph-9B",
+          "href" : "schedule/12/paragraph/9B",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "9C",
           "title" : "Certificate as to financial resources",
           "ref" : "schedule-12-paragraph-9C",
+          "id" : "schedule-12-paragraph-9C",
+          "href" : "schedule/12/paragraph/9C",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "9D",
           "title" : "Certificate as to consent of home state regulator",
           "ref" : "schedule-12-paragraph-9D",
+          "id" : "schedule-12-paragraph-9D",
+          "href" : "schedule/12/paragraph/9D",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -25364,12 +30262,16 @@
         "number" : "Part III",
         "title" : " Insurance business transfers effected outside the United Kingdom",
         "ref" : "schedule-12-part-III",
+        "id" : "schedule-12-part-III",
+        "href" : "schedule/12/part/III",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "10",
           "title" : "(1) This paragraph applies to a proposal to execute under...",
           "ref" : "schedule-12-paragraph-10",
+          "id" : "schedule-12-paragraph-10",
+          "href" : "schedule/12/paragraph/10",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -25378,24 +30280,32 @@
       "number" : "SCHEDULE 13",
       "title" : null,
       "ref" : "schedule-13",
+      "id" : "schedule-13",
+      "href" : "schedule/13",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "part",
         "number" : "Part I",
         "title" : " General",
         "ref" : "schedule-13-part-I",
+        "id" : "schedule-13-part-I",
+        "href" : "schedule/13/part/I",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : " Interpretation",
           "ref" : "schedule-13-part-I-crossheading-interpretation",
+          "id" : "schedule-13-part-I-crossheading-interpretation",
+          "href" : "schedule/13/part/I/crossheading/interpretation",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "1",
             "title" : "In this Schedule— “panel of chairmen” means the panel established...",
             "ref" : "schedule-13-paragraph-1",
+            "id" : "schedule-13-paragraph-1",
+            "href" : "schedule/13/paragraph/1",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -25404,18 +30314,24 @@
         "number" : "Part II",
         "title" : " The Tribunal",
         "ref" : "schedule-13-part-II",
+        "id" : "schedule-13-part-II",
+        "href" : "schedule/13/part/II",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : " President",
           "ref" : "schedule-13-part-II-crossheading-president",
+          "id" : "schedule-13-part-II-crossheading-president",
+          "href" : "schedule/13/part/II/crossheading/president",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "2",
             "title" : "(1) The Lord Chancellor must appoint one of the members...",
             "ref" : "schedule-13-paragraph-2",
+            "id" : "schedule-13-paragraph-2",
+            "href" : "schedule/13/paragraph/2",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -25423,12 +30339,16 @@
           "number" : null,
           "title" : " Panels",
           "ref" : "schedule-13-part-II-crossheading-panels",
+          "id" : "schedule-13-part-II-crossheading-panels",
+          "href" : "schedule/13/part/II/crossheading/panels",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "3",
             "title" : "(1) The Lord Chancellor must appoint a panel of persons...",
             "ref" : "schedule-13-paragraph-3",
+            "id" : "schedule-13-paragraph-3",
+            "href" : "schedule/13/paragraph/3",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -25436,12 +30356,16 @@
           "number" : null,
           "title" : " Terms of office etc",
           "ref" : "schedule-13-part-II-crossheading-terms-of-office-etc",
+          "id" : "schedule-13-part-II-crossheading-terms-of-office-etc",
+          "href" : "schedule/13/part/II/crossheading/terms-of-office-etc",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "4",
             "title" : "(1) Subject to the provisions of this Schedule, each member...",
             "ref" : "schedule-13-paragraph-4",
+            "id" : "schedule-13-paragraph-4",
+            "href" : "schedule/13/paragraph/4",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -25449,12 +30373,16 @@
           "number" : null,
           "title" : " Remuneration and expenses",
           "ref" : "schedule-13-part-II-crossheading-remuneration-and-expenses",
+          "id" : "schedule-13-part-II-crossheading-remuneration-and-expenses",
+          "href" : "schedule/13/part/II/crossheading/remuneration-and-expenses",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "5",
             "title" : "The Lord Chancellor may pay to any person, in respect...",
             "ref" : "schedule-13-paragraph-5",
+            "id" : "schedule-13-paragraph-5",
+            "href" : "schedule/13/paragraph/5",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -25462,12 +30390,16 @@
           "number" : null,
           "title" : " Staff",
           "ref" : "schedule-13-part-II-crossheading-staff",
+          "id" : "schedule-13-part-II-crossheading-staff",
+          "href" : "schedule/13/part/II/crossheading/staff",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "6",
             "title" : "(1) The Lord Chancellor may appoint such staff for the...",
             "ref" : "schedule-13-paragraph-6",
+            "id" : "schedule-13-paragraph-6",
+            "href" : "schedule/13/paragraph/6",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -25476,12 +30408,16 @@
         "number" : "Part III",
         "title" : " Constitution of Tribunal",
         "ref" : "schedule-13-part-III",
+        "id" : "schedule-13-part-III",
+        "href" : "schedule/13/part/III",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "7",
           "title" : "(1) On a reference to the Tribunal, the persons to...",
           "ref" : "schedule-13-paragraph-7",
+          "id" : "schedule-13-paragraph-7",
+          "href" : "schedule/13/paragraph/7",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -25489,30 +30425,40 @@
         "number" : "Part IV",
         "title" : " Tribunal Procedure",
         "ref" : "schedule-13-part-IV",
+        "id" : "schedule-13-part-IV",
+        "href" : "schedule/13/part/IV",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "8",
           "title" : "For the purpose of dealing with references, or any matter...",
           "ref" : "schedule-13-paragraph-8",
+          "id" : "schedule-13-paragraph-8",
+          "href" : "schedule/13/paragraph/8",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "9",
           "title" : "Rules made by the Lord Chancellor under section 132 may,...",
           "ref" : "schedule-13-paragraph-9",
+          "id" : "schedule-13-paragraph-9",
+          "href" : "schedule/13/paragraph/9",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "pblock",
           "number" : null,
           "title" : " Practice directions",
           "ref" : "schedule-13-part-IV-crossheading-practice-directions",
+          "id" : "schedule-13-part-IV-crossheading-practice-directions",
+          "href" : "schedule/13/part/IV/crossheading/practice-directions",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "10",
             "title" : "The President of the Tribunal may give directions as to...",
             "ref" : "schedule-13-paragraph-10",
+            "id" : "schedule-13-paragraph-10",
+            "href" : "schedule/13/paragraph/10",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -25520,12 +30466,16 @@
           "number" : null,
           "title" : " Evidence",
           "ref" : "schedule-13-part-IV-crossheading-evidence",
+          "id" : "schedule-13-part-IV-crossheading-evidence",
+          "href" : "schedule/13/part/IV/crossheading/evidence",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "11",
             "title" : "(1) The Tribunal may by summons require any person to...",
             "ref" : "schedule-13-paragraph-11",
+            "id" : "schedule-13-paragraph-11",
+            "href" : "schedule/13/paragraph/11",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -25533,12 +30483,16 @@
           "number" : null,
           "title" : " Decisions of Tribunal",
           "ref" : "schedule-13-part-IV-crossheading-decisions-of-tribunal",
+          "id" : "schedule-13-part-IV-crossheading-decisions-of-tribunal",
+          "href" : "schedule/13/part/IV/crossheading/decisions-of-tribunal",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "12",
             "title" : "(1) A decision of the Tribunal may be taken by...",
             "ref" : "schedule-13-paragraph-12",
+            "id" : "schedule-13-paragraph-12",
+            "href" : "schedule/13/paragraph/12",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -25546,12 +30500,16 @@
           "number" : null,
           "title" : " Costs",
           "ref" : "schedule-13-part-IV-crossheading-costs",
+          "id" : "schedule-13-part-IV-crossheading-costs",
+          "href" : "schedule/13/part/IV/crossheading/costs",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "13",
             "title" : "(1) If the Tribunal considers that a party to any...",
             "ref" : "schedule-13-paragraph-13",
+            "id" : "schedule-13-paragraph-13",
+            "href" : "schedule/13/paragraph/13",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -25561,18 +30519,24 @@
       "number" : "SCHEDULE 14",
       "title" : " Role of the Competition Commission",
       "ref" : "schedule-14",
+      "id" : "schedule-14",
+      "href" : "schedule/14",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : " Provision of information by Treasury",
         "ref" : "schedule-14-crossheading-provision-of-information-by-treasury",
+        "id" : "schedule-14-crossheading-provision-of-information-by-treasury",
+        "href" : "schedule/14/crossheading/provision-of-information-by-treasury",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "1",
           "title" : " Role of the Competition Commission",
           "ref" : "schedule-14-paragraph-1",
+          "id" : "schedule-14-paragraph-1",
+          "href" : "schedule/14/paragraph/1",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -25580,61 +30544,81 @@
         "number" : null,
         "title" : " Consideration of matters arising on a report",
         "ref" : "schedule-14-crossheading-consideration-of-matters-arising-on-a-report",
+        "id" : "schedule-14-crossheading-consideration-of-matters-arising-on-a-report",
+        "href" : "schedule/14/crossheading/consideration-of-matters-arising-on-a-report",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "2",
           "title" : " Role of the Competition Commission",
           "ref" : "schedule-14-paragraph-2",
+          "id" : "schedule-14-paragraph-2",
+          "href" : "schedule/14/paragraph/2",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
         "name" : "item",
         "number" : "",
         "title" : "Investigations under section 162: application of Enterprise Act 2002 ",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ ]
       }, {
         "name" : "item",
         "number" : "2A",
         "title" : " Role of the Competition Commission",
         "ref" : "schedule-14-paragraph-2A",
+        "id" : "schedule-14-paragraph-2A",
+        "href" : "schedule/14/paragraph/2A",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "",
         "title" : "Section 162: modification of Schedule 7 to the Competition Act...",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ ]
       }, {
         "name" : "item",
         "number" : "2B",
         "title" : " Role of the Competition Commission",
         "ref" : "schedule-14-paragraph-2B",
+        "id" : "schedule-14-paragraph-2B",
+        "href" : "schedule/14/paragraph/2B",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "",
         "title" : "Reports under section 162: further provision ",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ ]
       }, {
         "name" : "item",
         "number" : "2C",
         "title" : " Role of the Competition Commission",
         "ref" : "schedule-14-paragraph-2C",
+        "id" : "schedule-14-paragraph-2C",
+        "href" : "schedule/14/paragraph/2C",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "pblock",
         "number" : null,
         "title" : " Applied provisions",
         "ref" : "schedule-14-crossheading-applied-provisions",
+        "id" : "schedule-14-crossheading-applied-provisions",
+        "href" : "schedule/14/crossheading/applied-provisions",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "3",
           "title" : " Role of the Competition Commission",
           "ref" : "schedule-14-paragraph-3",
+          "id" : "schedule-14-paragraph-3",
+          "href" : "schedule/14/paragraph/3",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -25642,12 +30626,16 @@
         "number" : null,
         "title" : " Publication of reports",
         "ref" : "schedule-14-crossheading-publication-of-reports",
+        "id" : "schedule-14-crossheading-publication-of-reports",
+        "href" : "schedule/14/crossheading/publication-of-reports",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "4",
           "title" : " Role of the Competition Commission",
           "ref" : "schedule-14-paragraph-4",
+          "id" : "schedule-14-paragraph-4",
+          "href" : "schedule/14/paragraph/4",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -25656,24 +30644,32 @@
       "number" : "SCHEDULE 15",
       "title" : " Information and Investigations: Connected Persons",
       "ref" : "schedule-15",
+      "id" : "schedule-15",
+      "href" : "schedule/15",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "part",
         "number" : "Part I",
         "title" : " Rules for Specific Bodies",
         "ref" : "schedule-15-part-I",
+        "id" : "schedule-15-part-I",
+        "href" : "schedule/15/part/I",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : " Corporate bodies",
           "ref" : "schedule-15-part-I-crossheading-corporate-bodies",
+          "id" : "schedule-15-part-I-crossheading-corporate-bodies",
+          "href" : "schedule/15/part/I/crossheading/corporate-bodies",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "1",
             "title" : "If the authorised person (“BC”) is a body corporate, a...",
             "ref" : "schedule-15-paragraph-1",
+            "id" : "schedule-15-paragraph-1",
+            "href" : "schedule/15/paragraph/1",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -25681,12 +30677,16 @@
           "number" : null,
           "title" : " Partnerships",
           "ref" : "schedule-15-part-I-crossheading-partnerships",
+          "id" : "schedule-15-part-I-crossheading-partnerships",
+          "href" : "schedule/15/part/I/crossheading/partnerships",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "2",
             "title" : "If the authorised person (“PP”) is a partnership, a person...",
             "ref" : "schedule-15-paragraph-2",
+            "id" : "schedule-15-paragraph-2",
+            "href" : "schedule/15/paragraph/2",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -25694,12 +30694,16 @@
           "number" : null,
           "title" : " Unincorporated associations",
           "ref" : "schedule-15-part-I-crossheading-unincorporated-associations",
+          "id" : "schedule-15-part-I-crossheading-unincorporated-associations",
+          "href" : "schedule/15/part/I/crossheading/unincorporated-associations",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "3",
             "title" : "If the authorised person (“UA”) is an unincorporated association of...",
             "ref" : "schedule-15-paragraph-3",
+            "id" : "schedule-15-paragraph-3",
+            "href" : "schedule/15/paragraph/3",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -25707,12 +30711,16 @@
           "number" : null,
           "title" : " Friendly societies",
           "ref" : "schedule-15-part-I-crossheading-friendly-societies",
+          "id" : "schedule-15-part-I-crossheading-friendly-societies",
+          "href" : "schedule/15/part/I/crossheading/friendly-societies",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "4",
             "title" : "(1) If the authorised person (“FS”) is a friendly society,...",
             "ref" : "schedule-15-paragraph-4",
+            "id" : "schedule-15-paragraph-4",
+            "href" : "schedule/15/paragraph/4",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -25720,12 +30728,16 @@
           "number" : null,
           "title" : " Building societies",
           "ref" : "schedule-15-part-I-crossheading-building-societies",
+          "id" : "schedule-15-part-I-crossheading-building-societies",
+          "href" : "schedule/15/part/I/crossheading/building-societies",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "5",
             "title" : "(1) If the authorised person (“BS”) is a building society,...",
             "ref" : "schedule-15-paragraph-5",
+            "id" : "schedule-15-paragraph-5",
+            "href" : "schedule/15/paragraph/5",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -25733,12 +30745,16 @@
           "number" : null,
           "title" : " Individuals",
           "ref" : "schedule-15-part-I-crossheading-individuals",
+          "id" : "schedule-15-part-I-crossheading-individuals",
+          "href" : "schedule/15/part/I/crossheading/individuals",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "6",
             "title" : "If the authorised person (“IP”) is an individual, a person...",
             "ref" : "schedule-15-paragraph-6",
+            "id" : "schedule-15-paragraph-6",
+            "href" : "schedule/15/paragraph/6",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -25746,12 +30762,16 @@
           "number" : null,
           "title" : " Application to sections 171 and 172",
           "ref" : "schedule-15-part-I-crossheading-application-to-sections-171-and-172",
+          "id" : "schedule-15-part-I-crossheading-application-to-sections-171-and-172",
+          "href" : "schedule/15/part/I/crossheading/application-to-sections-171-and-172",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "7",
             "title" : "For the purposes of sections 171 and 172, if the...",
             "ref" : "schedule-15-paragraph-7",
+            "id" : "schedule-15-paragraph-7",
+            "href" : "schedule/15/paragraph/7",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -25760,12 +30780,16 @@
         "number" : "Part II",
         "title" : " Additional Rules",
         "ref" : "schedule-15-part-II",
+        "id" : "schedule-15-part-II",
+        "href" : "schedule/15/part/II",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "8",
           "title" : "A person who is, or at the relevant time was,...",
           "ref" : "schedule-15-paragraph-8",
+          "id" : "schedule-15-paragraph-8",
+          "href" : "schedule/15/paragraph/8",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -25774,18 +30798,24 @@
       "number" : "SCHEDULE 16",
       "title" : " Prohibitions and Restrictions imposed by  OFFICE OF FAIR TRADING",
       "ref" : "schedule-16",
+      "id" : "schedule-16",
+      "href" : "schedule/16",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : " Preliminary",
         "ref" : "schedule-16-crossheading-preliminary",
+        "id" : "schedule-16-crossheading-preliminary",
+        "href" : "schedule/16/crossheading/preliminary",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "1",
           "title" : "In this Schedule— “appeal period” has the same meaning as...",
           "ref" : "schedule-16-paragraph-1",
+          "id" : "schedule-16-paragraph-1",
+          "href" : "schedule/16/paragraph/1",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -25793,12 +30823,16 @@
         "number" : null,
         "title" : " Notice of prohibition or restriction",
         "ref" : "schedule-16-crossheading-notice-of-prohibition-or-restriction",
+        "id" : "schedule-16-crossheading-notice-of-prohibition-or-restriction",
+        "href" : "schedule/16/crossheading/notice-of-prohibition-or-restriction",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "2",
           "title" : "(1) This paragraph applies if the OFT proposes, in relation...",
           "ref" : "schedule-16-paragraph-2",
+          "id" : "schedule-16-paragraph-2",
+          "href" : "schedule/16/paragraph/2",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -25806,12 +30840,16 @@
         "number" : null,
         "title" : " Application to revoke prohibition or restriction",
         "ref" : "schedule-16-crossheading-application-to-revoke-prohibition-or-restriction",
+        "id" : "schedule-16-crossheading-application-to-revoke-prohibition-or-restriction",
+        "href" : "schedule/16/crossheading/application-to-revoke-prohibition-or-restriction",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "3",
           "title" : "(1) This paragraph applies if the OFT proposes to refuse...",
           "ref" : "schedule-16-paragraph-3",
+          "id" : "schedule-16-paragraph-3",
+          "href" : "schedule/16/paragraph/3",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -25819,12 +30857,16 @@
         "number" : null,
         "title" : " Representations to  Office of Fair TradingOFT",
         "ref" : "schedule-16-crossheading-representations-to-director",
+        "id" : "schedule-16-crossheading-representations-to-director",
+        "href" : "schedule/16/crossheading/representations-to-director",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "4",
           "title" : "(1) If this paragraph applies to an invitation to submit...",
           "ref" : "schedule-16-paragraph-4",
+          "id" : "schedule-16-paragraph-4",
+          "href" : "schedule/16/paragraph/4",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -25832,12 +30874,16 @@
         "number" : null,
         "title" : " Appeals",
         "ref" : "schedule-16-crossheading-appeals",
+        "id" : "schedule-16-crossheading-appeals",
+        "href" : "schedule/16/crossheading/appeals",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "5",
           "title" : "Section 41 of the Consumer Credit Act 1974 (appeals to...",
           "ref" : "schedule-16-paragraph-5",
+          "id" : "schedule-16-paragraph-5",
+          "href" : "schedule/16/paragraph/5",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -25846,24 +30892,32 @@
       "number" : "SCHEDULE 17",
       "title" : " The Ombudsman Scheme",
       "ref" : "schedule-17",
+      "id" : "schedule-17",
+      "href" : "schedule/17",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "part",
         "number" : "Part I",
         "title" : " General",
         "ref" : "schedule-17-part-I",
+        "id" : "schedule-17-part-I",
+        "href" : "schedule/17/part/I",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : " Interpretation",
           "ref" : "schedule-17-part-I-crossheading-interpretation",
+          "id" : "schedule-17-part-I-crossheading-interpretation",
+          "href" : "schedule/17/part/I/crossheading/interpretation",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "1",
             "title" : "In this Schedule— “ ADR Directive” means Directive 2013/11/ EU...",
             "ref" : "schedule-17-paragraph-1",
+            "id" : "schedule-17-paragraph-1",
+            "href" : "schedule/17/paragraph/1",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -25872,18 +30926,24 @@
         "number" : "Part II",
         "title" : " The Scheme Operator",
         "ref" : "schedule-17-part-II",
+        "id" : "schedule-17-part-II",
+        "href" : "schedule/17/part/II",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : " Duty of FCA",
           "ref" : "schedule-17-part-II-crossheading-establishment-by-the-authority",
+          "id" : "schedule-17-part-II-crossheading-establishment-by-the-authority",
+          "href" : "schedule/17/part/II/crossheading/establishment-by-the-authority",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "2",
             "title" : "(1) The FCA must take such steps as are necessary...",
             "ref" : "schedule-17-paragraph-2",
+            "id" : "schedule-17-paragraph-2",
+            "href" : "schedule/17/paragraph/2",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -25891,12 +30951,16 @@
           "number" : null,
           "title" : " Constitution",
           "ref" : "schedule-17-part-II-crossheading-constitution",
+          "id" : "schedule-17-part-II-crossheading-constitution",
+          "href" : "schedule/17/part/II/crossheading/constitution",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "3",
             "title" : "(1) The constitution of the scheme operator must provide for...",
             "ref" : "schedule-17-paragraph-3",
+            "id" : "schedule-17-paragraph-3",
+            "href" : "schedule/17/paragraph/3",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -25904,12 +30968,16 @@
           "number" : null,
           "title" : "Relationship with FCA",
           "ref" : "schedule-17-part-II-crossheading-relationship-with-fca",
+          "id" : "schedule-17-part-II-crossheading-relationship-with-fca",
+          "href" : "schedule/17/part/II/crossheading/relationship-with-fca",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "3A",
             "title" : "(1) The scheme operator and the FCA must each take...",
             "ref" : "schedule-17-paragraph-3A",
+            "id" : "schedule-17-paragraph-3A",
+            "href" : "schedule/17/paragraph/3A",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -25917,12 +30985,16 @@
           "number" : null,
           "title" : " The panel of ombudsmen",
           "ref" : "schedule-17-part-II-crossheading-the-panel-of-ombudsmen",
+          "id" : "schedule-17-part-II-crossheading-the-panel-of-ombudsmen",
+          "href" : "schedule/17/part/II/crossheading/the-panel-of-ombudsmen",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "4",
             "title" : "(1) The scheme operator must appoint and maintain a panel...",
             "ref" : "schedule-17-paragraph-4",
+            "id" : "schedule-17-paragraph-4",
+            "href" : "schedule/17/paragraph/4",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -25930,12 +31002,16 @@
           "number" : null,
           "title" : " The Chief Ombudsman",
           "ref" : "schedule-17-part-II-crossheading-the-chief-ombudsman",
+          "id" : "schedule-17-part-II-crossheading-the-chief-ombudsman",
+          "href" : "schedule/17/part/II/crossheading/the-chief-ombudsman",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "5",
             "title" : "(1) The scheme operator must appoint one member of the...",
             "ref" : "schedule-17-paragraph-5",
+            "id" : "schedule-17-paragraph-5",
+            "href" : "schedule/17/paragraph/5",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -25943,12 +31019,16 @@
           "number" : null,
           "title" : " Status",
           "ref" : "schedule-17-part-II-crossheading-status",
+          "id" : "schedule-17-part-II-crossheading-status",
+          "href" : "schedule/17/part/II/crossheading/status",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "6",
             "title" : "(1) The scheme operator is not to be regarded as...",
             "ref" : "schedule-17-paragraph-6",
+            "id" : "schedule-17-paragraph-6",
+            "href" : "schedule/17/paragraph/6",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -25956,12 +31036,16 @@
           "number" : null,
           "title" : " Annual reports",
           "ref" : "schedule-17-part-II-crossheading-annual-reports",
+          "id" : "schedule-17-part-II-crossheading-annual-reports",
+          "href" : "schedule/17/part/II/crossheading/annual-reports",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "7",
             "title" : "(1) At least once a year— (a) the scheme operator...",
             "ref" : "schedule-17-paragraph-7",
+            "id" : "schedule-17-paragraph-7",
+            "href" : "schedule/17/paragraph/7",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -25969,12 +31053,16 @@
           "number" : null,
           "title" : "Audit of accounts",
           "ref" : "schedule-17-part-II-crossheading-audit-of-accounts",
+          "id" : "schedule-17-part-II-crossheading-audit-of-accounts",
+          "href" : "schedule/17/part/II/crossheading/audit-of-accounts",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "7A",
             "title" : "(1) The scheme operator must send a copy of its...",
             "ref" : "schedule-17-paragraph-7A",
+            "id" : "schedule-17-paragraph-7A",
+            "href" : "schedule/17/paragraph/7A",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -25982,12 +31070,16 @@
           "number" : null,
           "title" : " Information, advice and guidance",
           "ref" : "schedule-17-part-II-crossheading-guidance",
+          "id" : "schedule-17-part-II-crossheading-guidance",
+          "href" : "schedule/17/part/II/crossheading/guidance",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "8",
             "title" : "The scheme operator may publish such information, guidance or advice...",
             "ref" : "schedule-17-paragraph-8",
+            "id" : "schedule-17-paragraph-8",
+            "href" : "schedule/17/paragraph/8",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -25995,12 +31087,16 @@
           "number" : null,
           "title" : " Budget",
           "ref" : "schedule-17-part-II-crossheading-budget",
+          "id" : "schedule-17-part-II-crossheading-budget",
+          "href" : "schedule/17/part/II/crossheading/budget",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "9",
             "title" : "(1) The scheme operator must, before the start of each...",
             "ref" : "schedule-17-paragraph-9",
+            "id" : "schedule-17-paragraph-9",
+            "href" : "schedule/17/paragraph/9",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26008,12 +31104,16 @@
           "number" : null,
           "title" : "Annual plan",
           "ref" : "schedule-17-part-II-crossheading-annual-plan",
+          "id" : "schedule-17-part-II-crossheading-annual-plan",
+          "href" : "schedule/17/part/II/crossheading/annual-plan",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "9A",
             "title" : "(1) The scheme operator must in respect of each of...",
             "ref" : "schedule-17-paragraph-9A",
+            "id" : "schedule-17-paragraph-9A",
+            "href" : "schedule/17/paragraph/9A",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26021,12 +31121,16 @@
           "number" : null,
           "title" : " Exemption from liability in damages",
           "ref" : "schedule-17-part-II-crossheading-exemption-from-liability-in-damages",
+          "id" : "schedule-17-part-II-crossheading-exemption-from-liability-in-damages",
+          "href" : "schedule/17/part/II/crossheading/exemption-from-liability-in-damages",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "10",
             "title" : "(1) No person is to be liable in damages for...",
             "ref" : "schedule-17-paragraph-10",
+            "id" : "schedule-17-paragraph-10",
+            "href" : "schedule/17/paragraph/10",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26034,12 +31138,16 @@
           "number" : null,
           "title" : " Privilege",
           "ref" : "schedule-17-part-II-crossheading-privilege",
+          "id" : "schedule-17-part-II-crossheading-privilege",
+          "href" : "schedule/17/part/II/crossheading/privilege",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "11",
             "title" : "For the purposes of the law relating to defamation, proceedings...",
             "ref" : "schedule-17-paragraph-11",
+            "id" : "schedule-17-paragraph-11",
+            "href" : "schedule/17/paragraph/11",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -26048,18 +31156,24 @@
         "number" : "Part III",
         "title" : " The Compulsory Jurisdiction",
         "ref" : "schedule-17-part-III",
+        "id" : "schedule-17-part-III",
+        "href" : "schedule/17/part/III",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : " Introduction",
           "ref" : "schedule-17-part-III-crossheading-introduction",
+          "id" : "schedule-17-part-III-crossheading-introduction",
+          "href" : "schedule/17/part/III/crossheading/introduction",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "12",
             "title" : "This Part of this Schedule applies only in relation to...",
             "ref" : "schedule-17-paragraph-12",
+            "id" : "schedule-17-paragraph-12",
+            "href" : "schedule/17/paragraph/12",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26067,12 +31181,16 @@
           "number" : null,
           "title" : "  FCA's  ... rules",
           "ref" : "schedule-17-part-III-crossheading-authoritys-procedural-rules",
+          "id" : "schedule-17-part-III-crossheading-authoritys-procedural-rules",
+          "href" : "schedule/17/part/III/crossheading/authoritys-procedural-rules",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "13",
             "title" : "(1) The FCA must make rules providing that a complaint...",
             "ref" : "schedule-17-paragraph-13",
+            "id" : "schedule-17-paragraph-13",
+            "href" : "schedule/17/paragraph/13",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26080,12 +31198,16 @@
           "number" : null,
           "title" : " The scheme operator’s rules",
           "ref" : "schedule-17-part-III-crossheading-the-scheme-operators-rules",
+          "id" : "schedule-17-part-III-crossheading-the-scheme-operators-rules",
+          "href" : "schedule/17/part/III/crossheading/the-scheme-operators-rules",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "14",
             "title" : "(1) The scheme operator must make rules, to be known...",
             "ref" : "schedule-17-paragraph-14",
+            "id" : "schedule-17-paragraph-14",
+            "href" : "schedule/17/paragraph/14",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26093,12 +31215,16 @@
           "number" : null,
           "title" : " Fees",
           "ref" : "schedule-17-part-III-crossheading-fees",
+          "id" : "schedule-17-part-III-crossheading-fees",
+          "href" : "schedule/17/part/III/crossheading/fees",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "15",
             "title" : "(1) Scheme rules may require a respondent or other persons...",
             "ref" : "schedule-17-paragraph-15",
+            "id" : "schedule-17-paragraph-15",
+            "href" : "schedule/17/paragraph/15",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26106,12 +31232,16 @@
           "number" : null,
           "title" : " Enforcement of money awards",
           "ref" : "schedule-17-part-III-crossheading-enforcement-of-money-awards",
+          "id" : "schedule-17-part-III-crossheading-enforcement-of-money-awards",
+          "href" : "schedule/17/part/III/crossheading/enforcement-of-money-awards",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "16",
             "title" : "A money award, including interest, which has been registered in...",
             "ref" : "schedule-17-paragraph-16",
+            "id" : "schedule-17-paragraph-16",
+            "href" : "schedule/17/paragraph/16",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -26120,18 +31250,24 @@
         "number" : "Part 3A",
         "title" : "The consumer credit jurisdiction",
         "ref" : "schedule-17-part-3A",
+        "id" : "schedule-17-part-3A",
+        "href" : "schedule/17/part/3A",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Introduction",
           "ref" : "schedule-17-part-3A-crossheading-introduction",
+          "id" : "schedule-17-part-3A-crossheading-introduction",
+          "href" : "schedule/17/part/3A/crossheading/introduction",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "16A",
             "title" : "This Part of this Schedule applies only in relation to...",
             "ref" : "schedule-17-paragraph-16A",
+            "id" : "schedule-17-paragraph-16A",
+            "href" : "schedule/17/paragraph/16A",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26139,12 +31275,16 @@
           "number" : null,
           "title" : "Procedure for complaints etc.",
           "ref" : "schedule-17-part-3A-crossheading-procedure-for-complaints-etc",
+          "id" : "schedule-17-part-3A-crossheading-procedure-for-complaints-etc",
+          "href" : "schedule/17/part/3A/crossheading/procedure-for-complaints-etc",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "16B",
             "title" : "(1) Consumer credit rules— (a) must provide that a complaint...",
             "ref" : "schedule-17-paragraph-16B",
+            "id" : "schedule-17-paragraph-16B",
+            "href" : "schedule/17/paragraph/16B",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26152,12 +31292,16 @@
           "number" : null,
           "title" : "Fees",
           "ref" : "schedule-17-part-3A-crossheading-fees",
+          "id" : "schedule-17-part-3A-crossheading-fees",
+          "href" : "schedule/17/part/3A/crossheading/fees",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "16C",
             "title" : "(1) Consumer credit rules may require a respondent to pay...",
             "ref" : "schedule-17-paragraph-16C",
+            "id" : "schedule-17-paragraph-16C",
+            "href" : "schedule/17/paragraph/16C",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26165,12 +31309,16 @@
           "number" : null,
           "title" : "Enforcement of money awards",
           "ref" : "schedule-17-part-3A-crossheading-enforcement-of-money-awards",
+          "id" : "schedule-17-part-3A-crossheading-enforcement-of-money-awards",
+          "href" : "schedule/17/part/3A/crossheading/enforcement-of-money-awards",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "16D",
             "title" : "A money award, including interest, which has been registered in...",
             "ref" : "schedule-17-paragraph-16D",
+            "id" : "schedule-17-paragraph-16D",
+            "href" : "schedule/17/paragraph/16D",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26178,12 +31326,16 @@
           "number" : null,
           "title" : "Procedure for consumer credit rules",
           "ref" : "schedule-17-part-3A-crossheading-procedure-for-consumer-credit-rules",
+          "id" : "schedule-17-part-3A-crossheading-procedure-for-consumer-credit-rules",
+          "href" : "schedule/17/part/3A/crossheading/procedure-for-consumer-credit-rules",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "16E",
             "title" : "(1) If the scheme operator makes any consumer credit rules,...",
             "ref" : "schedule-17-paragraph-16E",
+            "id" : "schedule-17-paragraph-16E",
+            "href" : "schedule/17/paragraph/16E",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26191,12 +31343,16 @@
           "number" : null,
           "title" : "Verification of consumer credit rules",
           "ref" : "schedule-17-part-3A-crossheading-verification-of-consumer-credit-rules",
+          "id" : "schedule-17-part-3A-crossheading-verification-of-consumer-credit-rules",
+          "href" : "schedule/17/part/3A/crossheading/verification-of-consumer-credit-rules",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "16F",
             "title" : "(1) The production of a printed copy of consumer credit...",
             "ref" : "schedule-17-paragraph-16F",
+            "id" : "schedule-17-paragraph-16F",
+            "href" : "schedule/17/paragraph/16F",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26204,12 +31360,16 @@
           "number" : null,
           "title" : "Consultation",
           "ref" : "schedule-17-part-3A-crossheading-consultation",
+          "id" : "schedule-17-part-3A-crossheading-consultation",
+          "href" : "schedule/17/part/3A/crossheading/consultation",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "16G",
             "title" : "(1) If the scheme operator proposes to make consumer credit...",
             "ref" : "schedule-17-paragraph-16G",
+            "id" : "schedule-17-paragraph-16G",
+            "href" : "schedule/17/paragraph/16G",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -26218,18 +31378,24 @@
         "number" : "Part IV",
         "title" : " The Voluntary Jurisdiction",
         "ref" : "schedule-17-part-IV",
+        "id" : "schedule-17-part-IV",
+        "href" : "schedule/17/part/IV",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : " Introduction",
           "ref" : "schedule-17-part-IV-crossheading-introduction",
+          "id" : "schedule-17-part-IV-crossheading-introduction",
+          "href" : "schedule/17/part/IV/crossheading/introduction",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "17",
             "title" : "This Part of this Schedule applies only in relation to...",
             "ref" : "schedule-17-paragraph-17",
+            "id" : "schedule-17-paragraph-17",
+            "href" : "schedule/17/paragraph/17",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26237,12 +31403,16 @@
           "number" : null,
           "title" : " Terms of reference to the scheme",
           "ref" : "schedule-17-part-IV-crossheading-terms-of-reference-to-the-scheme",
+          "id" : "schedule-17-part-IV-crossheading-terms-of-reference-to-the-scheme",
+          "href" : "schedule/17/part/IV/crossheading/terms-of-reference-to-the-scheme",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "18",
             "title" : "(1) Complaints are to be dealt with and determined under...",
             "ref" : "schedule-17-paragraph-18",
+            "id" : "schedule-17-paragraph-18",
+            "href" : "schedule/17/paragraph/18",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26250,12 +31420,16 @@
           "number" : null,
           "title" : " Delegation by and to other schemes",
           "ref" : "schedule-17-part-IV-crossheading-delegation-by-and-to-other-schemes",
+          "id" : "schedule-17-part-IV-crossheading-delegation-by-and-to-other-schemes",
+          "href" : "schedule/17/part/IV/crossheading/delegation-by-and-to-other-schemes",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "19",
             "title" : "(1) The scheme operator may make arrangements with a relevant...",
             "ref" : "schedule-17-paragraph-19",
+            "id" : "schedule-17-paragraph-19",
+            "href" : "schedule/17/paragraph/19",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26263,12 +31437,16 @@
           "number" : null,
           "title" : " Voluntary jurisdiction rules: procedure",
           "ref" : "schedule-17-part-IV-crossheading-voluntary-jurisdiction-rules-procedure",
+          "id" : "schedule-17-part-IV-crossheading-voluntary-jurisdiction-rules-procedure",
+          "href" : "schedule/17/part/IV/crossheading/voluntary-jurisdiction-rules-procedure",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "20",
             "title" : "(1) If the scheme operator makes voluntary jurisdiction rules, it...",
             "ref" : "schedule-17-paragraph-20",
+            "id" : "schedule-17-paragraph-20",
+            "href" : "schedule/17/paragraph/20",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26276,12 +31454,16 @@
           "number" : null,
           "title" : " Verification of the rules",
           "ref" : "schedule-17-part-IV-crossheading-verification-of-the-rules",
+          "id" : "schedule-17-part-IV-crossheading-verification-of-the-rules",
+          "href" : "schedule/17/part/IV/crossheading/verification-of-the-rules",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "21",
             "title" : "(1) The production of a printed copy of voluntary jurisdiction...",
             "ref" : "schedule-17-paragraph-21",
+            "id" : "schedule-17-paragraph-21",
+            "href" : "schedule/17/paragraph/21",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26289,12 +31471,16 @@
           "number" : null,
           "title" : " Consultation",
           "ref" : "schedule-17-part-IV-crossheading-consultation",
+          "id" : "schedule-17-part-IV-crossheading-consultation",
+          "href" : "schedule/17/part/IV/crossheading/consultation",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "22",
             "title" : "(1) If the scheme operator proposes to make voluntary jurisdiction...",
             "ref" : "schedule-17-paragraph-22",
+            "id" : "schedule-17-paragraph-22",
+            "href" : "schedule/17/paragraph/22",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -26304,60 +31490,80 @@
       "number" : "SCHEDULE 17A",
       "title" : "Further provision in relation to exercise of Part 18 functions , or other FMI functions, by Bank of England",
       "ref" : "schedule-17A",
+      "id" : "schedule-17A",
+      "href" : "schedule/17A",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "part",
         "number" : "Part 1",
         "title" : "Co-operation between appropriate regulators",
         "ref" : "schedule-17A-part-1",
+        "id" : "schedule-17A-part-1",
+        "href" : "schedule/17A/part/1",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Memorandum of understanding between appropriate regulators and PRA",
           "ref" : "schedule-17A-part-1-crossheading-memorandum-of-understanding-between-appropriate-regulators-and-pra",
+          "id" : "schedule-17A-part-1-crossheading-memorandum-of-understanding-between-appropriate-regulators-and-pra",
+          "href" : "schedule/17A/part/1/crossheading/memorandum-of-understanding-between-appropriate-regulators-and-pra",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "1",
             "title" : "(1) The appropriate regulators must prepare and maintain a memorandum...",
             "ref" : "schedule-17A-paragraph-1",
+            "id" : "schedule-17A-paragraph-1",
+            "href" : "schedule/17A/paragraph/1",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "2",
             "title" : "(1) The FCA and the PRA must prepare and maintain...",
             "ref" : "schedule-17A-paragraph-2",
+            "id" : "schedule-17A-paragraph-2",
+            "href" : "schedule/17A/paragraph/2",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "3",
             "title" : "The parties to a memorandum under paragraph 1 or 2...",
             "ref" : "schedule-17A-paragraph-3",
+            "id" : "schedule-17A-paragraph-3",
+            "href" : "schedule/17A/paragraph/3",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "4",
             "title" : "The parties to a memorandum under paragraph 1 or 2...",
             "ref" : "schedule-17A-paragraph-4",
+            "id" : "schedule-17A-paragraph-4",
+            "href" : "schedule/17A/paragraph/4",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "5",
             "title" : "The Treasury must lay before Parliament a copy of any...",
             "ref" : "schedule-17A-paragraph-5",
+            "id" : "schedule-17A-paragraph-5",
+            "href" : "schedule/17A/paragraph/5",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "6",
             "title" : "The parties to a memorandum under paragraph 1 or 2...",
             "ref" : "schedule-17A-paragraph-6",
+            "id" : "schedule-17A-paragraph-6",
+            "href" : "schedule/17A/paragraph/6",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "6A",
             "title" : "(1) If the Bank makes a Part 18 prohibition order...",
             "ref" : "schedule-17A-paragraph-6A",
+            "id" : "schedule-17A-paragraph-6A",
+            "href" : "schedule/17A/paragraph/6A",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26365,18 +31571,24 @@
           "number" : null,
           "title" : "Notification by FCA of action in relation to recognised clearing houses",
           "ref" : "schedule-17A-part-1-crossheading-notification-by-fca-of-action-in-relation-to-recognised-clearing-houses",
+          "id" : "schedule-17A-part-1-crossheading-notification-by-fca-of-action-in-relation-to-recognised-clearing-houses",
+          "href" : "schedule/17A/part/1/crossheading/notification-by-fca-of-action-in-relation-to-recognised-clearing-houses",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "7",
             "title" : "The FCA must notify the Bank of England of any...",
             "ref" : "schedule-17A-paragraph-7",
+            "id" : "schedule-17A-paragraph-7",
+            "href" : "schedule/17A/paragraph/7",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "8",
             "title" : "The FCA must notify the Bank of England of any...",
             "ref" : "schedule-17A-paragraph-8",
+            "id" : "schedule-17A-paragraph-8",
+            "href" : "schedule/17A/paragraph/8",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -26385,18 +31597,24 @@
         "number" : "Part 2",
         "title" : "Application of provisions of this Act in relation to Bank of England",
         "ref" : "schedule-17A-part-2",
+        "id" : "schedule-17A-part-2",
+        "href" : "schedule/17A/part/2",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Introduction",
           "ref" : "schedule-17A-part-2-crossheading-introduction",
+          "id" : "schedule-17A-part-2-crossheading-introduction",
+          "href" : "schedule/17A/part/2/crossheading/introduction",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "9",
             "title" : "(1) The provisions of this Act mentioned in this Part...",
             "ref" : "schedule-17A-paragraph-9",
+            "id" : "schedule-17A-paragraph-9",
+            "href" : "schedule/17A/paragraph/9",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26404,12 +31622,16 @@
           "number" : null,
           "title" : "Public consultations",
           "ref" : "schedule-17A-part-2-crossheading-public-consultations",
+          "id" : "schedule-17A-part-2-crossheading-public-consultations",
+          "href" : "schedule/17A/part/2/crossheading/public-consultations",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "9A",
             "title" : "(1) Section 1RB (requirements in connection with public consultations) applies...",
             "ref" : "schedule-17A-paragraph-9A",
+            "id" : "schedule-17A-paragraph-9A",
+            "href" : "schedule/17A/paragraph/9A",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26417,12 +31639,16 @@
           "number" : null,
           "title" : "Requirements",
           "ref" : "schedule-17A-part-2-crossheading-requirements",
+          "id" : "schedule-17A-part-2-crossheading-requirements",
+          "href" : "schedule/17A/part/2/crossheading/requirements",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "9B",
             "title" : "(1) The powers conferred by section 55L(3) (FCA own-initiative power...",
             "ref" : "schedule-17A-paragraph-9B",
+            "id" : "schedule-17A-paragraph-9B",
+            "href" : "schedule/17A/paragraph/9B",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26430,18 +31656,24 @@
           "number" : null,
           "title" : "Rules",
           "ref" : "schedule-17A-part-2-crossheading-rules",
+          "id" : "schedule-17A-part-2-crossheading-rules",
+          "href" : "schedule/17A/part/2/crossheading/rules",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "10",
             "title" : "(1) The following provisions of Part 9A of this Act...",
             "ref" : "schedule-17A-paragraph-10",
+            "id" : "schedule-17A-paragraph-10",
+            "href" : "schedule/17A/paragraph/10",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "10A",
             "title" : "The following provisions of Part 9A of this Act are...",
             "ref" : "schedule-17A-paragraph-10A",
+            "id" : "schedule-17A-paragraph-10A",
+            "href" : "schedule/17A/paragraph/10A",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26449,48 +31681,64 @@
           "number" : null,
           "title" : "Information gathering and investigations",
           "ref" : "schedule-17A-part-2-crossheading-information-gathering-and-investigations",
+          "id" : "schedule-17A-part-2-crossheading-information-gathering-and-investigations",
+          "href" : "schedule/17A/part/2/crossheading/information-gathering-and-investigations",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "11",
             "title" : "(1) The powers conferred by section 165(1) and (3) (power...",
             "ref" : "schedule-17A-paragraph-11",
+            "id" : "schedule-17A-paragraph-11",
+            "href" : "schedule/17A/paragraph/11",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "12",
             "title" : "The power conferred by section 166 (reports by skilled person)...",
             "ref" : "schedule-17A-paragraph-12",
+            "id" : "schedule-17A-paragraph-12",
+            "href" : "schedule/17A/paragraph/12",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "12A",
             "title" : "(1) Section 166A applies in relation to rules made by...",
             "ref" : "schedule-17A-paragraph-12A",
+            "id" : "schedule-17A-paragraph-12A",
+            "href" : "schedule/17A/paragraph/12A",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "13",
             "title" : "(1) The powers conferred by section 167 (appointment of persons...",
             "ref" : "schedule-17A-paragraph-13",
+            "id" : "schedule-17A-paragraph-13",
+            "href" : "schedule/17A/paragraph/13",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "14",
             "title" : "(1) The power conferred by section 168(5) (appointment of persons...",
             "ref" : "schedule-17A-paragraph-14",
+            "id" : "schedule-17A-paragraph-14",
+            "href" : "schedule/17A/paragraph/14",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "15",
             "title" : "An overseas regulator may, in accordance with section 169, request...",
             "ref" : "schedule-17A-paragraph-15",
+            "id" : "schedule-17A-paragraph-15",
+            "href" : "schedule/17A/paragraph/15",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "16",
             "title" : "The power to give information under section 176(1) (entry of...",
             "ref" : "schedule-17A-paragraph-16",
+            "id" : "schedule-17A-paragraph-16",
+            "href" : "schedule/17A/paragraph/16",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26498,12 +31746,16 @@
           "number" : null,
           "title" : "Powers in relation to parent undertakings",
           "ref" : "schedule-17A-part-2-crossheading-powers-in-relation-to-parent-undertakings",
+          "id" : "schedule-17A-part-2-crossheading-powers-in-relation-to-parent-undertakings",
+          "href" : "schedule/17A/part/2/crossheading/powers-in-relation-to-parent-undertakings",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "17",
             "title" : "(1) The following provisions of Part 12A of this Act...",
             "ref" : "schedule-17A-paragraph-17",
+            "id" : "schedule-17A-paragraph-17",
+            "href" : "schedule/17A/paragraph/17",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26511,30 +31763,40 @@
           "number" : null,
           "title" : "Auditors",
           "ref" : "schedule-17A-part-2-crossheading-auditors",
+          "id" : "schedule-17A-part-2-crossheading-auditors",
+          "href" : "schedule/17A/part/2/crossheading/auditors",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "18",
             "title" : "(1) Section 342 (information given by auditor to a regulator)...",
             "ref" : "schedule-17A-paragraph-18",
+            "id" : "schedule-17A-paragraph-18",
+            "href" : "schedule/17A/paragraph/18",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "19",
             "title" : "(1) Section 343 (information given by auditor: person with close...",
             "ref" : "schedule-17A-paragraph-19",
+            "id" : "schedule-17A-paragraph-19",
+            "href" : "schedule/17A/paragraph/19",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "20",
             "title" : "Section 344 (duty of auditor resigning to give notice) applies...",
             "ref" : "schedule-17A-paragraph-20",
+            "id" : "schedule-17A-paragraph-20",
+            "href" : "schedule/17A/paragraph/20",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "21",
             "title" : "Sections 345A to 345E apply to auditors to whom section...",
             "ref" : "schedule-17A-paragraph-21",
+            "id" : "schedule-17A-paragraph-21",
+            "href" : "schedule/17A/paragraph/21",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26542,18 +31804,24 @@
           "number" : null,
           "title" : "Public record and disclosure of information",
           "ref" : "schedule-17A-part-2-crossheading-public-record-and-disclosure-of-information",
+          "id" : "schedule-17A-part-2-crossheading-public-record-and-disclosure-of-information",
+          "href" : "schedule/17A/part/2/crossheading/public-record-and-disclosure-of-information",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "22",
             "title" : "Section 347 (record of authorised persons, recognised investment exchanges, etc),....",
             "ref" : "schedule-17A-paragraph-22",
+            "id" : "schedule-17A-paragraph-22",
+            "href" : "schedule/17A/paragraph/22",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "23",
             "title" : "(1) Sections 348 to 350 and 353 (disclosure of information)...",
             "ref" : "schedule-17A-paragraph-23",
+            "id" : "schedule-17A-paragraph-23",
+            "href" : "schedule/17A/paragraph/23",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26561,12 +31829,16 @@
           "number" : null,
           "title" : "Co-operation",
           "ref" : "schedule-17A-part-2-crossheading-cooperation",
+          "id" : "schedule-17A-part-2-crossheading-cooperation",
+          "href" : "schedule/17A/part/2/crossheading/cooperation",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "23A",
             "title" : "Section 354B (co-operation) applies in relation to the Bank for...",
             "ref" : "schedule-17A-paragraph-23A",
+            "id" : "schedule-17A-paragraph-23A",
+            "href" : "schedule/17A/paragraph/23A",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26574,18 +31846,24 @@
           "number" : null,
           "title" : "Insolvency",
           "ref" : "schedule-17A-part-2-crossheading-insolvency",
+          "id" : "schedule-17A-part-2-crossheading-insolvency",
+          "href" : "schedule/17A/part/2/crossheading/insolvency",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "24",
             "title" : "(1) The following provisions of Part 24 of this Act...",
             "ref" : "schedule-17A-paragraph-24",
+            "id" : "schedule-17A-paragraph-24",
+            "href" : "schedule/17A/paragraph/24",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "25",
             "title" : "(1) In the case of any regulated activity which is...",
             "ref" : "schedule-17A-paragraph-25",
+            "id" : "schedule-17A-paragraph-25",
+            "href" : "schedule/17A/paragraph/25",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26593,24 +31871,32 @@
           "number" : null,
           "title" : "Injunctions and restitution",
           "ref" : "schedule-17A-part-2-crossheading-injunctions-and-restitution",
+          "id" : "schedule-17A-part-2-crossheading-injunctions-and-restitution",
+          "href" : "schedule/17A/part/2/crossheading/injunctions-and-restitution",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "26",
             "title" : "(1) The power to make an application under section 380(1),...",
             "ref" : "schedule-17A-paragraph-26",
+            "id" : "schedule-17A-paragraph-26",
+            "href" : "schedule/17A/paragraph/26",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "27",
             "title" : "(1) The power to make an application under section 382(1)...",
             "ref" : "schedule-17A-paragraph-27",
+            "id" : "schedule-17A-paragraph-27",
+            "href" : "schedule/17A/paragraph/27",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "28",
             "title" : "(1) The power conferred by section 384(5) (power of FCA...",
             "ref" : "schedule-17A-paragraph-28",
+            "id" : "schedule-17A-paragraph-28",
+            "href" : "schedule/17A/paragraph/28",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26618,12 +31904,16 @@
           "number" : null,
           "title" : "Notices",
           "ref" : "schedule-17A-part-2-crossheading-notices",
+          "id" : "schedule-17A-part-2-crossheading-notices",
+          "href" : "schedule/17A/part/2/crossheading/notices",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "29",
             "title" : "The provisions of Part 26 of this Act (notices) apply,...",
             "ref" : "schedule-17A-paragraph-29",
+            "id" : "schedule-17A-paragraph-29",
+            "href" : "schedule/17A/paragraph/29",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26631,18 +31921,24 @@
           "number" : null,
           "title" : "Offences",
           "ref" : "schedule-17A-part-2-crossheading-offences",
+          "id" : "schedule-17A-part-2-crossheading-offences",
+          "href" : "schedule/17A/part/2/crossheading/offences",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "30",
             "title" : "Section 398 (misleading the FCA: residual cases) applies to information...",
             "ref" : "schedule-17A-paragraph-30",
+            "id" : "schedule-17A-paragraph-30",
+            "href" : "schedule/17A/paragraph/30",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "31",
             "title" : "(1) Section 401 (proceedings for an offence) applies to the...",
             "ref" : "schedule-17A-paragraph-31",
+            "id" : "schedule-17A-paragraph-31",
+            "href" : "schedule/17A/paragraph/31",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26650,12 +31946,16 @@
           "number" : null,
           "title" : "International obligations",
           "ref" : "schedule-17A-part-2-crossheading-international-obligations",
+          "id" : "schedule-17A-part-2-crossheading-international-obligations",
+          "href" : "schedule/17A/part/2/crossheading/international-obligations",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "31A",
             "title" : "(1) The following provisions of Part 28 of this Act...",
             "ref" : "schedule-17A-paragraph-31A",
+            "id" : "schedule-17A-paragraph-31A",
+            "href" : "schedule/17A/paragraph/31A",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26663,12 +31963,16 @@
           "number" : null,
           "title" : "Transitional provisions",
           "ref" : "schedule-17A-part-2-crossheading-transitional-provisions",
+          "id" : "schedule-17A-part-2-crossheading-transitional-provisions",
+          "href" : "schedule/17A/part/2/crossheading/transitional-provisions",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "31B",
             "title" : "Section 427 (transitional provisions), so far as it relates to...",
             "ref" : "schedule-17A-paragraph-31B",
+            "id" : "schedule-17A-paragraph-31B",
+            "href" : "schedule/17A/paragraph/31B",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26676,12 +31980,16 @@
           "number" : null,
           "title" : "Records",
           "ref" : "schedule-17A-part-2-crossheading-records",
+          "id" : "schedule-17A-part-2-crossheading-records",
+          "href" : "schedule/17A/part/2/crossheading/records",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "32",
             "title" : "Paragraph 17 of Schedule 1ZB (records) applies in relation to...",
             "ref" : "schedule-17A-paragraph-32",
+            "id" : "schedule-17A-paragraph-32",
+            "href" : "schedule/17A/paragraph/32",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26689,12 +31997,16 @@
           "number" : null,
           "title" : "Annual report",
           "ref" : "schedule-17A-part-2-crossheading-annual-report",
+          "id" : "schedule-17A-part-2-crossheading-annual-report",
+          "href" : "schedule/17A/part/2/crossheading/annual-report",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "33",
             "title" : "Paragraph 19 of Schedule 1ZB (annual report by PRA) applies...",
             "ref" : "schedule-17A-paragraph-33",
+            "id" : "schedule-17A-paragraph-33",
+            "href" : "schedule/17A/paragraph/33",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26702,12 +32014,16 @@
           "number" : null,
           "title" : "Other reports",
           "ref" : "schedule-17A-part-2-crossheading-other-reports",
+          "id" : "schedule-17A-part-2-crossheading-other-reports",
+          "href" : "schedule/17A/part/2/crossheading/other-reports",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "33A",
             "title" : "Paragraph 21A of Schedule 1ZB (other reports by PRA) applies...",
             "ref" : "schedule-17A-paragraph-33A",
+            "id" : "schedule-17A-paragraph-33A",
+            "href" : "schedule/17A/paragraph/33A",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26715,12 +32031,16 @@
           "number" : null,
           "title" : "Engagement with Parliamentary Committees",
           "ref" : "schedule-17A-part-2-crossheading-engagement-with-parliamentary-committees",
+          "id" : "schedule-17A-part-2-crossheading-engagement-with-parliamentary-committees",
+          "href" : "schedule/17A/part/2/crossheading/engagement-with-parliamentary-committees",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "33B",
             "title" : "(1) Paragraph 36 of Schedule 1ZB (PRA engagement with Parliamentary...",
             "ref" : "schedule-17A-paragraph-33B",
+            "id" : "schedule-17A-paragraph-33B",
+            "href" : "schedule/17A/paragraph/33B",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -26729,18 +32049,24 @@
         "number" : "Part 3",
         "title" : "Winding up, administration or insolvency of recognised clearing houses",
         "ref" : "schedule-17A-part-3",
+        "id" : "schedule-17A-part-3",
+        "href" : "schedule/17A/part/3",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Notice to Bank of England of preliminary steps",
           "ref" : "schedule-17A-part-3-crossheading-notice-to-bank-of-england-of-preliminary-steps",
+          "id" : "schedule-17A-part-3-crossheading-notice-to-bank-of-england-of-preliminary-steps",
+          "href" : "schedule/17A/part/3/crossheading/notice-to-bank-of-england-of-preliminary-steps",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "34",
             "title" : "(1) An application for an administration order in respect of...",
             "ref" : "schedule-17A-paragraph-34",
+            "id" : "schedule-17A-paragraph-34",
+            "href" : "schedule/17A/paragraph/34",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26748,12 +32074,16 @@
           "number" : null,
           "title" : "Power to give directions to insolvency practitioner",
           "ref" : "schedule-17A-part-3-crossheading-power-to-give-directions-to-insolvency-practitioner",
+          "id" : "schedule-17A-part-3-crossheading-power-to-give-directions-to-insolvency-practitioner",
+          "href" : "schedule/17A/part/3/crossheading/power-to-give-directions-to-insolvency-practitioner",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "35",
             "title" : "(1) This paragraph applies where a person has been appointed...",
             "ref" : "schedule-17A-paragraph-35",
+            "id" : "schedule-17A-paragraph-35",
+            "href" : "schedule/17A/paragraph/35",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -26762,18 +32092,24 @@
         "number" : "Part 4",
         "title" : "Fees",
         "ref" : "schedule-17A-part-4",
+        "id" : "schedule-17A-part-4",
+        "href" : "schedule/17A/part/4",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "36",
           "title" : "(1) The Bank of England may, in connection with the...",
           "ref" : "schedule-17A-paragraph-36",
+          "id" : "schedule-17A-paragraph-36",
+          "href" : "schedule/17A/paragraph/36",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "37",
           "title" : "Any fee which is owed to the Bank under paragraph...",
           "ref" : "schedule-17A-paragraph-37",
+          "id" : "schedule-17A-paragraph-37",
+          "href" : "schedule/17A/paragraph/37",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -26782,42 +32118,56 @@
       "number" : "SCHEDULE 18",
       "title" : " Mutuals",
       "ref" : "schedule-18",
+      "id" : "schedule-18",
+      "href" : "schedule/18",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "part",
         "number" : "Part I",
         "title" : " Friendly Societies",
         "ref" : "schedule-18-part-I",
+        "id" : "schedule-18-part-I",
+        "href" : "schedule/18/part/I",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : " The Friendly Societies Act 1974 (c.46)",
           "ref" : "schedule-18-part-I-crossheading-the-friendly-societies-act-1974-c46",
+          "id" : "schedule-18-part-I-crossheading-the-friendly-societies-act-1974-c46",
+          "href" : "schedule/18/part/I/crossheading/the-friendly-societies-act-1974-c46",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "1",
             "title" : "Omit sections 4 (provision for separate registration areas) and 10...",
             "ref" : "schedule-18-paragraph-1",
+            "id" : "schedule-18-paragraph-1",
+            "href" : "schedule/18/paragraph/1",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "2",
             "title" : "In section 7 (societies which may be registered), in subsection...",
             "ref" : "schedule-18-paragraph-2",
+            "id" : "schedule-18-paragraph-2",
+            "href" : "schedule/18/paragraph/2",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "3",
             "title" : "In section 11 (additional registration requirements for societies with branches),...",
             "ref" : "schedule-18-paragraph-3",
+            "id" : "schedule-18-paragraph-3",
+            "href" : "schedule/18/paragraph/3",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "4",
             "title" : "In section 99(4) (punishment of fraud etc and recovery of...",
             "ref" : "schedule-18-paragraph-4",
+            "id" : "schedule-18-paragraph-4",
+            "href" : "schedule/18/paragraph/4",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26825,30 +32175,40 @@
           "number" : null,
           "title" : " The Friendly Societies Act 1992 (c.40)",
           "ref" : "schedule-18-part-I-crossheading-the-friendly-societies-act-1992-c40",
+          "id" : "schedule-18-part-I-crossheading-the-friendly-societies-act-1992-c40",
+          "href" : "schedule/18/part/I/crossheading/the-friendly-societies-act-1992-c40",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "5",
             "title" : "Omit sections 31 to 36A (authorisation of friendly societies business)....",
             "ref" : "schedule-18-paragraph-5",
+            "id" : "schedule-18-paragraph-5",
+            "href" : "schedule/18/paragraph/5",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "6",
             "title" : "In section 37 (restrictions on combinations of business), omit subsections...",
             "ref" : "schedule-18-paragraph-6",
+            "id" : "schedule-18-paragraph-6",
+            "href" : "schedule/18/paragraph/6",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "7",
             "title" : "Omit sections 38 to 43 (restrictions on business of certain...",
             "ref" : "schedule-18-paragraph-7",
+            "id" : "schedule-18-paragraph-7",
+            "href" : "schedule/18/paragraph/7",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "8",
             "title" : "Omit sections 44 to 50 (regulation of friendly societies business)....",
             "ref" : "schedule-18-paragraph-8",
+            "id" : "schedule-18-paragraph-8",
+            "href" : "schedule/18/paragraph/8",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -26857,18 +32217,24 @@
         "number" : "Part II",
         "title" : " Friendly Societies: Subsidiaries and Controlled Bodies",
         "ref" : "schedule-18-part-II",
+        "id" : "schedule-18-part-II",
+        "href" : "schedule/18/part/II",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : " Interpretation",
           "ref" : "schedule-18-part-II-crossheading-interpretation",
+          "id" : "schedule-18-part-II-crossheading-interpretation",
+          "href" : "schedule/18/part/II/crossheading/interpretation",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "9",
             "title" : "In this Part of this Schedule— “the 1992 Act” means...",
             "ref" : "schedule-18-paragraph-9",
+            "id" : "schedule-18-paragraph-9",
+            "href" : "schedule/18/paragraph/9",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26876,12 +32242,16 @@
           "number" : null,
           "title" : " Qualifying bodies",
           "ref" : "schedule-18-part-II-crossheading-qualifying-bodies",
+          "id" : "schedule-18-part-II-crossheading-qualifying-bodies",
+          "href" : "schedule/18/part/II/crossheading/qualifying-bodies",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "10",
             "title" : "(1) Subsections (2) to (5) of section 13 (incorporated friendly...",
             "ref" : "schedule-18-paragraph-10",
+            "id" : "schedule-18-paragraph-10",
+            "href" : "schedule/18/paragraph/10",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26889,12 +32259,16 @@
           "number" : null,
           "title" : " Bodies controlled by societies",
           "ref" : "schedule-18-part-II-crossheading-bodies-controlled-by-societies",
+          "id" : "schedule-18-part-II-crossheading-bodies-controlled-by-societies",
+          "href" : "schedule/18/part/II/crossheading/bodies-controlled-by-societies",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "11",
             "title" : "In section 13(9) (defined terms), after paragraph (a) insert— ",
             "ref" : "schedule-18-paragraph-11",
+            "id" : "schedule-18-paragraph-11",
+            "href" : "schedule/18/paragraph/11",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26902,12 +32276,16 @@
           "number" : null,
           "title" : " Joint control by societies",
           "ref" : "schedule-18-part-II-crossheading-joint-control-by-societies",
+          "id" : "schedule-18-part-II-crossheading-joint-control-by-societies",
+          "href" : "schedule/18/part/II/crossheading/joint-control-by-societies",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "12",
             "title" : "In section 13(9), after paragraph (c) insert— ",
             "ref" : "schedule-18-paragraph-12",
+            "id" : "schedule-18-paragraph-12",
+            "href" : "schedule/18/paragraph/12",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26915,12 +32293,16 @@
           "number" : null,
           "title" : " Acquisition of joint control",
           "ref" : "schedule-18-part-II-crossheading-acquisition-of-joint-control",
+          "id" : "schedule-18-part-II-crossheading-acquisition-of-joint-control",
+          "href" : "schedule/18/part/II/crossheading/acquisition-of-joint-control",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "13",
             "title" : "In section 13(9), in the words following paragraph (d), after...",
             "ref" : "schedule-18-paragraph-13",
+            "id" : "schedule-18-paragraph-13",
+            "href" : "schedule/18/paragraph/13",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26928,12 +32310,16 @@
           "number" : null,
           "title" : " Amendment of Schedule 8 to the 1992 Act",
           "ref" : "schedule-18-part-II-crossheading-amendment-of-schedule-8-to-the-1992-act",
+          "id" : "schedule-18-part-II-crossheading-amendment-of-schedule-8-to-the-1992-act",
+          "href" : "schedule/18/part/II/crossheading/amendment-of-schedule-8-to-the-1992-act",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "14",
             "title" : "(1) Schedule 8 to the 1992 Act (provisions supplementing section...",
             "ref" : "schedule-18-paragraph-14",
+            "id" : "schedule-18-paragraph-14",
+            "href" : "schedule/18/paragraph/14",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26941,12 +32327,16 @@
           "number" : null,
           "title" : " Consequential amendments",
           "ref" : "schedule-18-part-II-crossheading-consequential-amendments",
+          "id" : "schedule-18-part-II-crossheading-consequential-amendments",
+          "href" : "schedule/18/part/II/crossheading/consequential-amendments",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "15",
             "title" : "(1) Section 52 of the 1992 Act is amended as...",
             "ref" : "schedule-18-paragraph-15",
+            "id" : "schedule-18-paragraph-15",
+            "href" : "schedule/18/paragraph/15",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -26954,12 +32344,16 @@
           "number" : null,
           "title" : "References in other enactments",
           "ref" : "schedule-18-part-II-crossheading-references-in-other-enactments",
+          "id" : "schedule-18-part-II-crossheading-references-in-other-enactments",
+          "href" : "schedule/18/part/II/crossheading/references-in-other-enactments",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "16",
             "title" : "References in any provision of, or made under, any enactment...",
             "ref" : "schedule-18-paragraph-16",
+            "id" : "schedule-18-paragraph-16",
+            "href" : "schedule/18/paragraph/16",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -26968,24 +32362,32 @@
         "number" : "Part III",
         "title" : " Building Societies",
         "ref" : "schedule-18-part-III",
+        "id" : "schedule-18-part-III",
+        "href" : "schedule/18/part/III",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : " The Building Societies Act 1986 (c.53)",
           "ref" : "schedule-18-part-III-crossheading-the-building-societies-act-1986-c53",
+          "id" : "schedule-18-part-III-crossheading-the-building-societies-act-1986-c53",
+          "href" : "schedule/18/part/III/crossheading/the-building-societies-act-1986-c53",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "17",
             "title" : "Omit section 9 (initial authorisation to raise funds and borrow...",
             "ref" : "schedule-18-paragraph-17",
+            "id" : "schedule-18-paragraph-17",
+            "href" : "schedule/18/paragraph/17",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "18",
             "title" : "Omit Schedule 3 (supplementary provisions about authorisation). ",
             "ref" : "schedule-18-paragraph-18",
+            "id" : "schedule-18-paragraph-18",
+            "href" : "schedule/18/paragraph/18",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -26994,24 +32396,32 @@
         "number" : "Part IV",
         "title" : " Industrial and Provident Societies",
         "ref" : "schedule-18-part-IV",
+        "id" : "schedule-18-part-IV",
+        "href" : "schedule/18/part/IV",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : " The Industrial and Provident Societies Act 1965 (c.12)",
           "ref" : "schedule-18-part-IV-crossheading-the-industrial-and-provident-societies-act-1965-c12",
+          "id" : "schedule-18-part-IV-crossheading-the-industrial-and-provident-societies-act-1965-c12",
+          "href" : "schedule/18/part/IV/crossheading/the-industrial-and-provident-societies-act-1965-c12",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "19",
             "title" : "Omit section 8 (provision for separate registration areas for Scotland...",
             "ref" : "schedule-18-paragraph-19",
+            "id" : "schedule-18-paragraph-19",
+            "href" : "schedule/18/paragraph/19",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "20",
             "title" : "Omit section 70 (scale of fees to be paid in...",
             "ref" : "schedule-18-paragraph-20",
+            "id" : "schedule-18-paragraph-20",
+            "href" : "schedule/18/paragraph/20",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -27020,48 +32430,64 @@
         "number" : "Part V",
         "title" : " Credit Unions",
         "ref" : "schedule-18-part-V",
+        "id" : "schedule-18-part-V",
+        "href" : "schedule/18/part/V",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : " The Credit Unions Act 1979 (c.34)",
           "ref" : "schedule-18-part-V-crossheading-the-credit-unions-act-1979-c34",
+          "id" : "schedule-18-part-V-crossheading-the-credit-unions-act-1979-c34",
+          "href" : "schedule/18/part/V/crossheading/the-credit-unions-act-1979-c34",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "21",
             "title" : "In section 6 (minimum and maximum number of members), omit...",
             "ref" : "schedule-18-paragraph-21",
+            "id" : "schedule-18-paragraph-21",
+            "href" : "schedule/18/paragraph/21",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "22",
             "title" : "In section 11 (loans), omit subsections (2) and (6). ",
             "ref" : "schedule-18-paragraph-22",
+            "id" : "schedule-18-paragraph-22",
+            "href" : "schedule/18/paragraph/22",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "23",
             "title" : "Omit sections 11B (loans approved by credit unions), 11C (grant...",
             "ref" : "schedule-18-paragraph-23",
+            "id" : "schedule-18-paragraph-23",
+            "href" : "schedule/18/paragraph/23",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "24",
             "title" : "In section 12, omit subsections (4) and (5). ",
             "ref" : "schedule-18-paragraph-24",
+            "id" : "schedule-18-paragraph-24",
+            "href" : "schedule/18/paragraph/24",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "25",
             "title" : "In section 14, omit subsections (2), (3), (5) and (6)....",
             "ref" : "schedule-18-paragraph-25",
+            "id" : "schedule-18-paragraph-25",
+            "href" : "schedule/18/paragraph/25",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "26",
             "title" : "In section 28 (offences), omit subsection (2). ",
             "ref" : "schedule-18-paragraph-26",
+            "id" : "schedule-18-paragraph-26",
+            "href" : "schedule/18/paragraph/26",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -27071,18 +32497,24 @@
       "number" : "SCHEDULE 19",
       "title" : null,
       "ref" : "schedule-19",
+      "id" : "schedule-19",
+      "href" : "schedule/19",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "part",
         "number" : "Part I",
         "title" : " Persons and functions for the purposes of section 351",
         "ref" : "schedule-19-part-I",
+        "id" : "schedule-19-part-I",
+        "href" : "schedule/19/part/I",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "1",
           "title" : "The Table set out after this paragraph has effect for...",
           "ref" : "schedule-19-part-I-paragraph-1",
+          "id" : "schedule-19-part-I-paragraph-1",
+          "href" : "schedule/19/part/I/paragraph/1",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -27090,120 +32522,160 @@
         "number" : "Part II",
         "title" : " The enactments",
         "ref" : "schedule-19-part-II",
+        "id" : "schedule-19-part-II",
+        "href" : "schedule/19/part/II",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "1",
           "title" : "The Fair Trading Act 1973 ",
           "ref" : "schedule-19-part-II-paragraph-1",
+          "id" : "schedule-19-part-II-paragraph-1",
+          "href" : "schedule/19/part/II/paragraph/1",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "2",
           "title" : "The Consumer Credit Act 1974 ",
           "ref" : "schedule-19-paragraph-2",
+          "id" : "schedule-19-paragraph-2",
+          "href" : "schedule/19/paragraph/2",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "3",
           "title" : "The Estate Agents Act 1979 ",
           "ref" : "schedule-19-paragraph-3",
+          "id" : "schedule-19-paragraph-3",
+          "href" : "schedule/19/paragraph/3",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "4",
           "title" : "The Competition Act 1980 ",
           "ref" : "schedule-19-paragraph-4",
+          "id" : "schedule-19-paragraph-4",
+          "href" : "schedule/19/paragraph/4",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "5",
           "title" : "The Telecommunications Act 1984 ",
           "ref" : "schedule-19-paragraph-5",
+          "id" : "schedule-19-paragraph-5",
+          "href" : "schedule/19/paragraph/5",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "6",
           "title" : "The Airports Act 1986 ",
           "ref" : "schedule-19-paragraph-6",
+          "id" : "schedule-19-paragraph-6",
+          "href" : "schedule/19/paragraph/6",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "7",
           "title" : "The Gas Act 1986 ",
           "ref" : "schedule-19-paragraph-7",
+          "id" : "schedule-19-paragraph-7",
+          "href" : "schedule/19/paragraph/7",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "8",
           "title" : "The Control of Misleading Advertisements Regulations 1988 ",
           "ref" : "schedule-19-paragraph-8",
+          "id" : "schedule-19-paragraph-8",
+          "href" : "schedule/19/paragraph/8",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "9",
           "title" : "The Electricity Act 1989 ",
           "ref" : "schedule-19-paragraph-9",
+          "id" : "schedule-19-paragraph-9",
+          "href" : "schedule/19/paragraph/9",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "10",
           "title" : "The Broadcasting Act 1990 ",
           "ref" : "schedule-19-paragraph-10",
+          "id" : "schedule-19-paragraph-10",
+          "href" : "schedule/19/paragraph/10",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "11",
           "title" : "The Water Industry Act 1991 ",
           "ref" : "schedule-19-paragraph-11",
+          "id" : "schedule-19-paragraph-11",
+          "href" : "schedule/19/paragraph/11",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "12",
           "title" : "The Electricity (Northern Ireland) Order 1992 ",
           "ref" : "schedule-19-paragraph-12",
+          "id" : "schedule-19-paragraph-12",
+          "href" : "schedule/19/paragraph/12",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "13",
           "title" : "The Railways Act 1993 ",
           "ref" : "schedule-19-paragraph-13",
+          "id" : "schedule-19-paragraph-13",
+          "href" : "schedule/19/paragraph/13",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "14",
           "title" : "Part IV of the Airports (Northern Ireland) Order 1994 ",
           "ref" : "schedule-19-paragraph-14",
+          "id" : "schedule-19-paragraph-14",
+          "href" : "schedule/19/paragraph/14",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "15",
           "title" : "The Gas (Northern Ireland) Order 1996 ",
           "ref" : "schedule-19-paragraph-15",
+          "id" : "schedule-19-paragraph-15",
+          "href" : "schedule/19/paragraph/15",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "16",
           "title" : "The EC Competition (Articles 88 and 89) Enforcement Regulations 1996...",
           "ref" : "schedule-19-paragraph-16",
+          "id" : "schedule-19-paragraph-16",
+          "href" : "schedule/19/paragraph/16",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "17",
           "title" : "The Unfair Terms in Consumer Contracts Regulations 1999 ",
           "ref" : "schedule-19-paragraph-17",
+          "id" : "schedule-19-paragraph-17",
+          "href" : "schedule/19/paragraph/17",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "18",
           "title" : "This Act. ",
           "ref" : "schedule-19-paragraph-18",
+          "id" : "schedule-19-paragraph-18",
+          "href" : "schedule/19/paragraph/18",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "19",
           "title" : "An enactment specified for the purposes of this paragraph in...",
           "ref" : "schedule-19-paragraph-19",
+          "id" : "schedule-19-paragraph-19",
+          "href" : "schedule/19/paragraph/19",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -27212,48 +32684,64 @@
       "number" : "SCHEDULE 19A",
       "title" : "The manager of a write-down order",
       "ref" : "schedule-19A",
+      "id" : "schedule-19A",
+      "href" : "schedule/19A",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "1",
         "title" : "Application of Schedule",
         "ref" : "schedule-19A-paragraph-1",
+        "id" : "schedule-19A-paragraph-1",
+        "href" : "schedule/19A/paragraph/1",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "2",
         "title" : "Status of the manager",
         "ref" : "schedule-19A-paragraph-2",
+        "id" : "schedule-19A-paragraph-2",
+        "href" : "schedule/19A/paragraph/2",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "3",
         "title" : "Monitoring the insurer’s affairs",
         "ref" : "schedule-19A-paragraph-3",
+        "id" : "schedule-19A-paragraph-3",
+        "href" : "schedule/19A/paragraph/3",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "4",
         "title" : "Application by manager to revoke or vary a write-down order",
         "ref" : "schedule-19A-paragraph-4",
+        "id" : "schedule-19A-paragraph-4",
+        "href" : "schedule/19A/paragraph/4",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "5",
         "title" : "Provision of information and assistance to the manager",
         "ref" : "schedule-19A-paragraph-5",
+        "id" : "schedule-19A-paragraph-5",
+        "href" : "schedule/19A/paragraph/5",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "6",
         "title" : "Application by manager for directions",
         "ref" : "schedule-19A-paragraph-6",
+        "id" : "schedule-19A-paragraph-6",
+        "href" : "schedule/19A/paragraph/6",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "7",
         "title" : "Challenges to the manager’s actions",
         "ref" : "schedule-19A-paragraph-7",
+        "id" : "schedule-19A-paragraph-7",
+        "href" : "schedule/19A/paragraph/7",
         "extent" : [ "E", "W", "S", "NI" ]
       } ]
     }, {
@@ -27261,30 +32749,40 @@
       "number" : "SCHEDULE 19B",
       "title" : "Further provision about write-down orders",
       "ref" : "schedule-19B",
+      "id" : "schedule-19B",
+      "href" : "schedule/19B",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "part",
         "number" : "PART 1",
         "title" : "Restrictions on enforcement",
         "ref" : "schedule-19B-part-1",
+        "id" : "schedule-19B-part-1",
+        "href" : "schedule/19B/part/1",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "1",
           "title" : "Application of this Part of this Schedule",
           "ref" : "schedule-19B-paragraph-1",
+          "id" : "schedule-19B-paragraph-1",
+          "href" : "schedule/19B/paragraph/1",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "2",
           "title" : "Moratorium on proceedings",
           "ref" : "schedule-19B-paragraph-2",
+          "id" : "schedule-19B-paragraph-2",
+          "href" : "schedule/19B/paragraph/2",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "3",
           "title" : "Exceptions",
           "ref" : "schedule-19B-paragraph-3",
+          "id" : "schedule-19B-paragraph-3",
+          "href" : "schedule/19B/paragraph/3",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -27292,30 +32790,40 @@
         "number" : "PART 2",
         "title" : "Dealing with assets etc",
         "ref" : "schedule-19B-part-2",
+        "id" : "schedule-19B-part-2",
+        "href" : "schedule/19B/part/2",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "4",
           "title" : "Application of this Part of this Schedule",
           "ref" : "schedule-19B-paragraph-4",
+          "id" : "schedule-19B-paragraph-4",
+          "href" : "schedule/19B/paragraph/4",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "5",
           "title" : "Dealing with assets",
           "ref" : "schedule-19B-paragraph-5",
+          "id" : "schedule-19B-paragraph-5",
+          "href" : "schedule/19B/paragraph/5",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "6",
           "title" : "Paying variable remuneration",
           "ref" : "schedule-19B-paragraph-6",
+          "id" : "schedule-19B-paragraph-6",
+          "href" : "schedule/19B/paragraph/6",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "7",
           "title" : "Distributions",
           "ref" : "schedule-19B-paragraph-7",
+          "id" : "schedule-19B-paragraph-7",
+          "href" : "schedule/19B/paragraph/7",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -27323,24 +32831,32 @@
         "number" : "PART 3",
         "title" : "Treatment of written-down liabilities for certain purposes",
         "ref" : "schedule-19B-part-3",
+        "id" : "schedule-19B-part-3",
+        "href" : "schedule/19B/part/3",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "8",
           "title" : "Application of this Part of this Schedule",
           "ref" : "schedule-19B-paragraph-8",
+          "id" : "schedule-19B-paragraph-8",
+          "href" : "schedule/19B/paragraph/8",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "9",
           "title" : "Relevant insolvency provisions",
           "ref" : "schedule-19B-paragraph-9",
+          "id" : "schedule-19B-paragraph-9",
+          "href" : "schedule/19B/paragraph/9",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "10",
           "title" : "Reinsurance contracts",
           "ref" : "schedule-19B-paragraph-10",
+          "id" : "schedule-19B-paragraph-10",
+          "href" : "schedule/19B/paragraph/10",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -27348,12 +32864,16 @@
         "number" : "PART 4",
         "title" : "Interest",
         "ref" : "schedule-19B-part-4",
+        "id" : "schedule-19B-part-4",
+        "href" : "schedule/19B/part/4",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "11",
           "title" : "(1) This Part of this Schedule applies where— ",
           "ref" : "schedule-19B-paragraph-11",
+          "id" : "schedule-19B-paragraph-11",
+          "href" : "schedule/19B/paragraph/11",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -27362,24 +32882,32 @@
       "number" : "SCHEDULE 19C",
       "title" : "Insurers in financial difficulties: enforcement of contracts",
       "ref" : "schedule-19C",
+      "id" : "schedule-19C",
+      "href" : "schedule/19C",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "part",
         "number" : "PART 1",
         "title" : "Introductory",
         "ref" : "schedule-19C-part-1",
+        "id" : "schedule-19C-part-1",
+        "href" : "schedule/19C/part/1",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "1",
           "title" : "Application of this Schedule",
           "ref" : "schedule-19C-paragraph-1",
+          "id" : "schedule-19C-paragraph-1",
+          "href" : "schedule/19C/paragraph/1",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "2",
           "title" : "“Financial difficulties”",
           "ref" : "schedule-19C-paragraph-2",
+          "id" : "schedule-19C-paragraph-2",
+          "href" : "schedule/19C/paragraph/2",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -27387,24 +32915,32 @@
         "number" : "PART 2",
         "title" : "Policyholder surrender rights",
         "ref" : "schedule-19C-part-2",
+        "id" : "schedule-19C-part-2",
+        "href" : "schedule/19C/part/2",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "3",
           "title" : "Restriction on policyholder surrender rights",
           "ref" : "schedule-19C-paragraph-3",
+          "id" : "schedule-19C-paragraph-3",
+          "href" : "schedule/19C/paragraph/3",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "4",
           "title" : "Switching rights",
           "ref" : "schedule-19C-paragraph-4",
+          "id" : "schedule-19C-paragraph-4",
+          "href" : "schedule/19C/paragraph/4",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "5",
           "title" : "Consent to exceed surrender limit",
           "ref" : "schedule-19C-paragraph-5",
+          "id" : "schedule-19C-paragraph-5",
+          "href" : "schedule/19C/paragraph/5",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -27412,24 +32948,32 @@
         "number" : "PART 3",
         "title" : "Termination etc of relevant contracts",
         "ref" : "schedule-19C-part-3",
+        "id" : "schedule-19C-part-3",
+        "href" : "schedule/19C/part/3",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "6",
           "title" : "Relevant contracts",
           "ref" : "schedule-19C-paragraph-6",
+          "id" : "schedule-19C-paragraph-6",
+          "href" : "schedule/19C/paragraph/6",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "7",
           "title" : "Restriction on termination etc",
           "ref" : "schedule-19C-paragraph-7",
+          "id" : "schedule-19C-paragraph-7",
+          "href" : "schedule/19C/paragraph/7",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "8",
           "title" : "Consent to terminate relevant contracts",
           "ref" : "schedule-19C-paragraph-8",
+          "id" : "schedule-19C-paragraph-8",
+          "href" : "schedule/19C/paragraph/8",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -27437,24 +32981,32 @@
         "number" : "PART 4",
         "title" : "Exclusions and disapplication of this Schedule",
         "ref" : "schedule-19C-part-4",
+        "id" : "schedule-19C-part-4",
+        "href" : "schedule/19C/part/4",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "9",
           "title" : "Exclusions",
           "ref" : "schedule-19C-paragraph-9",
+          "id" : "schedule-19C-paragraph-9",
+          "href" : "schedule/19C/paragraph/9",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "10",
           "title" : "Disapplication of this Schedule by the court",
           "ref" : "schedule-19C-paragraph-10",
+          "id" : "schedule-19C-paragraph-10",
+          "href" : "schedule/19C/paragraph/10",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "11",
           "title" : "Procedure",
           "ref" : "schedule-19C-paragraph-11",
+          "id" : "schedule-19C-paragraph-11",
+          "href" : "schedule/19C/paragraph/11",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -27462,12 +33014,16 @@
         "number" : "PART 5",
         "title" : "Powers to amend this Schedule",
         "ref" : "schedule-19C-part-5",
+        "id" : "schedule-19C-part-5",
+        "href" : "schedule/19C/part/5",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "12",
           "title" : "The Treasury may by regulations amend this Schedule so as...",
           "ref" : "schedule-19C-paragraph-12",
+          "id" : "schedule-19C-paragraph-12",
+          "href" : "schedule/19C/paragraph/12",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -27476,18 +33032,24 @@
       "number" : "SCHEDULE 20",
       "title" : " Minor and Consequential Amendments",
       "ref" : "schedule-20",
+      "id" : "schedule-20",
+      "href" : "schedule/20",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : " The House of Commons Disqualification Act 1975 (c. 24)",
         "ref" : "schedule-20-crossheading-the-house-of-commons-disqualification-act-1975-c-24",
+        "id" : "schedule-20-crossheading-the-house-of-commons-disqualification-act-1975-c-24",
+        "href" : "schedule/20/crossheading/the-house-of-commons-disqualification-act-1975-c-24",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "1",
           "title" : "In Part III of Schedule 1 to the House of...",
           "ref" : "schedule-20-paragraph-1",
+          "id" : "schedule-20-paragraph-1",
+          "href" : "schedule/20/paragraph/1",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -27495,12 +33057,16 @@
         "number" : null,
         "title" : " The Northern Ireland Assembly Disqualification Act 1975 (c. 25)",
         "ref" : "schedule-20-crossheading-the-northern-ireland-assembly-disqualification-act-1975-c-25",
+        "id" : "schedule-20-crossheading-the-northern-ireland-assembly-disqualification-act-1975-c-25",
+        "href" : "schedule/20/crossheading/the-northern-ireland-assembly-disqualification-act-1975-c-25",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "2",
           "title" : "In Part III of Schedule 1 to the Northern Ireland...",
           "ref" : "schedule-20-paragraph-2",
+          "id" : "schedule-20-paragraph-2",
+          "href" : "schedule/20/paragraph/2",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -27508,12 +33074,16 @@
         "number" : null,
         "title" : " The Civil Jurisdiction and Judgments Act 1982 (c. 27)",
         "ref" : "schedule-20-crossheading-the-civil-jurisdiction-and-judgments-act-1982-c-27",
+        "id" : "schedule-20-crossheading-the-civil-jurisdiction-and-judgments-act-1982-c-27",
+        "href" : "schedule/20/crossheading/the-civil-jurisdiction-and-judgments-act-1982-c-27",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "3",
           "title" : "In paragraph 10 of Schedule 5 to the Civil Jurisdiction...",
           "ref" : "schedule-20-paragraph-3",
+          "id" : "schedule-20-paragraph-3",
+          "href" : "schedule/20/paragraph/3",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -27521,12 +33091,16 @@
         "number" : null,
         "title" : " The Income and Corporation Taxes Act 1988 (c. 1)",
         "ref" : "schedule-20-crossheading-the-income-and-corporation-taxes-act-1988-c-1",
+        "id" : "schedule-20-crossheading-the-income-and-corporation-taxes-act-1988-c-1",
+        "href" : "schedule/20/crossheading/the-income-and-corporation-taxes-act-1988-c-1",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "4",
           "title" : "(1) The Income and Corporation Taxes Act 1988 is amended...",
           "ref" : "schedule-20-paragraph-4",
+          "id" : "schedule-20-paragraph-4",
+          "href" : "schedule/20/paragraph/4",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -27534,12 +33108,16 @@
         "number" : null,
         "title" : " The Finance Act 1991 (c. 31)",
         "ref" : "schedule-20-crossheading-the-finance-act-1991-c-31",
+        "id" : "schedule-20-crossheading-the-finance-act-1991-c-31",
+        "href" : "schedule/20/crossheading/the-finance-act-1991-c-31",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "5",
           "title" : "(1) The Finance Act 1991 is amended as follows. ",
           "ref" : "schedule-20-paragraph-5",
+          "id" : "schedule-20-paragraph-5",
+          "href" : "schedule/20/paragraph/5",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -27547,12 +33125,16 @@
         "number" : null,
         "title" : " The Tribunals and Inquiries Act 1992 (c. 53)",
         "ref" : "schedule-20-crossheading-the-tribunals-and-inquiries-act-1992-c-53",
+        "id" : "schedule-20-crossheading-the-tribunals-and-inquiries-act-1992-c-53",
+        "href" : "schedule/20/crossheading/the-tribunals-and-inquiries-act-1992-c-53",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "6",
           "title" : " Minor and Consequential Amendments",
           "ref" : "schedule-20-paragraph-6",
+          "id" : "schedule-20-paragraph-6",
+          "href" : "schedule/20/paragraph/6",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -27560,12 +33142,16 @@
         "number" : null,
         "title" : " The Judicial Pensions and Retirement Act 1993 (c. 8)",
         "ref" : "schedule-20-crossheading-the-judicial-pensions-and-retirement-act-1993-c-8",
+        "id" : "schedule-20-crossheading-the-judicial-pensions-and-retirement-act-1993-c-8",
+        "href" : "schedule/20/crossheading/the-judicial-pensions-and-retirement-act-1993-c-8",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "7",
           "title" : "(1) The Judicial Pensions and Retirement Act 1993 is amended...",
           "ref" : "schedule-20-paragraph-7",
+          "id" : "schedule-20-paragraph-7",
+          "href" : "schedule/20/paragraph/7",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -27574,18 +33160,24 @@
       "number" : "SCHEDULE 21",
       "title" : " Transitional Provisions and Savings",
       "ref" : "schedule-21",
+      "id" : "schedule-21",
+      "href" : "schedule/21",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : " Self-regulating organisations",
         "ref" : "schedule-21-crossheading-selfregulating-organisations",
+        "id" : "schedule-21-crossheading-selfregulating-organisations",
+        "href" : "schedule/21/crossheading/selfregulating-organisations",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "1",
           "title" : "(1) No new application under section 9 of the 1986...",
           "ref" : "schedule-21-paragraph-1",
+          "id" : "schedule-21-paragraph-1",
+          "href" : "schedule/21/paragraph/1",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -27593,12 +33185,16 @@
         "number" : null,
         "title" : " Self-regulating organisations for friendly societies",
         "ref" : "schedule-21-crossheading-selfregulating-organisations-for-friendly-societies",
+        "id" : "schedule-21-crossheading-selfregulating-organisations-for-friendly-societies",
+        "href" : "schedule/21/crossheading/selfregulating-organisations-for-friendly-societies",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "2",
           "title" : "(1) No new application under paragraph 2 of Schedule 11...",
           "ref" : "schedule-21-paragraph-2",
+          "id" : "schedule-21-paragraph-2",
+          "href" : "schedule/21/paragraph/2",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -27607,6 +33203,8 @@
       "number" : "SCHEDULE 22",
       "title" : "Repeals",
       "ref" : "schedule-22",
+      "id" : "schedule-22",
+      "href" : "schedule/22",
       "extent" : [ "E", "W", "S", "NI" ]
     } ]
   }

--- a/src/test/resources/ukpga_2000_8/ukpga-2000-8-section-91.json
+++ b/src/test/resources/ukpga_2000_8/ukpga-2000-8-section-91.json
@@ -37,23 +37,23 @@
     "fragmentInfo" : {
       "element" : "P1",
       "id" : "section-91",
-      "href" : "ukpga/2000/8/section/91",
+      "href" : "section/91",
       "number" : "91",
       "title" : "Penalties for breach of Part 6 rules",
       "label" : "Section 91"
     },
     "prevInfo" : {
-      "href" : "ukpga/2000/8/section/90B",
+      "href" : "section/90B",
       "label" : "Provision"
     },
     "nextInfo" : {
-      "href" : "ukpga/2000/8/section/92",
+      "href" : "section/92",
       "label" : "Provision"
     },
     "ancestors" : [ {
       "element" : "Part",
       "id" : "part-VI",
-      "href" : "ukpga/2000/8/part/VI",
+      "href" : "part/VI",
       "number" : "Part VI",
       "title" : "Official Listing",
       "label" : "Part VI",
@@ -61,7 +61,7 @@
     }, {
       "element" : "Pblock",
       "id" : "part-VI-crossheading-penalties",
-      "href" : "ukpga/2000/8/part/VI/crossheading/penalties",
+      "href" : "part/VI/crossheading/penalties",
       "number" : null,
       "title" : "Penalties",
       "label" : "Penalties",
@@ -69,7 +69,7 @@
     }, {
       "element" : "P1",
       "id" : "section-91",
-      "href" : "ukpga/2000/8/section/91",
+      "href" : "section/91",
       "number" : "91",
       "title" : "Penalties for breach of Part 6 rules",
       "label" : "Section 91"
@@ -77,210 +77,210 @@
     "descendants" : [ {
       "element" : "P1",
       "id" : "section-91",
-      "href" : "ukpga/2000/8/section/91",
+      "href" : "section/91",
       "number" : "91",
       "title" : "Penalties for breach of Part 6 rules",
       "label" : "Section 91"
     }, {
       "element" : "P2",
       "id" : "section-91-1",
-      "href" : "ukpga/2000/8/section/91/1",
+      "href" : "section/91/1",
       "number" : "1",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-91-1-a",
-      "href" : "ukpga/2000/8/section/91/1/a",
+      "href" : "section/91/1/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-91-1-b",
-      "href" : "ukpga/2000/8/section/91/1/b",
+      "href" : "section/91/1/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P2",
       "id" : "section-91-1ZA",
-      "href" : "ukpga/2000/8/section/91/1ZA",
+      "href" : "section/91/1ZA",
       "number" : "1ZA",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "section-91-1A",
-      "href" : "ukpga/2000/8/section/91/1A",
+      "href" : "section/91/1A",
       "number" : "1A",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-91-1A-a",
-      "href" : "ukpga/2000/8/section/91/1A/a",
+      "href" : "section/91/1A/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-91-1A-b",
-      "href" : "ukpga/2000/8/section/91/1A/b",
+      "href" : "section/91/1A/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-91-1A-c",
-      "href" : "ukpga/2000/8/section/91/1A/c",
+      "href" : "section/91/1A/c",
       "number" : "c",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-91-1A-d",
-      "href" : "ukpga/2000/8/section/91/1A/d",
+      "href" : "section/91/1A/d",
       "number" : "d",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-91-1A-e",
-      "href" : "ukpga/2000/8/section/91/1A/e",
+      "href" : "section/91/1A/e",
       "number" : "e",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P2",
       "id" : "section-91-1B",
-      "href" : "ukpga/2000/8/section/91/1B",
+      "href" : "section/91/1B",
       "number" : "1B",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-91-1B-a",
-      "href" : "ukpga/2000/8/section/91/1B/a",
+      "href" : "section/91/1B/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P4",
       "id" : "section-91-1B-a-i",
-      "href" : "ukpga/2000/8/section/91/1B/a/i",
+      "href" : "section/91/1B/a/i",
       "number" : "i",
       "title" : null,
       "label" : "P4"
     }, {
       "element" : "P4",
       "id" : "section-91-1B-a-ii",
-      "href" : "ukpga/2000/8/section/91/1B/a/ii",
+      "href" : "section/91/1B/a/ii",
       "number" : "ii",
       "title" : null,
       "label" : "P4"
     }, {
       "element" : "P3",
       "id" : "section-91-1B-b",
-      "href" : "ukpga/2000/8/section/91/1B/b",
+      "href" : "section/91/1B/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P2",
       "id" : "section-91-2",
-      "href" : "ukpga/2000/8/section/91/2",
+      "href" : "section/91/2",
       "number" : "2",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "section-91-2A",
-      "href" : "ukpga/2000/8/section/91/2A",
+      "href" : "section/91/2A",
       "number" : "2A",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-91-2A-a",
-      "href" : "ukpga/2000/8/section/91/2A/a",
+      "href" : "section/91/2A/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-91-2A-b",
-      "href" : "ukpga/2000/8/section/91/2A/b",
+      "href" : "section/91/2A/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P2",
       "id" : "section-91-2B",
-      "href" : "ukpga/2000/8/section/91/2B",
+      "href" : "section/91/2B",
       "number" : "2B",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-91-2B-a",
-      "href" : "ukpga/2000/8/section/91/2B/a",
+      "href" : "section/91/2B/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-91-2B-b",
-      "href" : "ukpga/2000/8/section/91/2B/b",
+      "href" : "section/91/2B/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P2",
       "id" : "section-91-3",
-      "href" : "ukpga/2000/8/section/91/3",
+      "href" : "section/91/3",
       "number" : "3",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "section-91-4",
-      "href" : "ukpga/2000/8/section/91/4",
+      "href" : "section/91/4",
       "number" : "4",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "section-91-5",
-      "href" : "ukpga/2000/8/section/91/5",
+      "href" : "section/91/5",
       "number" : "5",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "section-91-6",
-      "href" : "ukpga/2000/8/section/91/6",
+      "href" : "section/91/6",
       "number" : "6",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "section-91-7",
-      "href" : "ukpga/2000/8/section/91/7",
+      "href" : "section/91/7",
       "number" : "7",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "section-91-7-a",
-      "href" : "ukpga/2000/8/section/91/7/a",
+      "href" : "section/91/7/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "section-91-7-b",
-      "href" : "ukpga/2000/8/section/91/7/b",
+      "href" : "section/91/7/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"

--- a/src/test/resources/ukpga_2000_8/ukpga-2000-8-section-91.json
+++ b/src/test/resources/ukpga_2000_8/ukpga-2000-8-section-91.json
@@ -56,14 +56,16 @@
       "href" : "ukpga/2000/8/part/VI",
       "number" : "Part VI",
       "title" : "Official Listing",
-      "label" : "Part VI"
+      "label" : "Part VI",
+      "start" : "2024-01-30"
     }, {
       "element" : "Pblock",
       "id" : "part-VI-crossheading-penalties",
       "href" : "ukpga/2000/8/part/VI/crossheading/penalties",
       "number" : null,
       "title" : "Penalties",
-      "label" : "Penalties"
+      "label" : "Penalties",
+      "start" : "2024-01-30"
     }, {
       "element" : "P1",
       "id" : "section-91",

--- a/src/test/resources/ukpga_2000_8_schedule_6_paragraph_4A/meta.json
+++ b/src/test/resources/ukpga_2000_8_schedule_6_paragraph_4A/meta.json
@@ -55,14 +55,16 @@
     "href" : "ukpga/2000/8/schedule/6",
     "number" : "SCHEDULE 6",
     "title" : null,
-    "label" : "SCHEDULE 6"
+    "label" : "SCHEDULE 6",
+    "start" : "2020-12-31"
   }, {
     "element" : "Part",
     "id" : "schedule-6-part-1D",
     "href" : "ukpga/2000/8/schedule/6/part/1D",
     "number" : "PART 1D",
     "title" : "Part 4A permission: conditions for which the PRA is responsible in relation to insurers etc.",
-    "label" : "PART 1D"
+    "label" : "PART 1D",
+    "start" : "2020-12-31"
   }, {
     "element" : "P1",
     "id" : "schedule-6-paragraph-4A",

--- a/src/test/resources/ukpga_2000_8_schedule_6_paragraph_4A/meta.json
+++ b/src/test/resources/ukpga_2000_8_schedule_6_paragraph_4A/meta.json
@@ -36,23 +36,23 @@
   "fragmentInfo" : {
     "element" : "P1",
     "id" : "schedule-6-paragraph-4A",
-    "href" : "ukpga/2000/8/schedule/6/paragraph/4A",
+    "href" : "schedule/6/paragraph/4A",
     "number" : "4A",
     "title" : "Introduction",
     "label" : "Schedule 6 paragraph 4A"
   },
   "prevInfo" : {
-    "href" : "ukpga/2000/8/schedule/6/paragraph/3E",
+    "href" : "schedule/6/paragraph/3E",
     "label" : "Paragraph"
   },
   "nextInfo" : {
-    "href" : "ukpga/2000/8/schedule/6/paragraph/4B",
+    "href" : "schedule/6/paragraph/4B",
     "label" : "Paragraph"
   },
   "ancestors" : [ {
     "element" : "Schedule",
     "id" : "schedule-6",
-    "href" : "ukpga/2000/8/schedule/6",
+    "href" : "schedule/6",
     "number" : "SCHEDULE 6",
     "title" : null,
     "label" : "SCHEDULE 6",
@@ -60,7 +60,7 @@
   }, {
     "element" : "Part",
     "id" : "schedule-6-part-1D",
-    "href" : "ukpga/2000/8/schedule/6/part/1D",
+    "href" : "schedule/6/part/1D",
     "number" : "PART 1D",
     "title" : "Part 4A permission: conditions for which the PRA is responsible in relation to insurers etc.",
     "label" : "PART 1D",
@@ -68,7 +68,7 @@
   }, {
     "element" : "P1",
     "id" : "schedule-6-paragraph-4A",
-    "href" : "ukpga/2000/8/schedule/6/paragraph/4A",
+    "href" : "schedule/6/paragraph/4A",
     "number" : "4A",
     "title" : "Introduction",
     "label" : "Schedule 6 paragraph 4A"
@@ -76,98 +76,98 @@
   "descendants" : [ {
     "element" : "P1",
     "id" : "schedule-6-paragraph-4A",
-    "href" : "ukpga/2000/8/schedule/6/paragraph/4A",
+    "href" : "schedule/6/paragraph/4A",
     "number" : "4A",
     "title" : "Introduction",
     "label" : "Schedule 6 paragraph 4A"
   }, {
     "element" : "P2",
     "id" : "schedule-6-paragraph-4A-1",
-    "href" : "ukpga/2000/8/schedule/6/paragraph/4A/1",
+    "href" : "schedule/6/paragraph/4A/1",
     "number" : "1",
     "title" : null,
     "label" : "P2"
   }, {
     "element" : "P2",
     "id" : "schedule-6-paragraph-4A-2",
-    "href" : "ukpga/2000/8/schedule/6/paragraph/4A/2",
+    "href" : "schedule/6/paragraph/4A/2",
     "number" : "2",
     "title" : null,
     "label" : "P2"
   }, {
     "element" : "P2",
     "id" : "schedule-6-paragraph-4A-3",
-    "href" : "ukpga/2000/8/schedule/6/paragraph/4A/3",
+    "href" : "schedule/6/paragraph/4A/3",
     "number" : "3",
     "title" : null,
     "label" : "P2"
   }, {
     "element" : "P2",
     "id" : "schedule-6-paragraph-4A-4",
-    "href" : "ukpga/2000/8/schedule/6/paragraph/4A/4",
+    "href" : "schedule/6/paragraph/4A/4",
     "number" : "4",
     "title" : null,
     "label" : "P2"
   }, {
     "element" : "P3",
     "id" : "schedule-6-paragraph-4A-4-a",
-    "href" : "ukpga/2000/8/schedule/6/paragraph/4A/4/a",
+    "href" : "schedule/6/paragraph/4A/4/a",
     "number" : "a",
     "title" : null,
     "label" : "P3"
   }, {
     "element" : "P3",
     "id" : "schedule-6-paragraph-4A-4-b",
-    "href" : "ukpga/2000/8/schedule/6/paragraph/4A/4/b",
+    "href" : "schedule/6/paragraph/4A/4/b",
     "number" : "b",
     "title" : null,
     "label" : "P3"
   }, {
     "element" : "P2",
     "id" : "schedule-6-paragraph-4A-5",
-    "href" : "ukpga/2000/8/schedule/6/paragraph/4A/5",
+    "href" : "schedule/6/paragraph/4A/5",
     "number" : "5",
     "title" : null,
     "label" : "P2"
   }, {
     "element" : "P2",
     "id" : "schedule-6-paragraph-4A-6",
-    "href" : "ukpga/2000/8/schedule/6/paragraph/4A/6",
+    "href" : "schedule/6/paragraph/4A/6",
     "number" : "6",
     "title" : null,
     "label" : "P2"
   }, {
     "element" : "P3",
     "id" : "schedule-6-paragraph-4A-6-a",
-    "href" : "ukpga/2000/8/schedule/6/paragraph/4A/6/a",
+    "href" : "schedule/6/paragraph/4A/6/a",
     "number" : "a",
     "title" : null,
     "label" : "P3"
   }, {
     "element" : "P3",
     "id" : "schedule-6-paragraph-4A-6-b",
-    "href" : "ukpga/2000/8/schedule/6/paragraph/4A/6/b",
+    "href" : "schedule/6/paragraph/4A/6/b",
     "number" : "b",
     "title" : null,
     "label" : "P3"
   }, {
     "element" : "P3",
     "id" : "schedule-6-paragraph-4A-6-c",
-    "href" : "ukpga/2000/8/schedule/6/paragraph/4A/6/c",
+    "href" : "schedule/6/paragraph/4A/6/c",
     "number" : "c",
     "title" : null,
     "label" : "P3"
   }, {
     "element" : "P3",
     "id" : "schedule-6-paragraph-4A-6-d",
-    "href" : "ukpga/2000/8/schedule/6/paragraph/4A/6/d",
+    "href" : "schedule/6/paragraph/4A/6/d",
     "number" : "d",
     "title" : null,
     "label" : "P3"
   }, {
     "element" : "P2",
     "id" : "schedule-6-paragraph-4A-7",
-    "href" : "ukpga/2000/8/schedule/6/paragraph/4A/7",
+    "href" : "schedule/6/paragraph/4A/7",
     "number" : "7",
     "title" : null,
     "label" : "P2"

--- a/src/test/resources/ukpga_2000_8_section_91/ukpga-2000-8-section-91-simplified.xml
+++ b/src/test/resources/ukpga_2000_8_section_91/ukpga-2000-8-section-91-simplified.xml
@@ -44,13 +44,15 @@
       <ancestors>
          <ancestor name="Part"
                    id="part-VI"
-                   DocumentURI="http://www.legislation.gov.uk/ukpga/2000/8/part/VI">
+                   DocumentURI="http://www.legislation.gov.uk/ukpga/2000/8/part/VI"
+                   RestrictStartDate="2024-01-30">
             <number>Part VI</number>
             <title>Official Listing</title>
          </ancestor>
          <ancestor name="Pblock"
                    id="part-VI-crossheading-penalties"
-                   DocumentURI="http://www.legislation.gov.uk/ukpga/2000/8/part/VI/crossheading/penalties">
+                   DocumentURI="http://www.legislation.gov.uk/ukpga/2000/8/part/VI/crossheading/penalties"
+                   RestrictStartDate="2024-01-30">
             <title>Penalties</title>
          </ancestor>
          <ancestor name="P1"

--- a/src/test/resources/ukpga_2023_29/ukpga-2023-29-contents-2024-11-01.json
+++ b/src/test/resources/ukpga_2023_29/ukpga-2023-29-contents-2024-11-01.json
@@ -2405,6 +2405,8 @@
       "number" : null,
       "title" : "Introductory Text",
       "ref" : "introduction",
+      "id" : null,
+      "href" : null,
       "extent" : [ "E", "W", "S", "NI" ]
     },
     "body" : [ {
@@ -2412,54 +2414,72 @@
       "number" : "PART 1",
       "title" : "Regulatory framework",
       "ref" : "part-1",
+      "id" : "part-1",
+      "href" : "part/1",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "chapter",
         "number" : "CHAPTER 1",
         "title" : "Revocation of assimilated law",
         "ref" : "part-1-chapter-1",
+        "id" : "part-1-chapter-1",
+        "href" : "part/1/chapter/1",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "1",
           "title" : "Revocation of assimilated law relating to financial services and markets",
           "ref" : "section-1",
+          "id" : "section-1",
+          "href" : "section/1",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "2",
           "title" : "Transitional amendments",
           "ref" : "section-2",
+          "id" : "section-2",
+          "href" : "section/2",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "3",
           "title" : "Power to make further transitional amendments",
           "ref" : "section-3",
+          "id" : "section-3",
+          "href" : "section/3",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "4",
           "title" : "Power to restate and modify saved legislation",
           "ref" : "section-4",
+          "id" : "section-4",
+          "href" : "section/4",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "5",
           "title" : "Power to replace references to EU directives",
           "ref" : "section-5",
+          "id" : "section-5",
+          "href" : "section/5",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "6",
           "title" : "Restatement in rules: exemption from consultation requirements etc",
           "ref" : "section-6",
+          "id" : "section-6",
+          "href" : "section/6",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "7",
           "title" : "Interpretation of Chapter",
           "ref" : "section-7",
+          "id" : "section-7",
+          "href" : "section/7",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -2467,18 +2487,24 @@
         "number" : "CHAPTER 2",
         "title" : "New regulatory powers",
         "ref" : "part-1-chapter-2",
+        "id" : "part-1-chapter-2",
+        "href" : "part/1/chapter/2",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "Designated activities regime",
           "ref" : "part-1-chapter-2-crossheading-designated-activities-regime",
+          "id" : "part-1-chapter-2-crossheading-designated-activities-regime",
+          "href" : "part/1/chapter/2/crossheading/designated-activities-regime",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "8",
             "title" : "Designated activities",
             "ref" : "section-8",
+            "id" : "section-8",
+            "href" : "section/8",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -2486,30 +2512,40 @@
           "number" : null,
           "title" : "Financial market infrastructure: general rules and requirements",
           "ref" : "part-1-chapter-2-crossheading-financial-market-infrastructure-general-rules-and-requirements",
+          "id" : "part-1-chapter-2-crossheading-financial-market-infrastructure-general-rules-and-requirements",
+          "href" : "part/1/chapter/2/crossheading/financial-market-infrastructure-general-rules-and-requirements",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "9",
             "title" : "Rules relating to central counterparties and central securities depositories",
             "ref" : "section-9",
+            "id" : "section-9",
+            "href" : "section/9",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "10",
             "title" : "Central counterparties and central securities depositories: other requirements",
             "ref" : "section-10",
+            "id" : "section-10",
+            "href" : "section/10",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "11",
             "title" : "Rules relating to investment exchanges and data reporting service providers",
             "ref" : "section-11",
+            "id" : "section-11",
+            "href" : "section/11",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "12",
             "title" : "Treasury directions to Bank of England: restrictions",
             "ref" : "section-12",
+            "id" : "section-12",
+            "href" : "section/12",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -2517,36 +2553,48 @@
           "number" : null,
           "title" : "Financial market infrastructure: piloting powers",
           "ref" : "part-1-chapter-2-crossheading-financial-market-infrastructure-piloting-powers",
+          "id" : "part-1-chapter-2-crossheading-financial-market-infrastructure-piloting-powers",
+          "href" : "part/1/chapter/2/crossheading/financial-market-infrastructure-piloting-powers",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "13",
             "title" : "Testing of FMI technologies or practices",
             "ref" : "section-13",
+            "id" : "section-13",
+            "href" : "section/13",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "14",
             "title" : "Reports on FMI sandboxes",
             "ref" : "section-14",
+            "id" : "section-14",
+            "href" : "section/14",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "15",
             "title" : "Permanent implementation of arrangements tested under an FMI sandbox",
             "ref" : "section-15",
+            "id" : "section-15",
+            "href" : "section/15",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "16",
             "title" : "Regulations",
             "ref" : "section-16",
+            "id" : "section-16",
+            "href" : "section/16",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "17",
             "title" : "Interpretation",
             "ref" : "section-17",
+            "id" : "section-17",
+            "href" : "section/17",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -2554,18 +2602,24 @@
           "number" : null,
           "title" : "Powers in relation to critical third parties",
           "ref" : "part-1-chapter-2-crossheading-powers-in-relation-to-critical-third-parties",
+          "id" : "part-1-chapter-2-crossheading-powers-in-relation-to-critical-third-parties",
+          "href" : "part/1/chapter/2/crossheading/powers-in-relation-to-critical-third-parties",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "18",
             "title" : "Critical third parties: designation and powers",
             "ref" : "section-18",
+            "id" : "section-18",
+            "href" : "section/18",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "19",
             "title" : "Critical third parties: related amendments",
             "ref" : "section-19",
+            "id" : "section-19",
+            "href" : "section/19",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -2573,12 +2627,16 @@
           "number" : null,
           "title" : "Financial promotion",
           "ref" : "part-1-chapter-2-crossheading-financial-promotion",
+          "id" : "part-1-chapter-2-crossheading-financial-promotion",
+          "href" : "part/1/chapter/2/crossheading/financial-promotion",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "20",
             "title" : "Financial promotion",
             "ref" : "section-20",
+            "id" : "section-20",
+            "href" : "section/20",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -2586,12 +2644,16 @@
           "number" : null,
           "title" : "Sustainability disclosure requirements",
           "ref" : "part-1-chapter-2-crossheading-sustainability-disclosure-requirements",
+          "id" : "part-1-chapter-2-crossheading-sustainability-disclosure-requirements",
+          "href" : "part/1/chapter/2/crossheading/sustainability-disclosure-requirements",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "21",
             "title" : "Sustainability disclosure requirements",
             "ref" : "section-21",
+            "id" : "section-21",
+            "href" : "section/21",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -2599,18 +2661,24 @@
           "number" : null,
           "title" : "Digital settlement assets",
           "ref" : "part-1-chapter-2-crossheading-digital-settlement-assets",
+          "id" : "part-1-chapter-2-crossheading-digital-settlement-assets",
+          "href" : "part/1/chapter/2/crossheading/digital-settlement-assets",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "22",
             "title" : "Digital settlement assets",
             "ref" : "section-22",
+            "id" : "section-22",
+            "href" : "section/22",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "23",
             "title" : "Digital settlement assets: power to make regulations",
             "ref" : "section-23",
+            "id" : "section-23",
+            "href" : "section/23",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -2618,12 +2686,16 @@
           "number" : null,
           "title" : "Mutual recognition",
           "ref" : "part-1-chapter-2-crossheading-mutual-recognition",
+          "id" : "part-1-chapter-2-crossheading-mutual-recognition",
+          "href" : "part/1/chapter/2/crossheading/mutual-recognition",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "24",
             "title" : "Implementation of mutual recognition agreements",
             "ref" : "section-24",
+            "id" : "section-24",
+            "href" : "section/24",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -2632,36 +2704,48 @@
         "number" : "CHAPTER 3",
         "title" : "Accountability of regulators",
         "ref" : "part-1-chapter-3",
+        "id" : "part-1-chapter-3",
+        "href" : "part/1/chapter/3",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "pblock",
           "number" : null,
           "title" : "FCA and PRA objectives and regulatory principles",
           "ref" : "part-1-chapter-3-crossheading-fca-and-pra-objectives-and-regulatory-principles",
+          "id" : "part-1-chapter-3-crossheading-fca-and-pra-objectives-and-regulatory-principles",
+          "href" : "part/1/chapter/3/crossheading/fca-and-pra-objectives-and-regulatory-principles",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "25",
             "title" : "Competitiveness and growth objective",
             "ref" : "section-25",
+            "id" : "section-25",
+            "href" : "section/25",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "26",
             "title" : "Competitiveness and growth objective: reporting requirements",
             "ref" : "section-26",
+            "id" : "section-26",
+            "href" : "section/26",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "27",
             "title" : "Regulatory principles",
             "ref" : "section-27",
+            "id" : "section-27",
+            "href" : "section/27",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "28",
             "title" : "Sections 25 and 27: consequential amendments",
             "ref" : "section-28",
+            "id" : "section-28",
+            "href" : "section/28",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -2669,42 +2753,56 @@
           "number" : null,
           "title" : "FCA and PRA powers to make rules etc",
           "ref" : "part-1-chapter-3-crossheading-fca-and-pra-powers-to-make-rules-etc",
+          "id" : "part-1-chapter-3-crossheading-fca-and-pra-powers-to-make-rules-etc",
+          "href" : "part/1/chapter/3/crossheading/fca-and-pra-powers-to-make-rules-etc",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "29",
             "title" : "Review of rules",
             "ref" : "section-29",
+            "id" : "section-29",
+            "href" : "section/29",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "30",
             "title" : "Treasury power in relation to rules",
             "ref" : "section-30",
+            "id" : "section-30",
+            "href" : "section/30",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "31",
             "title" : "Matters to consider when making rules",
             "ref" : "section-31",
+            "id" : "section-31",
+            "href" : "section/31",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "32",
             "title" : "Effect of rules etc on deference decisions",
             "ref" : "section-32",
+            "id" : "section-32",
+            "href" : "section/32",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "33",
             "title" : "Effect of rules etc on international trade obligations",
             "ref" : "section-33",
+            "id" : "section-33",
+            "href" : "section/33",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "34",
             "title" : "Power to disapply or modify rules",
             "ref" : "section-34",
+            "id" : "section-34",
+            "href" : "section/34",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -2712,30 +2810,40 @@
           "number" : null,
           "title" : "FCA and PRA engagement",
           "ref" : "part-1-chapter-3-crossheading-fca-and-pra-engagement",
+          "id" : "part-1-chapter-3-crossheading-fca-and-pra-engagement",
+          "href" : "part/1/chapter/3/crossheading/fca-and-pra-engagement",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "35",
             "title" : "Responses to recommendations of the Treasury",
             "ref" : "section-35",
+            "id" : "section-35",
+            "href" : "section/35",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "36",
             "title" : "Public consultation requirements",
             "ref" : "section-36",
+            "id" : "section-36",
+            "href" : "section/36",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "37",
             "title" : "Engagement with statutory panels",
             "ref" : "section-37",
+            "id" : "section-37",
+            "href" : "section/37",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "38",
             "title" : "Engagement with Parliamentary Committees",
             "ref" : "section-38",
+            "id" : "section-38",
+            "href" : "section/38",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -2743,18 +2851,24 @@
           "number" : "39",
           "title" : "Reporting requirements",
           "ref" : "section-39",
+          "id" : "section-39",
+          "href" : "section/39",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "pblock",
           "number" : null,
           "title" : "Co-operation of FCA and others",
           "ref" : "part-1-chapter-3-crossheading-cooperation-of-fca-and-others",
+          "id" : "part-1-chapter-3-crossheading-cooperation-of-fca-and-others",
+          "href" : "part/1/chapter/3/crossheading/cooperation-of-fca-and-others",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "40",
             "title" : "Duty to co-operate and consult in exercising functions",
             "ref" : "section-40",
+            "id" : "section-40",
+            "href" : "section/40",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -2762,48 +2876,64 @@
           "number" : null,
           "title" : "Panels and policy statements",
           "ref" : "part-1-chapter-3-crossheading-panels-and-policy-statements",
+          "id" : "part-1-chapter-3-crossheading-panels-and-policy-statements",
+          "href" : "part/1/chapter/3/crossheading/panels-and-policy-statements",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "41",
             "title" : "Listing Authority Advisory Panel",
             "ref" : "section-41",
+            "id" : "section-41",
+            "href" : "section/41",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "42",
             "title" : "Insurance Practitioner Panel",
             "ref" : "section-42",
+            "id" : "section-42",
+            "href" : "section/42",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "43",
             "title" : "Cost Benefit Analysis Panels",
             "ref" : "section-43",
+            "id" : "section-43",
+            "href" : "section/43",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "44",
             "title" : "Statement of policy on cost benefit analyses",
             "ref" : "section-44",
+            "id" : "section-44",
+            "href" : "section/44",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "45",
             "title" : "Statement of policy on panel appointments",
             "ref" : "section-45",
+            "id" : "section-45",
+            "href" : "section/45",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "46",
             "title" : "Composition of panels",
             "ref" : "section-46",
+            "id" : "section-46",
+            "href" : "section/46",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "47",
             "title" : "Panel reports",
             "ref" : "section-47",
+            "id" : "section-47",
+            "href" : "section/47",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -2811,24 +2941,32 @@
           "number" : null,
           "title" : "Bank of England regulatory powers",
           "ref" : "part-1-chapter-3-crossheading-bank-of-england-regulatory-powers",
+          "id" : "part-1-chapter-3-crossheading-bank-of-england-regulatory-powers",
+          "href" : "part/1/chapter/3/crossheading/bank-of-england-regulatory-powers",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "48",
             "title" : "Exercise of FMI regulatory powers",
             "ref" : "section-48",
+            "id" : "section-48",
+            "href" : "section/48",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "49",
             "title" : "Bank of England: rule-making powers",
             "ref" : "section-49",
+            "id" : "section-49",
+            "href" : "section/49",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "50",
             "title" : "Application of FSMA 2000 to FMI functions",
             "ref" : "section-50",
+            "id" : "section-50",
+            "href" : "section/50",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -2836,18 +2974,24 @@
           "number" : null,
           "title" : "Payment Systems Regulator",
           "ref" : "part-1-chapter-3-crossheading-payment-systems-regulator",
+          "id" : "part-1-chapter-3-crossheading-payment-systems-regulator",
+          "href" : "part/1/chapter/3/crossheading/payment-systems-regulator",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "51",
             "title" : "Payment Systems Regulator",
             "ref" : "section-51",
+            "id" : "section-51",
+            "href" : "section/51",
             "extent" : [ "E", "W", "S", "NI" ]
           }, {
             "name" : "item",
             "number" : "52",
             "title" : "Chair of the Payment Systems Regulator as member of FCA Board",
             "ref" : "section-52",
+            "id" : "section-52",
+            "href" : "section/52",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         }, {
@@ -2855,12 +2999,16 @@
           "number" : null,
           "title" : "Consultation on rules",
           "ref" : "part-1-chapter-3-crossheading-consultation-on-rules",
+          "id" : "part-1-chapter-3-crossheading-consultation-on-rules",
+          "href" : "part/1/chapter/3/crossheading/consultation-on-rules",
           "extent" : [ "E", "W", "S", "NI" ],
           "children" : [ {
             "name" : "item",
             "number" : "53",
             "title" : "Consultation on rules",
             "ref" : "section-53",
+            "id" : "section-53",
+            "href" : "section/53",
             "extent" : [ "E", "W", "S", "NI" ]
           } ]
         } ]
@@ -2870,18 +3018,24 @@
       "number" : "PART 2",
       "title" : "Access to cash",
       "ref" : "part-2",
+      "id" : "part-2",
+      "href" : "part/2",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "54",
         "title" : "Cash access services",
         "ref" : "section-54",
+        "id" : "section-54",
+        "href" : "section/54",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "55",
         "title" : "Wholesale cash distribution",
         "ref" : "section-55",
+        "id" : "section-55",
+        "href" : "section/55",
         "extent" : [ "E", "W", "S", "NI" ]
       } ]
     }, {
@@ -2889,12 +3043,16 @@
       "number" : "PART 3",
       "title" : "Performance of functions relating to financial market infrastructure",
       "ref" : "part-3",
+      "id" : "part-3",
+      "href" : "part/3",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "56",
         "title" : "Recognised bodies: senior managers and certification",
         "ref" : "section-56",
+        "id" : "section-56",
+        "href" : "section/56",
         "extent" : [ "E", "W", "S", "NI" ]
       } ]
     }, {
@@ -2902,12 +3060,16 @@
       "number" : "PART 4",
       "title" : "Central counterparties in financial difficulties",
       "ref" : "part-4",
+      "id" : "part-4",
+      "href" : "part/4",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "57",
         "title" : "Central counterparties in financial difficulties",
         "ref" : "section-57",
+        "id" : "section-57",
+        "href" : "section/57",
         "extent" : [ "E", "W", "S", "NI" ]
       } ]
     }, {
@@ -2915,12 +3077,16 @@
       "number" : "PART 5",
       "title" : "Insurers in financial difficulties",
       "ref" : "part-5",
+      "id" : "part-5",
+      "href" : "part/5",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "58",
         "title" : "Insurers in financial difficulties",
         "ref" : "section-58",
+        "id" : "section-58",
+        "href" : "section/58",
         "extent" : [ "E", "W", "S", "NI" ]
       } ]
     }, {
@@ -2928,78 +3094,104 @@
       "number" : "PART 6",
       "title" : "Miscellaneous",
       "ref" : "part-6",
+      "id" : "part-6",
+      "href" : "part/6",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "pblock",
         "number" : null,
         "title" : "Amendments to FSMA 2000",
         "ref" : "part-6-crossheading-amendments-to-fsma-2000",
+        "id" : "part-6-crossheading-amendments-to-fsma-2000",
+        "href" : "part/6/crossheading/amendments-to-fsma-2000",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "59",
           "title" : "Application of provisions to regulatory functions under this Act",
           "ref" : "section-59",
+          "id" : "section-59",
+          "href" : "section/59",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "60",
           "title" : "Formerly authorised persons",
           "ref" : "section-60",
+          "id" : "section-60",
+          "href" : "section/60",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "61",
           "title" : "Control over authorised persons",
           "ref" : "section-61",
+          "id" : "section-61",
+          "href" : "section/61",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "62",
           "title" : "Financial services compensation scheme",
           "ref" : "section-62",
+          "id" : "section-62",
+          "href" : "section/62",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "63",
           "title" : "The Ombudsman scheme",
           "ref" : "section-63",
+          "id" : "section-63",
+          "href" : "section/63",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "64",
           "title" : "Unauthorised co-ownership AIFs",
           "ref" : "section-64",
+          "id" : "section-64",
+          "href" : "section/64",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "65",
           "title" : "Power to amend enactments in consequence of rules",
           "ref" : "section-65",
+          "id" : "section-65",
+          "href" : "section/65",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "66",
           "title" : "Ambulatory references",
           "ref" : "section-66",
+          "id" : "section-66",
+          "href" : "section/66",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "67",
           "title" : "Power to amend or repeal certain provisions of FSMA 2000",
           "ref" : "section-67",
+          "id" : "section-67",
+          "href" : "section/67",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "68",
           "title" : "Power under FSMA 2000 to make transitional provisions",
           "ref" : "section-68",
+          "id" : "section-68",
+          "href" : "section/68",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "69",
           "title" : "Cryptoassets",
           "ref" : "section-69",
+          "id" : "section-69",
+          "href" : "section/69",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -3007,18 +3199,24 @@
         "number" : null,
         "title" : "Bank of England levy",
         "ref" : "part-6-crossheading-bank-of-england-levy",
+        "id" : "part-6-crossheading-bank-of-england-levy",
+        "href" : "part/6/crossheading/bank-of-england-levy",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "70",
           "title" : "Bank of England levy",
           "ref" : "section-70",
+          "id" : "section-70",
+          "href" : "section/70",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "71",
           "title" : "Bank of England levy: consequential amendments",
           "ref" : "section-71",
+          "id" : "section-71",
+          "href" : "section/71",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -3026,54 +3224,72 @@
         "number" : null,
         "title" : "Other miscellaneous provisions",
         "ref" : "part-6-crossheading-other-miscellaneous-provisions",
+        "id" : "part-6-crossheading-other-miscellaneous-provisions",
+        "href" : "part/6/crossheading/other-miscellaneous-provisions",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "72",
           "title" : "Liability of payment service providers for fraudulent transactions",
           "ref" : "section-72",
+          "id" : "section-72",
+          "href" : "section/72",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "73",
           "title" : "Credit unions",
           "ref" : "section-73",
+          "id" : "section-73",
+          "href" : "section/73",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "74",
           "title" : "Reinsurance for acts of terrorism",
           "ref" : "section-74",
+          "id" : "section-74",
+          "href" : "section/74",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "75",
           "title" : "Banking Act 2009: miscellaneous amendments",
           "ref" : "section-75",
+          "id" : "section-75",
+          "href" : "section/75",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "76",
           "title" : "Arrangements for the investigation of complaints",
           "ref" : "section-76",
+          "id" : "section-76",
+          "href" : "section/76",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "77",
           "title" : "Politically exposed persons: money laundering and terrorist financing",
           "ref" : "section-77",
+          "id" : "section-77",
+          "href" : "section/77",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "78",
           "title" : "Politically exposed persons: review of guidance",
           "ref" : "section-78",
+          "id" : "section-78",
+          "href" : "section/78",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "79",
           "title" : "Forest risk commodities: review",
           "ref" : "section-79",
+          "id" : "section-79",
+          "href" : "section/79",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -3082,54 +3298,72 @@
       "number" : "PART 7",
       "title" : "General",
       "ref" : "part-7",
+      "id" : "part-7",
+      "href" : "part/7",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "80",
         "title" : "Interpretation",
         "ref" : "section-80",
+        "id" : "section-80",
+        "href" : "section/80",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "81",
         "title" : "Pre-commencement consultation",
         "ref" : "section-81",
+        "id" : "section-81",
+        "href" : "section/81",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "82",
         "title" : "Financial provision",
         "ref" : "section-82",
+        "id" : "section-82",
+        "href" : "section/82",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "83",
         "title" : "Power to make consequential provision",
         "ref" : "section-83",
+        "id" : "section-83",
+        "href" : "section/83",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "84",
         "title" : "Regulations",
         "ref" : "section-84",
+        "id" : "section-84",
+        "href" : "section/84",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "85",
         "title" : "Extent",
         "ref" : "section-85",
+        "id" : "section-85",
+        "href" : "section/85",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "86",
         "title" : "Commencement",
         "ref" : "section-86",
+        "id" : "section-86",
+        "href" : "section/86",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "87",
         "title" : "Short title",
         "ref" : "section-87",
+        "id" : "section-87",
+        "href" : "section/87",
         "extent" : [ "E", "W", "S", "NI" ]
       } ]
     } ],
@@ -3138,36 +3372,48 @@
       "number" : "SCHEDULE 1",
       "title" : "Revocation of assimilated law relating to financial services",
       "ref" : "schedule-1",
+      "id" : "schedule-1",
+      "href" : "schedule/1",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "part",
         "number" : "PART 1",
         "title" : "Assimilated direct principal legislation",
         "ref" : "schedule-1-part-1",
+        "id" : "schedule-1-part-1",
+        "href" : "schedule/1/part/1",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "part",
         "number" : "PART 2",
         "title" : "Subordinate legislation",
         "ref" : "schedule-1-part-2",
+        "id" : "schedule-1-part-2",
+        "href" : "schedule/1/part/2",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "part",
         "number" : "PART 3",
         "title" : "EU tertiary legislation etc",
         "ref" : "schedule-1-part-3",
+        "id" : "schedule-1-part-3",
+        "href" : "schedule/1/part/3",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "part",
         "number" : "PART 4",
         "title" : "Primary legislation",
         "ref" : "schedule-1-part-4",
+        "id" : "schedule-1-part-4",
+        "href" : "schedule/1/part/4",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "part",
         "number" : "PART 5",
         "title" : "Other EU-derived legislation",
         "ref" : "schedule-1-part-5",
+        "id" : "schedule-1-part-5",
+        "href" : "schedule/1/part/5",
         "extent" : [ "E", "W", "S", "NI" ]
       } ]
     }, {
@@ -3175,174 +3421,232 @@
       "number" : "SCHEDULE 2",
       "title" : "Transitional amendments",
       "ref" : "schedule-2",
+      "id" : "schedule-2",
+      "href" : "schedule/2",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "part",
         "number" : "PART 1",
         "title" : "Amendments to the Markets in Financial Instruments Regulation",
         "ref" : "schedule-2-part-1",
+        "id" : "schedule-2-part-1",
+        "href" : "schedule/2/part/1",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "1",
           "title" : "Introductory",
           "ref" : "schedule-2-paragraph-1",
+          "id" : "schedule-2-paragraph-1",
+          "href" : "schedule/2/paragraph/1",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "2",
           "title" : "Transparency requirements for equities",
           "ref" : "schedule-2-paragraph-2",
+          "id" : "schedule-2-paragraph-2",
+          "href" : "schedule/2/paragraph/2",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "3",
           "title" : "For Article 4 substitute— Article 4 Waivers for equity instruments...",
           "ref" : "schedule-2-paragraph-3",
+          "id" : "schedule-2-paragraph-3",
+          "href" : "schedule/2/paragraph/3",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "4",
           "title" : "After Article 4 insert— Article 4a Suspension of waivers The FCA may direct that a waiver provided for by...",
           "ref" : "schedule-2-paragraph-4",
+          "id" : "schedule-2-paragraph-4",
+          "href" : "schedule/2/paragraph/4",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "5",
           "title" : "Omit Article 5 (volume cap mechanism). ",
           "ref" : "schedule-2-paragraph-5",
+          "id" : "schedule-2-paragraph-5",
+          "href" : "schedule/2/paragraph/5",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "6",
           "title" : "(1) Article 14 (obligation for systematic internalisers to make public...",
           "ref" : "schedule-2-paragraph-6",
+          "id" : "schedule-2-paragraph-6",
+          "href" : "schedule/2/paragraph/6",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "7",
           "title" : "Transparency requirements for fixed income instruments and derivatives etc",
           "ref" : "schedule-2-paragraph-7",
+          "id" : "schedule-2-paragraph-7",
+          "href" : "schedule/2/paragraph/7",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "8",
           "title" : "Systematic internalisers and other investment firms",
           "ref" : "schedule-2-paragraph-8",
+          "id" : "schedule-2-paragraph-8",
+          "href" : "schedule/2/paragraph/8",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "9",
           "title" : "In Article 17a (tick sizes), in the second paragraph, omit...",
           "ref" : "schedule-2-paragraph-9",
+          "id" : "schedule-2-paragraph-9",
+          "href" : "schedule/2/paragraph/9",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "10",
           "title" : "For Article 18 substitute— Article 18 Systematic internalisers: pre-trade transparency...",
           "ref" : "schedule-2-paragraph-10",
+          "id" : "schedule-2-paragraph-10",
+          "href" : "schedule/2/paragraph/10",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "11",
           "title" : "For Article 21 substitute— Article 21 Investment firms (including systematic...",
           "ref" : "schedule-2-paragraph-11",
+          "id" : "schedule-2-paragraph-11",
+          "href" : "schedule/2/paragraph/11",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "12",
           "title" : "Systematic internalisers and other investment firms",
           "ref" : "schedule-2-paragraph-12",
+          "id" : "schedule-2-paragraph-12",
+          "href" : "schedule/2/paragraph/12",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "13",
           "title" : "Share trading obligation",
           "ref" : "schedule-2-paragraph-13",
+          "id" : "schedule-2-paragraph-13",
+          "href" : "schedule/2/paragraph/13",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "14",
           "title" : "In Article 1(2E), omit “Article 23,”. ",
           "ref" : "schedule-2-paragraph-14",
+          "id" : "schedule-2-paragraph-14",
+          "href" : "schedule/2/paragraph/14",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "15",
           "title" : "Derivatives trading obligation",
           "ref" : "schedule-2-paragraph-15",
+          "id" : "schedule-2-paragraph-15",
+          "href" : "schedule/2/paragraph/15",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "16",
           "title" : "(1) Article 28 (obligation to trade on regulated markets, MTFs...",
           "ref" : "schedule-2-paragraph-16",
+          "id" : "schedule-2-paragraph-16",
+          "href" : "schedule/2/paragraph/16",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "17",
           "title" : "After Article 28 insert— Article 28a Suspension or modification of...",
           "ref" : "schedule-2-paragraph-17",
+          "id" : "schedule-2-paragraph-17",
+          "href" : "schedule/2/paragraph/17",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "18",
           "title" : "For Article 31 substitute— Article 31 Risk reduction services The FCA may by rules provide for one or more...",
           "ref" : "schedule-2-paragraph-18",
+          "id" : "schedule-2-paragraph-18",
+          "href" : "schedule/2/paragraph/18",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "19",
           "title" : "Consequential amendments relating to this Part",
           "ref" : "schedule-2-paragraph-19",
+          "id" : "schedule-2-paragraph-19",
+          "href" : "schedule/2/paragraph/19",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "20",
           "title" : "In Article 12(1) after “accordance with” insert “, or with...",
           "ref" : "schedule-2-paragraph-20",
+          "id" : "schedule-2-paragraph-20",
+          "href" : "schedule/2/paragraph/20",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "21",
           "title" : "In Article 13(1) after “accordance with” insert “, or with...",
           "ref" : "schedule-2-paragraph-21",
+          "id" : "schedule-2-paragraph-21",
+          "href" : "schedule/2/paragraph/21",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "22",
           "title" : "Omit Article 19. ",
           "ref" : "schedule-2-paragraph-22",
+          "id" : "schedule-2-paragraph-22",
+          "href" : "schedule/2/paragraph/22",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "23",
           "title" : "In Article 26(3), omit “and Article 21(5)(a)”. ",
           "ref" : "schedule-2-paragraph-23",
+          "id" : "schedule-2-paragraph-23",
+          "href" : "schedule/2/paragraph/23",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "24",
           "title" : "In Article 47(1A)(a), after “Regulation” insert “or in rules made...",
           "ref" : "schedule-2-paragraph-24",
+          "id" : "schedule-2-paragraph-24",
+          "href" : "schedule/2/paragraph/24",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "25",
           "title" : "In Article 50B (FCA directions), omit “Article 5, Article 9...",
           "ref" : "schedule-2-paragraph-25",
+          "id" : "schedule-2-paragraph-25",
+          "href" : "schedule/2/paragraph/25",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "26",
           "title" : "(1) Article 50C (other FCA directions) is amended as follows....",
           "ref" : "schedule-2-paragraph-26",
+          "id" : "schedule-2-paragraph-26",
+          "href" : "schedule/2/paragraph/26",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "27",
           "title" : "(1) Article 50D (FCA rules) is amended as follows. ",
           "ref" : "schedule-2-paragraph-27",
+          "id" : "schedule-2-paragraph-27",
+          "href" : "schedule/2/paragraph/27",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -3350,24 +3654,32 @@
         "number" : "PART 2",
         "title" : "Amendments to the European Market Infrastructure Regulation",
         "ref" : "schedule-2-part-2",
+        "id" : "schedule-2-part-2",
+        "href" : "schedule/2/part/2",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "28",
           "title" : "Regulation (EU) No 648/2012 on OTC derivatives, central counterparties and...",
           "ref" : "schedule-2-paragraph-28",
+          "id" : "schedule-2-paragraph-28",
+          "href" : "schedule/2/paragraph/28",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "29",
           "title" : "After Article 6a insert— Article 6b Risk reduction services The Bank of England may by rules provide for the...",
           "ref" : "schedule-2-paragraph-29",
+          "id" : "schedule-2-paragraph-29",
+          "href" : "schedule/2/paragraph/29",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "30",
           "title" : "After Article 84b insert— Article 84c Bank of England rules...",
           "ref" : "schedule-2-paragraph-30",
+          "id" : "schedule-2-paragraph-30",
+          "href" : "schedule/2/paragraph/30",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -3375,84 +3687,112 @@
         "number" : "PART 3",
         "title" : "Amendments to the EU Securitisation Regulation",
         "ref" : "schedule-2-part-3",
+        "id" : "schedule-2-part-3",
+        "href" : "schedule/2/part/3",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "31",
           "title" : "Introductory",
           "ref" : "schedule-2-paragraph-31",
+          "id" : "schedule-2-paragraph-31",
+          "href" : "schedule/2/paragraph/31",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "32",
           "title" : "STS equivalent non-UK securitisations",
           "ref" : "schedule-2-paragraph-32",
+          "id" : "schedule-2-paragraph-32",
+          "href" : "schedule/2/paragraph/32",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "33",
           "title" : "After Article 28 (third party verifying STS compliance) insert— CHAPTER...",
           "ref" : "schedule-2-paragraph-33",
+          "id" : "schedule-2-paragraph-33",
+          "href" : "schedule/2/paragraph/33",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "34",
           "title" : "Minor and consequential amendments",
           "ref" : "schedule-2-paragraph-34",
+          "id" : "schedule-2-paragraph-34",
+          "href" : "schedule/2/paragraph/34",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "35",
           "title" : "In Article 4 (requirements for securitisation special purpose entities)— ",
           "ref" : "schedule-2-paragraph-35",
+          "id" : "schedule-2-paragraph-35",
+          "href" : "schedule/2/paragraph/35",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "36",
           "title" : "(1) Article 5 (due-diligence requirements for institutional investors) is amended...",
           "ref" : "schedule-2-paragraph-36",
+          "id" : "schedule-2-paragraph-36",
+          "href" : "schedule/2/paragraph/36",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "37",
           "title" : "(1) Article 46 (Treasury review) is amended as follows. ",
           "ref" : "schedule-2-paragraph-37",
+          "id" : "schedule-2-paragraph-37",
+          "href" : "schedule/2/paragraph/37",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "38",
           "title" : "In Regulation (EU) No 575/2013 of the European Parliament and...",
           "ref" : "schedule-2-paragraph-38",
+          "id" : "schedule-2-paragraph-38",
+          "href" : "schedule/2/paragraph/38",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "39",
           "title" : "In Commission Delegated Regulation (EU) 2015/35 of 10 October 2014...",
           "ref" : "schedule-2-paragraph-39",
+          "id" : "schedule-2-paragraph-39",
+          "href" : "schedule/2/paragraph/39",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "40",
           "title" : "In Article 11(1) of Regulation (EU) 2017/1131 of the European...",
           "ref" : "schedule-2-paragraph-40",
+          "id" : "schedule-2-paragraph-40",
+          "href" : "schedule/2/paragraph/40",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "41",
           "title" : "The Securitisation Regulations 2018 (S.I. 2018/1288) are amended in accordance...",
           "ref" : "schedule-2-paragraph-41",
+          "id" : "schedule-2-paragraph-41",
+          "href" : "schedule/2/paragraph/41",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "42",
           "title" : "In regulation 2 (interpretation), in the definition of “SRUP”, in...",
           "ref" : "schedule-2-paragraph-42",
+          "id" : "schedule-2-paragraph-42",
+          "href" : "schedule/2/paragraph/42",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "43",
           "title" : "In regulation 4 (designation of competent authorities), in paragraph (1)(b),...",
           "ref" : "schedule-2-paragraph-43",
+          "id" : "schedule-2-paragraph-43",
+          "href" : "schedule/2/paragraph/43",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -3460,48 +3800,64 @@
         "number" : "PART 4",
         "title" : "Amendments to the Financial Services and Markets Act 2000 (Markets in Financial Instruments) Regulations 2017",
         "ref" : "schedule-2-part-4",
+        "id" : "schedule-2-part-4",
+        "href" : "schedule/2/part/4",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "44",
           "title" : "Introductory",
           "ref" : "schedule-2-paragraph-44",
+          "id" : "schedule-2-paragraph-44",
+          "href" : "schedule/2/paragraph/44",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "45",
           "title" : "Position limits for commodity derivatives",
           "ref" : "schedule-2-paragraph-45",
+          "id" : "schedule-2-paragraph-45",
+          "href" : "schedule/2/paragraph/45",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "46",
           "title" : "(1) Regulation 16 (FCA duty to establish position limits) is...",
           "ref" : "schedule-2-paragraph-46",
+          "id" : "schedule-2-paragraph-46",
+          "href" : "schedule/2/paragraph/46",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "47",
           "title" : "(1) Regulation 27 (FCA power to require information) is amended...",
           "ref" : "schedule-2-paragraph-47",
+          "id" : "schedule-2-paragraph-47",
+          "href" : "schedule/2/paragraph/47",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "48",
           "title" : "(1) Regulation 28 (FCA power to intervene) is amended as...",
           "ref" : "schedule-2-paragraph-48",
+          "id" : "schedule-2-paragraph-48",
+          "href" : "schedule/2/paragraph/48",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "49",
           "title" : "In regulation 29 (interpretation of Part 3), in paragraph (2)—...",
           "ref" : "schedule-2-paragraph-49",
+          "id" : "schedule-2-paragraph-49",
+          "href" : "schedule/2/paragraph/49",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "50",
           "title" : "Consequential revocations relating to this Part",
           "ref" : "schedule-2-paragraph-50",
+          "id" : "schedule-2-paragraph-50",
+          "href" : "schedule/2/paragraph/50",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -3509,12 +3865,16 @@
         "number" : "PART 5",
         "title" : "Amendments to the Central Counterparties (Amendment, etc., and Transitional Provision) (EU Exit) Regulations 2018",
         "ref" : "schedule-2-part-5",
+        "id" : "schedule-2-part-5",
+        "href" : "schedule/2/part/5",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "51",
           "title" : "(1) Regulation 19B of the Central Counterparties (Amendment, etc., and...",
           "ref" : "schedule-2-paragraph-51",
+          "id" : "schedule-2-paragraph-51",
+          "href" : "schedule/2/paragraph/51",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -3522,132 +3882,176 @@
         "number" : "PART 6",
         "title" : "Amendments relating to critical third parties",
         "ref" : "schedule-2-part-6",
+        "id" : "schedule-2-part-6",
+        "href" : "schedule/2/part/6",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "52",
           "title" : "The Electronic Money Regulations 2011 (S.I. 2011/99) are amended in...",
           "ref" : "schedule-2-paragraph-52",
+          "id" : "schedule-2-paragraph-52",
+          "href" : "schedule/2/paragraph/52",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "53",
           "title" : "In regulation 48 (monitoring and enforcement), after paragraph (1)(a) insert—...",
           "ref" : "schedule-2-paragraph-53",
+          "id" : "schedule-2-paragraph-53",
+          "href" : "schedule/2/paragraph/53",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "54",
           "title" : "In regulation 49 (reporting requirements), after paragraph (1) insert— ",
           "ref" : "schedule-2-paragraph-54",
+          "id" : "schedule-2-paragraph-54",
+          "href" : "schedule/2/paragraph/54",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "55",
           "title" : "In regulation 50 (public censure), after “Regulations” insert “or, in...",
           "ref" : "schedule-2-paragraph-55",
+          "id" : "schedule-2-paragraph-55",
+          "href" : "schedule/2/paragraph/55",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "56",
           "title" : "In regulation 51 (financial penalties)— (a) omit “or” at the...",
           "ref" : "schedule-2-paragraph-56",
+          "id" : "schedule-2-paragraph-56",
+          "href" : "schedule/2/paragraph/56",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "57",
           "title" : "In regulation 52 (suspending authorisation etc), in paragraph (1) after...",
           "ref" : "schedule-2-paragraph-57",
+          "id" : "schedule-2-paragraph-57",
+          "href" : "schedule/2/paragraph/57",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "58",
           "title" : "In regulation 54 (injunctions)— (a) omit “or” at the end...",
           "ref" : "schedule-2-paragraph-58",
+          "id" : "schedule-2-paragraph-58",
+          "href" : "schedule/2/paragraph/58",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "59",
           "title" : "In regulation 55 (power to require restitution), in paragraph (1)...",
           "ref" : "schedule-2-paragraph-59",
+          "id" : "schedule-2-paragraph-59",
+          "href" : "schedule/2/paragraph/59",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "60",
           "title" : "In regulation 57 (restitution orders), in paragraph (1) after “requirement,”...",
           "ref" : "schedule-2-paragraph-60",
+          "id" : "schedule-2-paragraph-60",
+          "href" : "schedule/2/paragraph/60",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "61",
           "title" : "In regulation 58 (complaints), in paragraph (1)— ",
           "ref" : "schedule-2-paragraph-61",
+          "id" : "schedule-2-paragraph-61",
+          "href" : "schedule/2/paragraph/61",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "62",
           "title" : "In Schedule 3 (application and modification of legislation)— ",
           "ref" : "schedule-2-paragraph-62",
+          "id" : "schedule-2-paragraph-62",
+          "href" : "schedule/2/paragraph/62",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "63",
           "title" : "The Payment Services Regulations 2017 (S.I. 2017/752) are amended in...",
           "ref" : "schedule-2-paragraph-63",
+          "id" : "schedule-2-paragraph-63",
+          "href" : "schedule/2/paragraph/63",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "64",
           "title" : "In regulation 108 (monitoring and enforcement), after paragraph (1)(a) insert—...",
           "ref" : "schedule-2-paragraph-64",
+          "id" : "schedule-2-paragraph-64",
+          "href" : "schedule/2/paragraph/64",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "65",
           "title" : "In regulation 109 (reporting requirements), after paragraph (1) insert— ",
           "ref" : "schedule-2-paragraph-65",
+          "id" : "schedule-2-paragraph-65",
+          "href" : "schedule/2/paragraph/65",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "66",
           "title" : "In regulation 110 (public censure), after “Regulations” insert “or, in...",
           "ref" : "schedule-2-paragraph-66",
+          "id" : "schedule-2-paragraph-66",
+          "href" : "schedule/2/paragraph/66",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "67",
           "title" : "In regulation 111 (financial penalties)— (a) omit “or” at the...",
           "ref" : "schedule-2-paragraph-67",
+          "id" : "schedule-2-paragraph-67",
+          "href" : "schedule/2/paragraph/67",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "68",
           "title" : "In regulation 113 (injunctions)— (a) omit “or” at the end...",
           "ref" : "schedule-2-paragraph-68",
+          "id" : "schedule-2-paragraph-68",
+          "href" : "schedule/2/paragraph/68",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "69",
           "title" : "In regulation 114 (power to require restitution), in paragraph (1)...",
           "ref" : "schedule-2-paragraph-69",
+          "id" : "schedule-2-paragraph-69",
+          "href" : "schedule/2/paragraph/69",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "70",
           "title" : "In regulation 116 (restitution orders), in paragraph (1) after “requirement,”...",
           "ref" : "schedule-2-paragraph-70",
+          "id" : "schedule-2-paragraph-70",
+          "href" : "schedule/2/paragraph/70",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "71",
           "title" : "In regulation 117 (complaints), in paragraph (1)— ",
           "ref" : "schedule-2-paragraph-71",
+          "id" : "schedule-2-paragraph-71",
+          "href" : "schedule/2/paragraph/71",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "72",
           "title" : "In Schedule 6 (application and modification of legislation)— ",
           "ref" : "schedule-2-paragraph-72",
+          "id" : "schedule-2-paragraph-72",
+          "href" : "schedule/2/paragraph/72",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -3656,66 +4060,88 @@
       "number" : "SCHEDULE 3",
       "title" : "New Schedule 6B to FSMA 2000",
       "ref" : "schedule-3",
+      "id" : "schedule-3",
+      "href" : "schedule/3",
       "extent" : [ "E", "W", "S", "NI" ]
     }, {
       "name" : "schedule",
       "number" : "SCHEDULE 4",
       "title" : "FMI Sandboxes",
       "ref" : "schedule-4",
+      "id" : "schedule-4",
+      "href" : "schedule/4",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "1",
         "title" : "Participation",
         "ref" : "schedule-4-paragraph-1",
+        "id" : "schedule-4-paragraph-1",
+        "href" : "schedule/4/paragraph/1",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "2",
         "title" : "Technology",
         "ref" : "schedule-4-paragraph-2",
+        "id" : "schedule-4-paragraph-2",
+        "href" : "schedule/4/paragraph/2",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "3",
         "title" : "Practices",
         "ref" : "schedule-4-paragraph-3",
+        "id" : "schedule-4-paragraph-3",
+        "href" : "schedule/4/paragraph/3",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "4",
         "title" : "Financial instruments",
         "ref" : "schedule-4-paragraph-4",
+        "id" : "schedule-4-paragraph-4",
+        "href" : "schedule/4/paragraph/4",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "5",
         "title" : "Settlement of payments",
         "ref" : "schedule-4-paragraph-5",
+        "id" : "schedule-4-paragraph-5",
+        "href" : "schedule/4/paragraph/5",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "6",
         "title" : "Requirements",
         "ref" : "schedule-4-paragraph-6",
+        "id" : "schedule-4-paragraph-6",
+        "href" : "schedule/4/paragraph/6",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "7",
         "title" : "Cooperation",
         "ref" : "schedule-4-paragraph-7",
+        "id" : "schedule-4-paragraph-7",
+        "href" : "schedule/4/paragraph/7",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "8",
         "title" : "Transparency and reporting",
         "ref" : "schedule-4-paragraph-8",
+        "id" : "schedule-4-paragraph-8",
+        "href" : "schedule/4/paragraph/8",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "9",
         "title" : "Enforcement",
         "ref" : "schedule-4-paragraph-9",
+        "id" : "schedule-4-paragraph-9",
+        "href" : "schedule/4/paragraph/9",
         "extent" : [ "E", "W", "S", "NI" ]
       } ]
     }, {
@@ -3723,78 +4149,104 @@
       "number" : "SCHEDULE 5",
       "title" : "Financial promotion: related amendments",
       "ref" : "schedule-5",
+      "id" : "schedule-5",
+      "href" : "schedule/5",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "1",
         "title" : "FSMA 2000 is amended as follows. ",
         "ref" : "schedule-5-paragraph-1",
+        "id" : "schedule-5-paragraph-1",
+        "href" : "schedule/5/paragraph/1",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "2",
         "title" : "In section 1H (further interpretative provisions for sections 1B to...",
         "ref" : "schedule-5-paragraph-2",
+        "id" : "schedule-5-paragraph-2",
+        "href" : "schedule/5/paragraph/2",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "3",
         "title" : "In section 25 (contravention of section 21), in subsection (2)(a)...",
         "ref" : "schedule-5-paragraph-3",
+        "id" : "schedule-5-paragraph-3",
+        "href" : "schedule/5/paragraph/3",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "4",
         "title" : "In section 55A (application for permission), after subsection (5) insert—...",
         "ref" : "schedule-5-paragraph-4",
+        "id" : "schedule-5-paragraph-4",
+        "href" : "schedule/5/paragraph/4",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "5",
         "title" : "(1) Section 55O (imposition of requirements on acquisition of control)...",
         "ref" : "schedule-5-paragraph-5",
+        "id" : "schedule-5-paragraph-5",
+        "href" : "schedule/5/paragraph/5",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "6",
         "title" : "In section 55R (persons connected with an applicant), in subsection...",
         "ref" : "schedule-5-paragraph-6",
+        "id" : "schedule-5-paragraph-6",
+        "href" : "schedule/5/paragraph/6",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "7",
         "title" : "In section 55U (applications under Part 4A), after subsection (3)...",
         "ref" : "schedule-5-paragraph-7",
+        "id" : "schedule-5-paragraph-7",
+        "href" : "schedule/5/paragraph/7",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "8",
         "title" : "In section 55V (determination of applications), in subsection (5)— ",
         "ref" : "schedule-5-paragraph-8",
+        "id" : "schedule-5-paragraph-8",
+        "href" : "schedule/5/paragraph/8",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "9",
         "title" : "(1) Section 55X (determination of applications: warning notices and decision...",
         "ref" : "schedule-5-paragraph-9",
+        "id" : "schedule-5-paragraph-9",
+        "href" : "schedule/5/paragraph/9",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "10",
         "title" : "(1) Section 55Y (exercise of own-initiative power: procedure) is amended...",
         "ref" : "schedule-5-paragraph-10",
+        "id" : "schedule-5-paragraph-10",
+        "href" : "schedule/5/paragraph/10",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "11",
         "title" : "(1) Section 55Z (cancellation of Part 4A permission: procedure) is...",
         "ref" : "schedule-5-paragraph-11",
+        "id" : "schedule-5-paragraph-11",
+        "href" : "schedule/5/paragraph/11",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "12",
         "title" : "In section 55Z3 (right to refer matters to the Tribunal),...",
         "ref" : "schedule-5-paragraph-12",
+        "id" : "schedule-5-paragraph-12",
+        "href" : "schedule/5/paragraph/12",
         "extent" : [ "E", "W", "S", "NI" ]
       } ]
     }, {
@@ -3802,246 +4254,328 @@
       "number" : "SCHEDULE 6",
       "title" : "Digital settlement assets",
       "ref" : "schedule-6",
+      "id" : "schedule-6",
+      "href" : "schedule/6",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "part",
         "number" : "PART 1",
         "title" : "Amendments to the Banking Act 2009",
         "ref" : "schedule-6-part-1",
+        "id" : "schedule-6-part-1",
+        "href" : "schedule/6/part/1",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "1",
           "title" : "The Banking Act 2009 is amended as follows. ",
           "ref" : "schedule-6-paragraph-1",
+          "id" : "schedule-6-paragraph-1",
+          "href" : "schedule/6/paragraph/1",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "2",
           "title" : "In the heading to Part 5 (payment systems), after “systems”...",
           "ref" : "schedule-6-paragraph-2",
+          "id" : "schedule-6-paragraph-2",
+          "href" : "schedule/6/paragraph/2",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "3",
           "title" : "In section 181 (overview), after “services” insert “, including”. ",
           "ref" : "schedule-6-paragraph-3",
+          "id" : "schedule-6-paragraph-3",
+          "href" : "schedule/6/paragraph/3",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "4",
           "title" : "(1) Section 182 (interpretation of payment system) is amended as...",
           "ref" : "schedule-6-paragraph-4",
+          "id" : "schedule-6-paragraph-4",
+          "href" : "schedule/6/paragraph/4",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "5",
           "title" : "(1) Section 183 (interpretation of other expressions) is amended as...",
           "ref" : "schedule-6-paragraph-5",
+          "id" : "schedule-6-paragraph-5",
+          "href" : "schedule/6/paragraph/5",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "6",
           "title" : "In the cross-heading before section 184 (recognition order), after “systems”...",
           "ref" : "schedule-6-paragraph-6",
+          "id" : "schedule-6-paragraph-6",
+          "href" : "schedule/6/paragraph/6",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "7",
           "title" : "In the heading to section 184 , after “order” insert...",
           "ref" : "schedule-6-paragraph-7",
+          "id" : "schedule-6-paragraph-7",
+          "href" : "schedule/6/paragraph/7",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "8",
           "title" : "In section 184, in subsection (4), after “constituting” insert “or...",
           "ref" : "schedule-6-paragraph-8",
+          "id" : "schedule-6-paragraph-8",
+          "href" : "schedule/6/paragraph/8",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "9",
           "title" : "After section 184 insert— Recognition order: DSA service provider (1) The Treasury may by order (“recognition order”) specify a...",
           "ref" : "schedule-6-paragraph-9",
+          "id" : "schedule-6-paragraph-9",
+          "href" : "schedule/6/paragraph/9",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "10",
           "title" : "In the heading to section 185 (recognition criteria) after “criteria”...",
           "ref" : "schedule-6-paragraph-10",
+          "id" : "schedule-6-paragraph-10",
+          "href" : "schedule/6/paragraph/10",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "11",
           "title" : "After section 185 insert— Recognition criteria: DSA service provider (1) The Treasury may make a recognition order in respect...",
           "ref" : "schedule-6-paragraph-11",
+          "id" : "schedule-6-paragraph-11",
+          "href" : "schedule/6/paragraph/11",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "12",
           "title" : "(1) Section 186 (procedure) is amended as follows. ",
           "ref" : "schedule-6-paragraph-12",
+          "id" : "schedule-6-paragraph-12",
+          "href" : "schedule/6/paragraph/12",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "13",
           "title" : "(1) Section 186A (amendment of recognition order) is amended as...",
           "ref" : "schedule-6-paragraph-13",
+          "id" : "schedule-6-paragraph-13",
+          "href" : "schedule/6/paragraph/13",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "14",
           "title" : "(1) Section 187 (de-recognition) is amended as follows. ",
           "ref" : "schedule-6-paragraph-14",
+          "id" : "schedule-6-paragraph-14",
+          "href" : "schedule/6/paragraph/14",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "15",
           "title" : "(1) Section 188 (principles) is amended as follows. ",
           "ref" : "schedule-6-paragraph-15",
+          "id" : "schedule-6-paragraph-15",
+          "href" : "schedule/6/paragraph/15",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "16",
           "title" : "In section 189 (codes of practice)— (a) the words after...",
           "ref" : "schedule-6-paragraph-16",
+          "id" : "schedule-6-paragraph-16",
+          "href" : "schedule/6/paragraph/16",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "17",
           "title" : "In section 190 (system rules), in subsection (1)(a)— ",
           "ref" : "schedule-6-paragraph-17",
+          "id" : "schedule-6-paragraph-17",
+          "href" : "schedule/6/paragraph/17",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "18",
           "title" : "After section 190 insert— Service provider rules (1) The Bank of England may require a recognised DSA...",
           "ref" : "schedule-6-paragraph-18",
+          "id" : "schedule-6-paragraph-18",
+          "href" : "schedule/6/paragraph/18",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "19",
           "title" : "(1) Section 191 (directions) is amended as follows. ",
           "ref" : "schedule-6-paragraph-19",
+          "id" : "schedule-6-paragraph-19",
+          "href" : "schedule/6/paragraph/19",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "20",
           "title" : "After section 192 (role of FCA and PRA), insert— Power...",
           "ref" : "schedule-6-paragraph-20",
+          "id" : "schedule-6-paragraph-20",
+          "href" : "schedule/6/paragraph/20",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "21",
           "title" : "(1) Section 193 (inspection) is amended as follows. ",
           "ref" : "schedule-6-paragraph-21",
+          "id" : "schedule-6-paragraph-21",
+          "href" : "schedule/6/paragraph/21",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "22",
           "title" : "(1) Section 194 (inspection: warrant) is amended as follows. ",
           "ref" : "schedule-6-paragraph-22",
+          "id" : "schedule-6-paragraph-22",
+          "href" : "schedule/6/paragraph/22",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "23",
           "title" : "(1) Section 195 (independent report) is amended as follows. ",
           "ref" : "schedule-6-paragraph-23",
+          "id" : "schedule-6-paragraph-23",
+          "href" : "schedule/6/paragraph/23",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "24",
           "title" : "In section 196 (compliance failure)— (a) after first “system” insert...",
           "ref" : "schedule-6-paragraph-24",
+          "id" : "schedule-6-paragraph-24",
+          "href" : "schedule/6/paragraph/24",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "25",
           "title" : "In section 197 (publication), in subsection (1)— ",
           "ref" : "schedule-6-paragraph-25",
+          "id" : "schedule-6-paragraph-25",
+          "href" : "schedule/6/paragraph/25",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "26",
           "title" : "In section 198 (penalty), in subsection (1)— ",
           "ref" : "schedule-6-paragraph-26",
+          "id" : "schedule-6-paragraph-26",
+          "href" : "schedule/6/paragraph/26",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "27",
           "title" : "(1) Section 199 (closure) is amended as follows. ",
           "ref" : "schedule-6-paragraph-27",
+          "id" : "schedule-6-paragraph-27",
+          "href" : "schedule/6/paragraph/27",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "28",
           "title" : "(1) Section 200 (management disqualification) is amended as follows. ",
           "ref" : "schedule-6-paragraph-28",
+          "id" : "schedule-6-paragraph-28",
+          "href" : "schedule/6/paragraph/28",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "29",
           "title" : "(1) Section 201 (warning) is amended as follows. ",
           "ref" : "schedule-6-paragraph-29",
+          "id" : "schedule-6-paragraph-29",
+          "href" : "schedule/6/paragraph/29",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "30",
           "title" : "In section 202 (appeal), in subsection (2)— ",
           "ref" : "schedule-6-paragraph-30",
+          "id" : "schedule-6-paragraph-30",
+          "href" : "schedule/6/paragraph/30",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "31",
           "title" : "(1) Section 202A (injunctions) is amended as follows. ",
           "ref" : "schedule-6-paragraph-31",
+          "id" : "schedule-6-paragraph-31",
+          "href" : "schedule/6/paragraph/31",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "32",
           "title" : "In section 203 (fees), in subsection (1)— ",
           "ref" : "schedule-6-paragraph-32",
+          "id" : "schedule-6-paragraph-32",
+          "href" : "schedule/6/paragraph/32",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "33",
           "title" : "After section 203B (annual report) insert— Policy statement (1) The Bank of England must prepare a statement of...",
           "ref" : "schedule-6-paragraph-33",
+          "id" : "schedule-6-paragraph-33",
+          "href" : "schedule/6/paragraph/33",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "34",
           "title" : "(1) Section 204 (information) is amended as follows. ",
           "ref" : "schedule-6-paragraph-34",
+          "id" : "schedule-6-paragraph-34",
+          "href" : "schedule/6/paragraph/34",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "35",
           "title" : "(1) Section 205 (pretending to be recognised) is amended as...",
           "ref" : "schedule-6-paragraph-35",
+          "id" : "schedule-6-paragraph-35",
+          "href" : "schedule/6/paragraph/35",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "36",
           "title" : "(1) Section 206 (saving for informal oversight) is amended as...",
           "ref" : "schedule-6-paragraph-36",
+          "id" : "schedule-6-paragraph-36",
+          "href" : "schedule/6/paragraph/36",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "37",
           "title" : "(1) Section 206A (services forming part of recognised payment systems)...",
           "ref" : "schedule-6-paragraph-37",
+          "id" : "schedule-6-paragraph-37",
+          "href" : "schedule/6/paragraph/37",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "38",
           "title" : "After section 206A insert— Service providers connected with a recognised...",
           "ref" : "schedule-6-paragraph-38",
+          "id" : "schedule-6-paragraph-38",
+          "href" : "schedule/6/paragraph/38",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "39",
           "title" : "In section 259 (statutory instruments), in the Table in subsection...",
           "ref" : "schedule-6-paragraph-39",
+          "id" : "schedule-6-paragraph-39",
+          "href" : "schedule/6/paragraph/39",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -4049,60 +4583,80 @@
         "number" : "PART 2",
         "title" : "Amendments to the Financial Services (Banking Reform) Act 2013",
         "ref" : "schedule-6-part-2",
+        "id" : "schedule-6-part-2",
+        "href" : "schedule/6/part/2",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "40",
           "title" : "The Financial Services (Banking Reform) Act 2013 is amended as...",
           "ref" : "schedule-6-paragraph-40",
+          "id" : "schedule-6-paragraph-40",
+          "href" : "schedule/6/paragraph/40",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "41",
           "title" : "(1) Section 41 (meaning of payment system) is amended as...",
           "ref" : "schedule-6-paragraph-41",
+          "id" : "schedule-6-paragraph-41",
+          "href" : "schedule/6/paragraph/41",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "42",
           "title" : "(1) Section 42 (participants in payment systems) is amended as...",
           "ref" : "schedule-6-paragraph-42",
+          "id" : "schedule-6-paragraph-42",
+          "href" : "schedule/6/paragraph/42",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "43",
           "title" : "In section 98 (duty of regulators to ensure co-ordinated exercise...",
           "ref" : "schedule-6-paragraph-43",
+          "id" : "schedule-6-paragraph-43",
+          "href" : "schedule/6/paragraph/43",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "44",
           "title" : "In section 110 (interpretation of Part), at the appropriate place...",
           "ref" : "schedule-6-paragraph-44",
+          "id" : "schedule-6-paragraph-44",
+          "href" : "schedule/6/paragraph/44",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "45",
           "title" : "In section 112 (interpretation: infrastructure companies), after subsection (2)(a) insert—...",
           "ref" : "schedule-6-paragraph-45",
+          "id" : "schedule-6-paragraph-45",
+          "href" : "schedule/6/paragraph/45",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "46",
           "title" : "In section 113 (interpretation: other expressions), in subsection (1) at...",
           "ref" : "schedule-6-paragraph-46",
+          "id" : "schedule-6-paragraph-46",
+          "href" : "schedule/6/paragraph/46",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "47",
           "title" : "(1) Section 115 (objective of FMI administration) is amended as...",
           "ref" : "schedule-6-paragraph-47",
+          "id" : "schedule-6-paragraph-47",
+          "href" : "schedule/6/paragraph/47",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "48",
           "title" : "In section 143 (Parliamentary control of orders and regulations), after...",
           "ref" : "schedule-6-paragraph-48",
+          "id" : "schedule-6-paragraph-48",
+          "href" : "schedule/6/paragraph/48",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -4111,84 +4665,112 @@
       "number" : "SCHEDULE 7",
       "title" : "Accountability of the Payment Systems Regulator",
       "ref" : "schedule-7",
+      "id" : "schedule-7",
+      "href" : "schedule/7",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "1",
         "title" : "The Financial Services (Banking Reform) Act 2013 is amended as...",
         "ref" : "schedule-7-paragraph-1",
+        "id" : "schedule-7-paragraph-1",
+        "href" : "schedule/7/paragraph/1",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "2",
         "title" : "In section 39 (overview)— (a) after subsection (11) insert— ",
         "ref" : "schedule-7-paragraph-2",
+        "id" : "schedule-7-paragraph-2",
+        "href" : "schedule/7/paragraph/2",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "3",
         "title" : "In section 53 (regulatory principles), in paragraph (c) at the...",
         "ref" : "schedule-7-paragraph-3",
+        "id" : "schedule-7-paragraph-3",
+        "href" : "schedule/7/paragraph/3",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "4",
         "title" : "After section 102 (power of PRA to require Regulator to...",
         "ref" : "schedule-7-paragraph-4",
+        "id" : "schedule-7-paragraph-4",
+        "href" : "schedule/7/paragraph/4",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "5",
         "title" : "Before section 103 (regulator’s general duty to consult) insert (under...",
         "ref" : "schedule-7-paragraph-5",
+        "id" : "schedule-7-paragraph-5",
+        "href" : "schedule/7/paragraph/5",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "6",
         "title" : "In section 104 (consultation in relation to generally applicable requirements)—...",
         "ref" : "schedule-7-paragraph-6",
+        "id" : "schedule-7-paragraph-6",
+        "href" : "schedule/7/paragraph/6",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "7",
         "title" : "After section 104 insert— Requirements in connection with public consultations...",
         "ref" : "schedule-7-paragraph-7",
+        "id" : "schedule-7-paragraph-7",
+        "href" : "schedule/7/paragraph/7",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "8",
         "title" : "After section 107 insert— International trade obligations (1) This section applies where it appears to the Payment...",
         "ref" : "schedule-7-paragraph-8",
+        "id" : "schedule-7-paragraph-8",
+        "href" : "schedule/7/paragraph/8",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "9",
         "title" : "In section 110(1) (interpretation), at the appropriate place insert— “generally...",
         "ref" : "schedule-7-paragraph-9",
+        "id" : "schedule-7-paragraph-9",
+        "href" : "schedule/7/paragraph/9",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "10",
         "title" : "In section 143 (orders and regulations: Parliamentary control), in subsection...",
         "ref" : "schedule-7-paragraph-10",
+        "id" : "schedule-7-paragraph-10",
+        "href" : "schedule/7/paragraph/10",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "11",
         "title" : "In Schedule 4 (the Payment Systems Regulator), after paragraph 7(2)(b)...",
         "ref" : "schedule-7-paragraph-11",
+        "id" : "schedule-7-paragraph-11",
+        "href" : "schedule/7/paragraph/11",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "12",
         "title" : "In Schedule 4, after paragraph 7 insert— Other reports (1) The Treasury may (subject to this paragraph) at any...",
         "ref" : "schedule-7-paragraph-12",
+        "id" : "schedule-7-paragraph-12",
+        "href" : "schedule/7/paragraph/12",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "13",
         "title" : "In Schedule 4, after paragraph 14 insert— Engagement with Parliamentary...",
         "ref" : "schedule-7-paragraph-13",
+        "id" : "schedule-7-paragraph-13",
+        "href" : "schedule/7/paragraph/13",
         "extent" : [ "E", "W", "S", "NI" ]
       } ]
     }, {
@@ -4196,18 +4778,24 @@
       "number" : "SCHEDULE 8",
       "title" : "Cash access services",
       "ref" : "schedule-8",
+      "id" : "schedule-8",
+      "href" : "schedule/8",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "part",
         "number" : "PART 1",
         "title" : "New Part 8B of FSMA 2000",
         "ref" : "schedule-8-part-1",
+        "id" : "schedule-8-part-1",
+        "href" : "schedule/8/part/1",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "1",
           "title" : "After Part 8A of FSMA 2000 (short selling) insert— PART...",
           "ref" : "schedule-8-paragraph-1",
+          "id" : "schedule-8-paragraph-1",
+          "href" : "schedule/8/paragraph/1",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -4215,54 +4803,72 @@
         "number" : "PART 2",
         "title" : "Consequential amendments to FSMA 2000",
         "ref" : "schedule-8-part-2",
+        "id" : "schedule-8-part-2",
+        "href" : "schedule/8/part/2",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "2",
           "title" : "FSMA 2000 is amended as follows. ",
           "ref" : "schedule-8-paragraph-2",
+          "id" : "schedule-8-paragraph-2",
+          "href" : "schedule/8/paragraph/2",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "3",
           "title" : "In section 3D (duty of FCA and PRA to ensure...",
           "ref" : "schedule-8-paragraph-3",
+          "id" : "schedule-8-paragraph-3",
+          "href" : "schedule/8/paragraph/3",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "4",
           "title" : "In section 55H (variation by FCA at request of authorised...",
           "ref" : "schedule-8-paragraph-4",
+          "id" : "schedule-8-paragraph-4",
+          "href" : "schedule/8/paragraph/4",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "5",
           "title" : "In section 55L (imposition of requirements by FCA), in subsection...",
           "ref" : "schedule-8-paragraph-5",
+          "id" : "schedule-8-paragraph-5",
+          "href" : "schedule/8/paragraph/5",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "6",
           "title" : "In section 55T (persons whose interests are protected), after “operational...",
           "ref" : "schedule-8-paragraph-6",
+          "id" : "schedule-8-paragraph-6",
+          "href" : "schedule/8/paragraph/6",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "7",
           "title" : "In section 232A (ombudsman scheme operator’s duty to provide information...",
           "ref" : "schedule-8-paragraph-7",
+          "id" : "schedule-8-paragraph-7",
+          "href" : "schedule/8/paragraph/7",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "8",
           "title" : "In section 395 (the FCA’s and PRA’s procedures), in subsection...",
           "ref" : "schedule-8-paragraph-8",
+          "id" : "schedule-8-paragraph-8",
+          "href" : "schedule/8/paragraph/8",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "9",
           "title" : "In section 429 (Parliamentary control of statutory instruments), in subsection...",
           "ref" : "schedule-8-paragraph-9",
+          "id" : "schedule-8-paragraph-9",
+          "href" : "schedule/8/paragraph/9",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -4271,18 +4877,24 @@
       "number" : "SCHEDULE 9",
       "title" : "Wholesale cash distribution",
       "ref" : "schedule-9",
+      "id" : "schedule-9",
+      "href" : "schedule/9",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "part",
         "number" : "PART 1",
         "title" : "New Part 5A of the Banking Act 2009",
         "ref" : "schedule-9-part-1",
+        "id" : "schedule-9-part-1",
+        "href" : "schedule/9/part/1",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "1",
           "title" : "After Part 5 of the Banking Act 2009 (payment systems)...",
           "ref" : "schedule-9-paragraph-1",
+          "id" : "schedule-9-paragraph-1",
+          "href" : "schedule/9/paragraph/1",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -4290,54 +4902,72 @@
         "number" : "PART 2",
         "title" : "Amendments to Part 6 of the Financial Services (Banking Reform) Act 2013",
         "ref" : "schedule-9-part-2",
+        "id" : "schedule-9-part-2",
+        "href" : "schedule/9/part/2",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "2",
           "title" : "Part 6 of the Financial Services (Banking Reform) Act 2013...",
           "ref" : "schedule-9-paragraph-2",
+          "id" : "schedule-9-paragraph-2",
+          "href" : "schedule/9/paragraph/2",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "3",
           "title" : "In section 111 (financial market infrastructure administration), in the heading,...",
           "ref" : "schedule-9-paragraph-3",
+          "id" : "schedule-9-paragraph-3",
+          "href" : "schedule/9/paragraph/3",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "4",
           "title" : "(1) Section 112 (interpretation: infrastructure companies) is amended as follows....",
           "ref" : "schedule-9-paragraph-4",
+          "id" : "schedule-9-paragraph-4",
+          "href" : "schedule/9/paragraph/4",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "5",
           "title" : "In section 113 (interpretation: other expressions), in subsection (1)— ",
           "ref" : "schedule-9-paragraph-5",
+          "id" : "schedule-9-paragraph-5",
+          "href" : "schedule/9/paragraph/5",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "6",
           "title" : "In section 115 (objective of FMI administration), after subsection (1A)...",
           "ref" : "schedule-9-paragraph-6",
+          "id" : "schedule-9-paragraph-6",
+          "href" : "schedule/9/paragraph/6",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "7",
           "title" : "In section 119 (continuity of supply), in subsection (6), in...",
           "ref" : "schedule-9-paragraph-7",
+          "id" : "schedule-9-paragraph-7",
+          "href" : "schedule/9/paragraph/7",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "8",
           "title" : "In section 120 (power to direct FMI administrator), in subsection...",
           "ref" : "schedule-9-paragraph-8",
+          "id" : "schedule-9-paragraph-8",
+          "href" : "schedule/9/paragraph/8",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "9",
           "title" : "In section 127 (interpretation of Part), in subsection (1), at...",
           "ref" : "schedule-9-paragraph-9",
+          "id" : "schedule-9-paragraph-9",
+          "href" : "schedule/9/paragraph/9",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -4345,48 +4975,64 @@
         "number" : "PART 3",
         "title" : "Consequential amendments",
         "ref" : "schedule-9-part-3",
+        "id" : "schedule-9-part-3",
+        "href" : "schedule/9/part/3",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "10",
           "title" : "Banking Act 2009",
           "ref" : "schedule-9-paragraph-10",
+          "id" : "schedule-9-paragraph-10",
+          "href" : "schedule/9/paragraph/10",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "11",
           "title" : "In section 259 (statutory instruments), in subsection (3), in the...",
           "ref" : "schedule-9-paragraph-11",
+          "id" : "schedule-9-paragraph-11",
+          "href" : "schedule/9/paragraph/11",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "12",
           "title" : "In section 261 (index of defined terms)— ",
           "ref" : "schedule-9-paragraph-12",
+          "id" : "schedule-9-paragraph-12",
+          "href" : "schedule/9/paragraph/12",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "13",
           "title" : "Financial Services Act 2012",
           "ref" : "schedule-9-paragraph-13",
+          "id" : "schedule-9-paragraph-13",
+          "href" : "schedule/9/paragraph/13",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "14",
           "title" : "(1) Section 85 (relevant functions in relation to complaints scheme)...",
           "ref" : "schedule-9-paragraph-14",
+          "id" : "schedule-9-paragraph-14",
+          "href" : "schedule/9/paragraph/14",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "15",
           "title" : "(1) Section 110 (payment to Treasury of penalties received by...",
           "ref" : "schedule-9-paragraph-15",
+          "id" : "schedule-9-paragraph-15",
+          "href" : "schedule/9/paragraph/15",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "16",
           "title" : "Financial Services (Banking Reform) Act 2013",
           "ref" : "schedule-9-paragraph-16",
+          "id" : "schedule-9-paragraph-16",
+          "href" : "schedule/9/paragraph/16",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -4395,18 +5041,24 @@
       "number" : "SCHEDULE 10",
       "title" : "Performance of functions relating to financial market infrastructure",
       "ref" : "schedule-10",
+      "id" : "schedule-10",
+      "href" : "schedule/10",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "part",
         "number" : "PART 1",
         "title" : "New Chapter 2A of Part 18 of FSMA 2000",
         "ref" : "schedule-10-part-1",
+        "id" : "schedule-10-part-1",
+        "href" : "schedule/10/part/1",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "1",
           "title" : "In Part 18 of FSMA 2000 (recognised investment exchanges, clearing...",
           "ref" : "schedule-10-paragraph-1",
+          "id" : "schedule-10-paragraph-1",
+          "href" : "schedule/10/paragraph/1",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -4414,126 +5066,168 @@
         "number" : "PART 2",
         "title" : "Related amendments",
         "ref" : "schedule-10-part-2",
+        "id" : "schedule-10-part-2",
+        "href" : "schedule/10/part/2",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "2",
           "title" : "Amendments to FSMA 2000",
           "ref" : "schedule-10-paragraph-2",
+          "id" : "schedule-10-paragraph-2",
+          "href" : "schedule/10/paragraph/2",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "3",
           "title" : "(1) Section 56 (prohibition orders) is amended as follows— ",
           "ref" : "schedule-10-paragraph-3",
+          "id" : "schedule-10-paragraph-3",
+          "href" : "schedule/10/paragraph/3",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "4",
           "title" : "(1) Section 57 (prohibition orders: procedure and right to refer...",
           "ref" : "schedule-10-paragraph-4",
+          "id" : "schedule-10-paragraph-4",
+          "href" : "schedule/10/paragraph/4",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "5",
           "title" : "In section 59AB(1) (specifying functions as controlled functions: transitional provision),...",
           "ref" : "schedule-10-paragraph-5",
+          "id" : "schedule-10-paragraph-5",
+          "href" : "schedule/10/paragraph/5",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "6",
           "title" : "In section 133(7A) (proceedings before Tribunal: general provision), after paragraph...",
           "ref" : "schedule-10-paragraph-6",
+          "id" : "schedule-10-paragraph-6",
+          "href" : "schedule/10/paragraph/6",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "7",
           "title" : "In section 138A (modification or waiver of rules), in subsection...",
           "ref" : "schedule-10-paragraph-7",
+          "id" : "schedule-10-paragraph-7",
+          "href" : "schedule/10/paragraph/7",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "8",
           "title" : "(1) Section 168 (appointment of persons to carry out investigations...",
           "ref" : "schedule-10-paragraph-8",
+          "id" : "schedule-10-paragraph-8",
+          "href" : "schedule/10/paragraph/8",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "9",
           "title" : "In the heading of Chapter 3B of Part 18, at...",
           "ref" : "schedule-10-paragraph-9",
+          "id" : "schedule-10-paragraph-9",
+          "href" : "schedule/10/paragraph/9",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "10",
           "title" : "Section 312FA is omitted. ",
           "ref" : "schedule-10-paragraph-10",
+          "id" : "schedule-10-paragraph-10",
+          "href" : "schedule/10/paragraph/10",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "11",
           "title" : "In section 313 (interpretation of Part 18), in subsection (1)—...",
           "ref" : "schedule-10-paragraph-11",
+          "id" : "schedule-10-paragraph-11",
+          "href" : "schedule/10/paragraph/11",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "12",
           "title" : "(1) Section 347 (the record of authorised persons etc) is...",
           "ref" : "schedule-10-paragraph-12",
+          "id" : "schedule-10-paragraph-12",
+          "href" : "schedule/10/paragraph/12",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "13",
           "title" : "In section 391 (publication of notices), in subsection (1ZB), after...",
           "ref" : "schedule-10-paragraph-13",
+          "id" : "schedule-10-paragraph-13",
+          "href" : "schedule/10/paragraph/13",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "14",
           "title" : "(1) Section 392 (application of sections 393 and 394) is...",
           "ref" : "schedule-10-paragraph-14",
+          "id" : "schedule-10-paragraph-14",
+          "href" : "schedule/10/paragraph/14",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "15",
           "title" : "In section 395 (the FCA’s and PRA’s procedures), in subsection...",
           "ref" : "schedule-10-paragraph-15",
+          "id" : "schedule-10-paragraph-15",
+          "href" : "schedule/10/paragraph/15",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "16",
           "title" : "(1) Section 417(1) (interpretation) is amended as follows. ",
           "ref" : "schedule-10-paragraph-16",
+          "id" : "schedule-10-paragraph-16",
+          "href" : "schedule/10/paragraph/16",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "17",
           "title" : "In section 429 (Parliamentary control of statutory instruments) ",
           "ref" : "schedule-10-paragraph-17",
+          "id" : "schedule-10-paragraph-17",
+          "href" : "schedule/10/paragraph/17",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "18",
           "title" : "(1) Schedule 1ZA (the Financial Conduct Authority) is amended as...",
           "ref" : "schedule-10-paragraph-18",
+          "id" : "schedule-10-paragraph-18",
+          "href" : "schedule/10/paragraph/18",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "19",
           "title" : "In Schedule 2A (Gibraltar-based persons carrying on activities in the...",
           "ref" : "schedule-10-paragraph-19",
+          "id" : "schedule-10-paragraph-19",
+          "href" : "schedule/10/paragraph/19",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "20",
           "title" : "(1) Schedule 17A (further provision in relation to exercise of...",
           "ref" : "schedule-10-paragraph-20",
+          "id" : "schedule-10-paragraph-20",
+          "href" : "schedule/10/paragraph/20",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "21",
           "title" : "Financial Services Act 2012",
           "ref" : "schedule-10-paragraph-21",
+          "id" : "schedule-10-paragraph-21",
+          "href" : "schedule/10/paragraph/21",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -4542,18 +5236,24 @@
       "number" : "SCHEDULE 11",
       "title" : "Central counterparties",
       "ref" : "schedule-11",
+      "id" : "schedule-11",
+      "href" : "schedule/11",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "part",
         "number" : "PART 1",
         "title" : "Introductory",
         "ref" : "schedule-11-part-1",
+        "id" : "schedule-11-part-1",
+        "href" : "schedule/11/part/1",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "1",
           "title" : "Overview",
           "ref" : "schedule-11-paragraph-1",
+          "id" : "schedule-11-paragraph-1",
+          "href" : "schedule/11/paragraph/1",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -4561,18 +5261,24 @@
         "number" : "PART 2",
         "title" : "Pre-resolution powers of the Bank of England",
         "ref" : "schedule-11-part-2",
+        "id" : "schedule-11-part-2",
+        "href" : "schedule/11/part/2",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "2",
           "title" : "Removal of impediments to the exercise of stabilisation powers etc",
           "ref" : "schedule-11-paragraph-2",
+          "id" : "schedule-11-paragraph-2",
+          "href" : "schedule/11/paragraph/2",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "3",
           "title" : "Safeguards relating to directions under paragraph 2",
           "ref" : "schedule-11-paragraph-3",
+          "id" : "schedule-11-paragraph-3",
+          "href" : "schedule/11/paragraph/3",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -4580,12 +5286,16 @@
         "number" : "PART 3",
         "title" : "Resolution plans",
         "ref" : "schedule-11-part-3",
+        "id" : "schedule-11-part-3",
+        "href" : "schedule/11/part/3",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "4",
           "title" : "Resolution plans",
           "ref" : "schedule-11-paragraph-4",
+          "id" : "schedule-11-paragraph-4",
+          "href" : "schedule/11/paragraph/4",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -4593,66 +5303,88 @@
         "number" : "PART 4",
         "title" : "Removal of directors and senior managers",
         "ref" : "schedule-11-part-4",
+        "id" : "schedule-11-part-4",
+        "href" : "schedule/11/part/4",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "5",
           "title" : "Removal of directors and senior managers",
           "ref" : "schedule-11-paragraph-5",
+          "id" : "schedule-11-paragraph-5",
+          "href" : "schedule/11/paragraph/5",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "6",
           "title" : "Temporary manager",
           "ref" : "schedule-11-paragraph-6",
+          "id" : "schedule-11-paragraph-6",
+          "href" : "schedule/11/paragraph/6",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "7",
           "title" : "Paragraphs 5 and 6: conditions",
           "ref" : "schedule-11-paragraph-7",
+          "id" : "schedule-11-paragraph-7",
+          "href" : "schedule/11/paragraph/7",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "8",
           "title" : "Temporary manager: further provisions in relation to the appointment",
           "ref" : "schedule-11-paragraph-8",
+          "id" : "schedule-11-paragraph-8",
+          "href" : "schedule/11/paragraph/8",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "9",
           "title" : "Temporary manager: instrument of appointment",
           "ref" : "schedule-11-paragraph-9",
+          "id" : "schedule-11-paragraph-9",
+          "href" : "schedule/11/paragraph/9",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "10",
           "title" : "Right to refer matters to the Tribunal",
           "ref" : "schedule-11-paragraph-10",
+          "id" : "schedule-11-paragraph-10",
+          "href" : "schedule/11/paragraph/10",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "11",
           "title" : "Removal of directors and senior managers and appointment of temporary manager: procedure",
           "ref" : "schedule-11-paragraph-11",
+          "id" : "schedule-11-paragraph-11",
+          "href" : "schedule/11/paragraph/11",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "12",
           "title" : "Removal of directors and senior managers and appointment of temporary manager: notice requirements",
           "ref" : "schedule-11-paragraph-12",
+          "id" : "schedule-11-paragraph-12",
+          "href" : "schedule/11/paragraph/12",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "13",
           "title" : "Temporary restriction on remuneration",
           "ref" : "schedule-11-paragraph-13",
+          "id" : "schedule-11-paragraph-13",
+          "href" : "schedule/11/paragraph/13",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "14",
           "title" : "Restriction on remuneration: review and revocation",
           "ref" : "schedule-11-paragraph-14",
+          "id" : "schedule-11-paragraph-14",
+          "href" : "schedule/11/paragraph/14",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -4660,630 +5392,840 @@
         "number" : "PART 5",
         "title" : "Special resolution action",
         "ref" : "schedule-11-part-5",
+        "id" : "schedule-11-part-5",
+        "href" : "schedule/11/part/5",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "15",
           "title" : "Special resolution objectives",
           "ref" : "schedule-11-paragraph-15",
+          "id" : "schedule-11-paragraph-15",
+          "href" : "schedule/11/paragraph/15",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "16",
           "title" : "Code of Practice",
           "ref" : "schedule-11-paragraph-16",
+          "id" : "schedule-11-paragraph-16",
+          "href" : "schedule/11/paragraph/16",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "17",
           "title" : "General conditions",
           "ref" : "schedule-11-paragraph-17",
+          "id" : "schedule-11-paragraph-17",
+          "href" : "schedule/11/paragraph/17",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "18",
           "title" : "Effect on other group members",
           "ref" : "schedule-11-paragraph-18",
+          "id" : "schedule-11-paragraph-18",
+          "href" : "schedule/11/paragraph/18",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "19",
           "title" : "Specific conditions: financial assistance cases",
           "ref" : "schedule-11-paragraph-19",
+          "id" : "schedule-11-paragraph-19",
+          "href" : "schedule/11/paragraph/19",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "20",
           "title" : "Resolution liaison panel",
           "ref" : "schedule-11-paragraph-20",
+          "id" : "schedule-11-paragraph-20",
+          "href" : "schedule/11/paragraph/20",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "21",
           "title" : "Restrictions on use of certain resolution powers",
           "ref" : "schedule-11-paragraph-21",
+          "id" : "schedule-11-paragraph-21",
+          "href" : "schedule/11/paragraph/21",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "22",
           "title" : "Pre-resolution valuation",
           "ref" : "schedule-11-paragraph-22",
+          "id" : "schedule-11-paragraph-22",
+          "href" : "schedule/11/paragraph/22",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "23",
           "title" : "Replacement of Bank’s provisional valuation",
           "ref" : "schedule-11-paragraph-23",
+          "id" : "schedule-11-paragraph-23",
+          "href" : "schedule/11/paragraph/23",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "24",
           "title" : "Independent valuer: valuation under paragraph 22 or 23",
           "ref" : "schedule-11-paragraph-24",
+          "id" : "schedule-11-paragraph-24",
+          "href" : "schedule/11/paragraph/24",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "25",
           "title" : "Independent valuer: supplemental",
           "ref" : "schedule-11-paragraph-25",
+          "id" : "schedule-11-paragraph-25",
+          "href" : "schedule/11/paragraph/25",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "26",
           "title" : "Consequences of a replacement valuation",
           "ref" : "schedule-11-paragraph-26",
+          "id" : "schedule-11-paragraph-26",
+          "href" : "schedule/11/paragraph/26",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "27",
           "title" : "Private sector purchaser",
           "ref" : "schedule-11-paragraph-27",
+          "id" : "schedule-11-paragraph-27",
+          "href" : "schedule/11/paragraph/27",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "28",
           "title" : "Private sector purchaser: marketing",
           "ref" : "schedule-11-paragraph-28",
+          "id" : "schedule-11-paragraph-28",
+          "href" : "schedule/11/paragraph/28",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "29",
           "title" : "Bridge central counterparty",
           "ref" : "schedule-11-paragraph-29",
+          "id" : "schedule-11-paragraph-29",
+          "href" : "schedule/11/paragraph/29",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "30",
           "title" : "Transfer of ownership",
           "ref" : "schedule-11-paragraph-30",
+          "id" : "schedule-11-paragraph-30",
+          "href" : "schedule/11/paragraph/30",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "31",
           "title" : "Tear-up power",
           "ref" : "schedule-11-paragraph-31",
+          "id" : "schedule-11-paragraph-31",
+          "href" : "schedule/11/paragraph/31",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "32",
           "title" : "Cash call power",
           "ref" : "schedule-11-paragraph-32",
+          "id" : "schedule-11-paragraph-32",
+          "href" : "schedule/11/paragraph/32",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "33",
           "title" : "Power to reduce variation margin payments",
           "ref" : "schedule-11-paragraph-33",
+          "id" : "schedule-11-paragraph-33",
+          "href" : "schedule/11/paragraph/33",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "34",
           "title" : "Write-down power",
           "ref" : "schedule-11-paragraph-34",
+          "id" : "schedule-11-paragraph-34",
+          "href" : "schedule/11/paragraph/34",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "35",
           "title" : "Powers in relation to securities",
           "ref" : "schedule-11-paragraph-35",
+          "id" : "schedule-11-paragraph-35",
+          "href" : "schedule/11/paragraph/35",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "36",
           "title" : "Report on provisions in write-down instrument",
           "ref" : "schedule-11-paragraph-36",
+          "id" : "schedule-11-paragraph-36",
+          "href" : "schedule/11/paragraph/36",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "37",
           "title" : "Priority between creditors",
           "ref" : "schedule-11-paragraph-37",
+          "id" : "schedule-11-paragraph-37",
+          "href" : "schedule/11/paragraph/37",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "38",
           "title" : "Power to take control",
           "ref" : "schedule-11-paragraph-38",
+          "id" : "schedule-11-paragraph-38",
+          "href" : "schedule/11/paragraph/38",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "39",
           "title" : "Shadow directors etc",
           "ref" : "schedule-11-paragraph-39",
+          "id" : "schedule-11-paragraph-39",
+          "href" : "schedule/11/paragraph/39",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "40",
           "title" : "Interpretation: “securities”",
           "ref" : "schedule-11-paragraph-40",
+          "id" : "schedule-11-paragraph-40",
+          "href" : "schedule/11/paragraph/40",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "41",
           "title" : "Share transfer instrument",
           "ref" : "schedule-11-paragraph-41",
+          "id" : "schedule-11-paragraph-41",
+          "href" : "schedule/11/paragraph/41",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "42",
           "title" : "Effect",
           "ref" : "schedule-11-paragraph-42",
+          "id" : "schedule-11-paragraph-42",
+          "href" : "schedule/11/paragraph/42",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "43",
           "title" : "Continuity",
           "ref" : "schedule-11-paragraph-43",
+          "id" : "schedule-11-paragraph-43",
+          "href" : "schedule/11/paragraph/43",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "44",
           "title" : "Conversion and delisting",
           "ref" : "schedule-11-paragraph-44",
+          "id" : "schedule-11-paragraph-44",
+          "href" : "schedule/11/paragraph/44",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "45",
           "title" : "Directors and senior managers",
           "ref" : "schedule-11-paragraph-45",
+          "id" : "schedule-11-paragraph-45",
+          "href" : "schedule/11/paragraph/45",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "46",
           "title" : "Ancillary instruments: production, registration, etc",
           "ref" : "schedule-11-paragraph-46",
+          "id" : "schedule-11-paragraph-46",
+          "href" : "schedule/11/paragraph/46",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "47",
           "title" : "Incidental provision",
           "ref" : "schedule-11-paragraph-47",
+          "id" : "schedule-11-paragraph-47",
+          "href" : "schedule/11/paragraph/47",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "48",
           "title" : "Procedure: instruments",
           "ref" : "schedule-11-paragraph-48",
+          "id" : "schedule-11-paragraph-48",
+          "href" : "schedule/11/paragraph/48",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "49",
           "title" : "Supplemental instruments",
           "ref" : "schedule-11-paragraph-49",
+          "id" : "schedule-11-paragraph-49",
+          "href" : "schedule/11/paragraph/49",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "50",
           "title" : "Onward transfer",
           "ref" : "schedule-11-paragraph-50",
+          "id" : "schedule-11-paragraph-50",
+          "href" : "schedule/11/paragraph/50",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "51",
           "title" : "Reverse share transfer",
           "ref" : "schedule-11-paragraph-51",
+          "id" : "schedule-11-paragraph-51",
+          "href" : "schedule/11/paragraph/51",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "52",
           "title" : "Bridge central counterparties: share transfers",
           "ref" : "schedule-11-paragraph-52",
+          "id" : "schedule-11-paragraph-52",
+          "href" : "schedule/11/paragraph/52",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "53",
           "title" : "Bridge central counterparties: reverse share transfer",
           "ref" : "schedule-11-paragraph-53",
+          "id" : "schedule-11-paragraph-53",
+          "href" : "schedule/11/paragraph/53",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "54",
           "title" : "Property transfer instrument",
           "ref" : "schedule-11-paragraph-54",
+          "id" : "schedule-11-paragraph-54",
+          "href" : "schedule/11/paragraph/54",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "55",
           "title" : "Effect",
           "ref" : "schedule-11-paragraph-55",
+          "id" : "schedule-11-paragraph-55",
+          "href" : "schedule/11/paragraph/55",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "56",
           "title" : "Transferable property",
           "ref" : "schedule-11-paragraph-56",
+          "id" : "schedule-11-paragraph-56",
+          "href" : "schedule/11/paragraph/56",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "57",
           "title" : "Continuity",
           "ref" : "schedule-11-paragraph-57",
+          "id" : "schedule-11-paragraph-57",
+          "href" : "schedule/11/paragraph/57",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "58",
           "title" : "Directors and senior managers",
           "ref" : "schedule-11-paragraph-58",
+          "id" : "schedule-11-paragraph-58",
+          "href" : "schedule/11/paragraph/58",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "59",
           "title" : "Recognised central counterparty rules",
           "ref" : "schedule-11-paragraph-59",
+          "id" : "schedule-11-paragraph-59",
+          "href" : "schedule/11/paragraph/59",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "60",
           "title" : "Recognised central counterparty membership",
           "ref" : "schedule-11-paragraph-60",
+          "id" : "schedule-11-paragraph-60",
+          "href" : "schedule/11/paragraph/60",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "61",
           "title" : "Licences",
           "ref" : "schedule-11-paragraph-61",
+          "id" : "schedule-11-paragraph-61",
+          "href" : "schedule/11/paragraph/61",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "62",
           "title" : "Foreign property",
           "ref" : "schedule-11-paragraph-62",
+          "id" : "schedule-11-paragraph-62",
+          "href" : "schedule/11/paragraph/62",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "63",
           "title" : "Incidental provision",
           "ref" : "schedule-11-paragraph-63",
+          "id" : "schedule-11-paragraph-63",
+          "href" : "schedule/11/paragraph/63",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "64",
           "title" : "Procedure",
           "ref" : "schedule-11-paragraph-64",
+          "id" : "schedule-11-paragraph-64",
+          "href" : "schedule/11/paragraph/64",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "65",
           "title" : "Property transfer instrument: delisting",
           "ref" : "schedule-11-paragraph-65",
+          "id" : "schedule-11-paragraph-65",
+          "href" : "schedule/11/paragraph/65",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "66",
           "title" : "Transfer of property subsequent to resolution instrument",
           "ref" : "schedule-11-paragraph-66",
+          "id" : "schedule-11-paragraph-66",
+          "href" : "schedule/11/paragraph/66",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "67",
           "title" : "Supplemental instruments",
           "ref" : "schedule-11-paragraph-67",
+          "id" : "schedule-11-paragraph-67",
+          "href" : "schedule/11/paragraph/67",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "68",
           "title" : "Private sector purchaser: reverse property transfer",
           "ref" : "schedule-11-paragraph-68",
+          "id" : "schedule-11-paragraph-68",
+          "href" : "schedule/11/paragraph/68",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "69",
           "title" : "Onward transfer",
           "ref" : "schedule-11-paragraph-69",
+          "id" : "schedule-11-paragraph-69",
+          "href" : "schedule/11/paragraph/69",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "70",
           "title" : "Bridge central counterparties: reverse property transfer",
           "ref" : "schedule-11-paragraph-70",
+          "id" : "schedule-11-paragraph-70",
+          "href" : "schedule/11/paragraph/70",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "71",
           "title" : "Transfer of ownership and private sector purchaser: property transfer",
           "ref" : "schedule-11-paragraph-71",
+          "id" : "schedule-11-paragraph-71",
+          "href" : "schedule/11/paragraph/71",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "72",
           "title" : "Transfer of ownership: reverse property transfer",
           "ref" : "schedule-11-paragraph-72",
+          "id" : "schedule-11-paragraph-72",
+          "href" : "schedule/11/paragraph/72",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "73",
           "title" : "Bridge central counterparty: supplemental property transfer powers",
           "ref" : "schedule-11-paragraph-73",
+          "id" : "schedule-11-paragraph-73",
+          "href" : "schedule/11/paragraph/73",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "74",
           "title" : "Bridge central counterparty: supplemental reverse property transfer powers",
           "ref" : "schedule-11-paragraph-74",
+          "id" : "schedule-11-paragraph-74",
+          "href" : "schedule/11/paragraph/74",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "75",
           "title" : "Restriction of partial transfers",
           "ref" : "schedule-11-paragraph-75",
+          "id" : "schedule-11-paragraph-75",
+          "href" : "schedule/11/paragraph/75",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "76",
           "title" : "Power to protect certain interests",
           "ref" : "schedule-11-paragraph-76",
+          "id" : "schedule-11-paragraph-76",
+          "href" : "schedule/11/paragraph/76",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "77",
           "title" : "Creation of liabilities",
           "ref" : "schedule-11-paragraph-77",
+          "id" : "schedule-11-paragraph-77",
+          "href" : "schedule/11/paragraph/77",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "78",
           "title" : "Regulations for safeguarding certain financial arrangements: write-down instruments",
           "ref" : "schedule-11-paragraph-78",
+          "id" : "schedule-11-paragraph-78",
+          "href" : "schedule/11/paragraph/78",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "79",
           "title" : "Resolution instruments: effect and supplementary matters",
           "ref" : "schedule-11-paragraph-79",
+          "id" : "schedule-11-paragraph-79",
+          "href" : "schedule/11/paragraph/79",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "80",
           "title" : "Write-down instruments: supplementary",
           "ref" : "schedule-11-paragraph-80",
+          "id" : "schedule-11-paragraph-80",
+          "href" : "schedule/11/paragraph/80",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "81",
           "title" : "Resolution instruments: procedure",
           "ref" : "schedule-11-paragraph-81",
+          "id" : "schedule-11-paragraph-81",
+          "href" : "schedule/11/paragraph/81",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "82",
           "title" : "Supplemental resolution instruments",
           "ref" : "schedule-11-paragraph-82",
+          "id" : "schedule-11-paragraph-82",
+          "href" : "schedule/11/paragraph/82",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "83",
           "title" : "Directors and senior managers",
           "ref" : "schedule-11-paragraph-83",
+          "id" : "schedule-11-paragraph-83",
+          "href" : "schedule/11/paragraph/83",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "84",
           "title" : "Termination rights etc",
           "ref" : "schedule-11-paragraph-84",
+          "id" : "schedule-11-paragraph-84",
+          "href" : "schedule/11/paragraph/84",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "85",
           "title" : "Deferment",
           "ref" : "schedule-11-paragraph-85",
+          "id" : "schedule-11-paragraph-85",
+          "href" : "schedule/11/paragraph/85",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "86",
           "title" : "Recovery of expenses",
           "ref" : "schedule-11-paragraph-86",
+          "id" : "schedule-11-paragraph-86",
+          "href" : "schedule/11/paragraph/86",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "87",
           "title" : "Compensation scheme",
           "ref" : "schedule-11-paragraph-87",
+          "id" : "schedule-11-paragraph-87",
+          "href" : "schedule/11/paragraph/87",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "88",
           "title" : "Instruments: notification of members and creditors",
           "ref" : "schedule-11-paragraph-88",
+          "id" : "schedule-11-paragraph-88",
+          "href" : "schedule/11/paragraph/88",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "89",
           "title" : "General continuity obligation: property transfers",
           "ref" : "schedule-11-paragraph-89",
+          "id" : "schedule-11-paragraph-89",
+          "href" : "schedule/11/paragraph/89",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "90",
           "title" : "Special continuity obligations: property transfers",
           "ref" : "schedule-11-paragraph-90",
+          "id" : "schedule-11-paragraph-90",
+          "href" : "schedule/11/paragraph/90",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "91",
           "title" : "Continuity obligations: onward property transfers",
           "ref" : "schedule-11-paragraph-91",
+          "id" : "schedule-11-paragraph-91",
+          "href" : "schedule/11/paragraph/91",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "92",
           "title" : "General continuity obligation: share transfers",
           "ref" : "schedule-11-paragraph-92",
+          "id" : "schedule-11-paragraph-92",
+          "href" : "schedule/11/paragraph/92",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "93",
           "title" : "Special continuity obligations: share transfers",
           "ref" : "schedule-11-paragraph-93",
+          "id" : "schedule-11-paragraph-93",
+          "href" : "schedule/11/paragraph/93",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "94",
           "title" : "Continuity obligations: onward share transfers",
           "ref" : "schedule-11-paragraph-94",
+          "id" : "schedule-11-paragraph-94",
+          "href" : "schedule/11/paragraph/94",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "95",
           "title" : "Continuity obligations: consideration and terms",
           "ref" : "schedule-11-paragraph-95",
+          "id" : "schedule-11-paragraph-95",
+          "href" : "schedule/11/paragraph/95",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "96",
           "title" : "Continuity obligations: termination",
           "ref" : "schedule-11-paragraph-96",
+          "id" : "schedule-11-paragraph-96",
+          "href" : "schedule/11/paragraph/96",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "97",
           "title" : "Suspension of obligations",
           "ref" : "schedule-11-paragraph-97",
+          "id" : "schedule-11-paragraph-97",
+          "href" : "schedule/11/paragraph/97",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "98",
           "title" : "Restriction of security interests",
           "ref" : "schedule-11-paragraph-98",
+          "id" : "schedule-11-paragraph-98",
+          "href" : "schedule/11/paragraph/98",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "99",
           "title" : "Suspension of termination rights",
           "ref" : "schedule-11-paragraph-99",
+          "id" : "schedule-11-paragraph-99",
+          "href" : "schedule/11/paragraph/99",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "100",
           "title" : "Suspension: general provision",
           "ref" : "schedule-11-paragraph-100",
+          "id" : "schedule-11-paragraph-100",
+          "href" : "schedule/11/paragraph/100",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "101",
           "title" : "Stay on terminating membership",
           "ref" : "schedule-11-paragraph-101",
+          "id" : "schedule-11-paragraph-101",
+          "href" : "schedule/11/paragraph/101",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "102",
           "title" : "Restriction on remuneration",
           "ref" : "schedule-11-paragraph-102",
+          "id" : "schedule-11-paragraph-102",
+          "href" : "schedule/11/paragraph/102",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "103",
           "title" : "Pensions",
           "ref" : "schedule-11-paragraph-103",
+          "id" : "schedule-11-paragraph-103",
+          "href" : "schedule/11/paragraph/103",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "104",
           "title" : "Disputes",
           "ref" : "schedule-11-paragraph-104",
+          "id" : "schedule-11-paragraph-104",
+          "href" : "schedule/11/paragraph/104",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "105",
           "title" : "Tax",
           "ref" : "schedule-11-paragraph-105",
+          "id" : "schedule-11-paragraph-105",
+          "href" : "schedule/11/paragraph/105",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "106",
           "title" : "Stay or sist of legal proceedings",
           "ref" : "schedule-11-paragraph-106",
+          "id" : "schedule-11-paragraph-106",
+          "href" : "schedule/11/paragraph/106",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "107",
           "title" : "Insolvency proceedings",
           "ref" : "schedule-11-paragraph-107",
+          "id" : "schedule-11-paragraph-107",
+          "href" : "schedule/11/paragraph/107",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "108",
           "title" : "Recognition of transferee company",
           "ref" : "schedule-11-paragraph-108",
+          "id" : "schedule-11-paragraph-108",
+          "href" : "schedule/11/paragraph/108",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "109",
           "title" : "International obligation notice: general",
           "ref" : "schedule-11-paragraph-109",
+          "id" : "schedule-11-paragraph-109",
+          "href" : "schedule/11/paragraph/109",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "110",
           "title" : "International obligation notice: bridge central counterparty",
           "ref" : "schedule-11-paragraph-110",
+          "id" : "schedule-11-paragraph-110",
+          "href" : "schedule/11/paragraph/110",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "111",
           "title" : "Public funds: general",
           "ref" : "schedule-11-paragraph-111",
+          "id" : "schedule-11-paragraph-111",
+          "href" : "schedule/11/paragraph/111",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "112",
           "title" : "Public funds: bridge central counterparty",
           "ref" : "schedule-11-paragraph-112",
+          "id" : "schedule-11-paragraph-112",
+          "href" : "schedule/11/paragraph/112",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "113",
           "title" : "Private sector purchaser: report",
           "ref" : "schedule-11-paragraph-113",
+          "id" : "schedule-11-paragraph-113",
+          "href" : "schedule/11/paragraph/113",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "114",
           "title" : "Bridge central counterparty: report",
           "ref" : "schedule-11-paragraph-114",
+          "id" : "schedule-11-paragraph-114",
+          "href" : "schedule/11/paragraph/114",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "115",
           "title" : "Resolution instruments: report",
           "ref" : "schedule-11-paragraph-115",
+          "id" : "schedule-11-paragraph-115",
+          "href" : "schedule/11/paragraph/115",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "116",
           "title" : "Transfer of ownership: report",
           "ref" : "schedule-11-paragraph-116",
+          "id" : "schedule-11-paragraph-116",
+          "href" : "schedule/11/paragraph/116",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "117",
           "title" : "Sale to commercial purchaser, transfer to bridge central counterparty and transfer of ownership: conditions for group companies",
           "ref" : "schedule-11-paragraph-117",
+          "id" : "schedule-11-paragraph-117",
+          "href" : "schedule/11/paragraph/117",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "118",
           "title" : "Paragraph 117: supplemental",
           "ref" : "schedule-11-paragraph-118",
+          "id" : "schedule-11-paragraph-118",
+          "href" : "schedule/11/paragraph/118",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -5291,162 +6233,216 @@
         "number" : "PART 6",
         "title" : "Information, investigation and enforcement",
         "ref" : "schedule-11-part-6",
+        "id" : "schedule-11-part-6",
+        "href" : "schedule/11/part/6",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "119",
           "title" : "Information",
           "ref" : "schedule-11-paragraph-119",
+          "id" : "schedule-11-paragraph-119",
+          "href" : "schedule/11/paragraph/119",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "120",
           "title" : "Reports by skilled persons",
           "ref" : "schedule-11-paragraph-120",
+          "id" : "schedule-11-paragraph-120",
+          "href" : "schedule/11/paragraph/120",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "121",
           "title" : "Appointment of persons to carry out general investigations",
           "ref" : "schedule-11-paragraph-121",
+          "id" : "schedule-11-paragraph-121",
+          "href" : "schedule/11/paragraph/121",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "122",
           "title" : "Appointment of person to carry out investigations in particular cases",
           "ref" : "schedule-11-paragraph-122",
+          "id" : "schedule-11-paragraph-122",
+          "href" : "schedule/11/paragraph/122",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "123",
           "title" : "Investigations etc in support of foreign resolution authorities",
           "ref" : "schedule-11-paragraph-123",
+          "id" : "schedule-11-paragraph-123",
+          "href" : "schedule/11/paragraph/123",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "124",
           "title" : "Investigations: general",
           "ref" : "schedule-11-paragraph-124",
+          "id" : "schedule-11-paragraph-124",
+          "href" : "schedule/11/paragraph/124",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "125",
           "title" : "Powers of persons appointed under paragraph 121",
           "ref" : "schedule-11-paragraph-125",
+          "id" : "schedule-11-paragraph-125",
+          "href" : "schedule/11/paragraph/125",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "126",
           "title" : "Powers of persons appointed as a result of paragraph 122",
           "ref" : "schedule-11-paragraph-126",
+          "id" : "schedule-11-paragraph-126",
+          "href" : "schedule/11/paragraph/126",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "127",
           "title" : "Admissibility of statements made to investigators",
           "ref" : "schedule-11-paragraph-127",
+          "id" : "schedule-11-paragraph-127",
+          "href" : "schedule/11/paragraph/127",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "128",
           "title" : "Information and documents: supplemental provision",
           "ref" : "schedule-11-paragraph-128",
+          "id" : "schedule-11-paragraph-128",
+          "href" : "schedule/11/paragraph/128",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "129",
           "title" : "Protected items",
           "ref" : "schedule-11-paragraph-129",
+          "id" : "schedule-11-paragraph-129",
+          "href" : "schedule/11/paragraph/129",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "130",
           "title" : "Entry of premises under warrant",
           "ref" : "schedule-11-paragraph-130",
+          "id" : "schedule-11-paragraph-130",
+          "href" : "schedule/11/paragraph/130",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "131",
           "title" : "Retention of documents obtained under paragraph 130",
           "ref" : "schedule-11-paragraph-131",
+          "id" : "schedule-11-paragraph-131",
+          "href" : "schedule/11/paragraph/131",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "132",
           "title" : "Offences etc",
           "ref" : "schedule-11-paragraph-132",
+          "id" : "schedule-11-paragraph-132",
+          "href" : "schedule/11/paragraph/132",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "133",
           "title" : "Prosecution of offences under paragraph 132",
           "ref" : "schedule-11-paragraph-133",
+          "id" : "schedule-11-paragraph-133",
+          "href" : "schedule/11/paragraph/133",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "134",
           "title" : "Offences under paragraph 132 by bodies corporate etc",
           "ref" : "schedule-11-paragraph-134",
+          "id" : "schedule-11-paragraph-134",
+          "href" : "schedule/11/paragraph/134",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "135",
           "title" : "Injunctions to prevent failure to comply with relevant requirement",
           "ref" : "schedule-11-paragraph-135",
+          "id" : "schedule-11-paragraph-135",
+          "href" : "schedule/11/paragraph/135",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "136",
           "title" : "Regulatory sanctions",
           "ref" : "schedule-11-paragraph-136",
+          "id" : "schedule-11-paragraph-136",
+          "href" : "schedule/11/paragraph/136",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "137",
           "title" : "Determination of sanctions",
           "ref" : "schedule-11-paragraph-137",
+          "id" : "schedule-11-paragraph-137",
+          "href" : "schedule/11/paragraph/137",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "138",
           "title" : "Procedure: warning notice",
           "ref" : "schedule-11-paragraph-138",
+          "id" : "schedule-11-paragraph-138",
+          "href" : "schedule/11/paragraph/138",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "139",
           "title" : "Procedure: decision notice",
           "ref" : "schedule-11-paragraph-139",
+          "id" : "schedule-11-paragraph-139",
+          "href" : "schedule/11/paragraph/139",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "140",
           "title" : "Procedure: general",
           "ref" : "schedule-11-paragraph-140",
+          "id" : "schedule-11-paragraph-140",
+          "href" : "schedule/11/paragraph/140",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "141",
           "title" : "Appeals",
           "ref" : "schedule-11-paragraph-141",
+          "id" : "schedule-11-paragraph-141",
+          "href" : "schedule/11/paragraph/141",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "142",
           "title" : "Injunctions: failure to comply with certain paragraph 136 sanctions",
           "ref" : "schedule-11-paragraph-142",
+          "id" : "schedule-11-paragraph-142",
+          "href" : "schedule/11/paragraph/142",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "143",
           "title" : "Publication",
           "ref" : "schedule-11-paragraph-143",
+          "id" : "schedule-11-paragraph-143",
+          "href" : "schedule/11/paragraph/143",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "144",
           "title" : "Co-operation",
           "ref" : "schedule-11-paragraph-144",
+          "id" : "schedule-11-paragraph-144",
+          "href" : "schedule/11/paragraph/144",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -5454,24 +6450,32 @@
         "number" : "PART 7",
         "title" : "Third-country resolution actions",
         "ref" : "schedule-11-part-7",
+        "id" : "schedule-11-part-7",
+        "href" : "schedule/11/part/7",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "145",
           "title" : "Third-country resolution actions",
           "ref" : "schedule-11-paragraph-145",
+          "id" : "schedule-11-paragraph-145",
+          "href" : "schedule/11/paragraph/145",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "146",
           "title" : "Effects of recognition on third-country resolution action",
           "ref" : "schedule-11-paragraph-146",
+          "id" : "schedule-11-paragraph-146",
+          "href" : "schedule/11/paragraph/146",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "147",
           "title" : "Third-country instruments: supplementary provision",
           "ref" : "schedule-11-paragraph-147",
+          "id" : "schedule-11-paragraph-147",
+          "href" : "schedule/11/paragraph/147",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -5479,60 +6483,80 @@
         "number" : "PART 8",
         "title" : "General",
         "ref" : "schedule-11-part-8",
+        "id" : "schedule-11-part-8",
+        "href" : "schedule/11/part/8",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "148",
           "title" : "Information",
           "ref" : "schedule-11-paragraph-148",
+          "id" : "schedule-11-paragraph-148",
+          "href" : "schedule/11/paragraph/148",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "149",
           "title" : "Restrictions on disclosure of confidential information",
           "ref" : "schedule-11-paragraph-149",
+          "id" : "schedule-11-paragraph-149",
+          "href" : "schedule/11/paragraph/149",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "150",
           "title" : "Remedies on judicial review",
           "ref" : "schedule-11-paragraph-150",
+          "id" : "schedule-11-paragraph-150",
+          "href" : "schedule/11/paragraph/150",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "151",
           "title" : "Giving of notices, documents etc under this Schedule",
           "ref" : "schedule-11-paragraph-151",
+          "id" : "schedule-11-paragraph-151",
+          "href" : "schedule/11/paragraph/151",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "152",
           "title" : "“Financial assistance”",
           "ref" : "schedule-11-paragraph-152",
+          "id" : "schedule-11-paragraph-152",
+          "href" : "schedule/11/paragraph/152",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "153",
           "title" : "Modifications to the law",
           "ref" : "schedule-11-paragraph-153",
+          "id" : "schedule-11-paragraph-153",
+          "href" : "schedule/11/paragraph/153",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "154",
           "title" : "Interpretation",
           "ref" : "schedule-11-paragraph-154",
+          "id" : "schedule-11-paragraph-154",
+          "href" : "schedule/11/paragraph/154",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "155",
           "title" : "Recognised central counterparty",
           "ref" : "schedule-11-paragraph-155",
+          "id" : "schedule-11-paragraph-155",
+          "href" : "schedule/11/paragraph/155",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "156",
           "title" : "Interpretation: “CCP group company”, etc",
           "ref" : "schedule-11-paragraph-156",
+          "id" : "schedule-11-paragraph-156",
+          "href" : "schedule/11/paragraph/156",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -5540,18 +6564,24 @@
         "number" : "PART 9",
         "title" : "Treasury support for CCPs",
         "ref" : "schedule-11-part-9",
+        "id" : "schedule-11-part-9",
+        "href" : "schedule/11/part/9",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "157",
           "title" : "Consolidated Fund",
           "ref" : "schedule-11-paragraph-157",
+          "id" : "schedule-11-paragraph-157",
+          "href" : "schedule/11/paragraph/157",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "158",
           "title" : "National Loans Fund",
           "ref" : "schedule-11-paragraph-158",
+          "id" : "schedule-11-paragraph-158",
+          "href" : "schedule/11/paragraph/158",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -5559,48 +6589,64 @@
         "number" : "PART 10",
         "title" : "Consequential etc provision",
         "ref" : "schedule-11-part-10",
+        "id" : "schedule-11-part-10",
+        "href" : "schedule/11/part/10",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "159",
           "title" : "Bank of England Act 1998",
           "ref" : "schedule-11-paragraph-159",
+          "id" : "schedule-11-paragraph-159",
+          "href" : "schedule/11/paragraph/159",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "160",
           "title" : "Financial Services and Markets Act 2000",
           "ref" : "schedule-11-paragraph-160",
+          "id" : "schedule-11-paragraph-160",
+          "href" : "schedule/11/paragraph/160",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "161",
           "title" : "Companies Act 2006",
           "ref" : "schedule-11-paragraph-161",
+          "id" : "schedule-11-paragraph-161",
+          "href" : "schedule/11/paragraph/161",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "162",
           "title" : "Banking Act 2009",
           "ref" : "schedule-11-paragraph-162",
+          "id" : "schedule-11-paragraph-162",
+          "href" : "schedule/11/paragraph/162",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "163",
           "title" : "Financial Services Act 2012",
           "ref" : "schedule-11-paragraph-163",
+          "id" : "schedule-11-paragraph-163",
+          "href" : "schedule/11/paragraph/163",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "164",
           "title" : "Financial Services (Banking Reform) Act 2013",
           "ref" : "schedule-11-paragraph-164",
+          "id" : "schedule-11-paragraph-164",
+          "href" : "schedule/11/paragraph/164",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "165",
           "title" : "Modified application of corporate law to CCPs in resolution",
           "ref" : "schedule-11-paragraph-165",
+          "id" : "schedule-11-paragraph-165",
+          "href" : "schedule/11/paragraph/165",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -5609,18 +6655,24 @@
       "number" : "SCHEDULE 12",
       "title" : "Write-down orders",
       "ref" : "schedule-12",
+      "id" : "schedule-12",
+      "href" : "schedule/12",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "part",
         "number" : "PART 1",
         "title" : "Write-down orders: main provisions",
         "ref" : "schedule-12-part-1",
+        "id" : "schedule-12-part-1",
+        "href" : "schedule/12/part/1",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "1",
           "title" : "(1) Part 24 of FSMA 2000 (insolvency) is amended as...",
           "ref" : "schedule-12-paragraph-1",
+          "id" : "schedule-12-paragraph-1",
+          "href" : "schedule/12/paragraph/1",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -5628,12 +6680,16 @@
         "number" : "PART 2",
         "title" : "The manager of a write-down order",
         "ref" : "schedule-12-part-2",
+        "id" : "schedule-12-part-2",
+        "href" : "schedule/12/part/2",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "2",
           "title" : "After Schedule 19 to FSMA 2000 (competition information), insert— SCHEDULE...",
           "ref" : "schedule-12-paragraph-2",
+          "id" : "schedule-12-paragraph-2",
+          "href" : "schedule/12/paragraph/2",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -5641,12 +6697,16 @@
         "number" : "PART 3",
         "title" : "Further provision about write-down orders",
         "ref" : "schedule-12-part-3",
+        "id" : "schedule-12-part-3",
+        "href" : "schedule/12/part/3",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "3",
           "title" : "After Schedule 19A to FSMA 2000 (the manager of a...",
           "ref" : "schedule-12-paragraph-3",
+          "id" : "schedule-12-paragraph-3",
+          "href" : "schedule/12/paragraph/3",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -5654,30 +6714,40 @@
         "number" : "PART 4",
         "title" : "Write-down orders: financial services compensation scheme",
         "ref" : "schedule-12-part-4",
+        "id" : "schedule-12-part-4",
+        "href" : "schedule/12/part/4",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "4",
           "title" : "Part 15 of FSMA 2000 (the Financial Services Compensation Scheme)...",
           "ref" : "schedule-12-paragraph-4",
+          "id" : "schedule-12-paragraph-4",
+          "href" : "schedule/12/paragraph/4",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "5",
           "title" : "After section 217 (insurers in financial difficulties) insert— Insurers subject...",
           "ref" : "schedule-12-paragraph-5",
+          "id" : "schedule-12-paragraph-5",
+          "href" : "schedule/12/paragraph/5",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "6",
           "title" : "In section 219 (scheme manager’s power to require information), in...",
           "ref" : "schedule-12-paragraph-6",
+          "id" : "schedule-12-paragraph-6",
+          "href" : "schedule/12/paragraph/6",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "7",
           "title" : "After section 220 (scheme manager’s power to inspect information held...",
           "ref" : "schedule-12-paragraph-7",
+          "id" : "schedule-12-paragraph-7",
+          "href" : "schedule/12/paragraph/7",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -5685,36 +6755,48 @@
         "number" : "PART 5",
         "title" : "Consequential amendments",
         "ref" : "schedule-12-part-5",
+        "id" : "schedule-12-part-5",
+        "href" : "schedule/12/part/5",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "8",
           "title" : "FSMA 2000",
           "ref" : "schedule-12-paragraph-8",
+          "id" : "schedule-12-paragraph-8",
+          "href" : "schedule/12/paragraph/8",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "9",
           "title" : "(1) Section 348 (restrictions on disclosure of confidential information by...",
           "ref" : "schedule-12-paragraph-9",
+          "id" : "schedule-12-paragraph-9",
+          "href" : "schedule/12/paragraph/9",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "10",
           "title" : "In section 429 (Parliamentary control of statutory instruments), in subsection...",
           "ref" : "schedule-12-paragraph-10",
+          "id" : "schedule-12-paragraph-10",
+          "href" : "schedule/12/paragraph/10",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "11",
           "title" : "In Schedule 1ZB (the PRA), in paragraph 33(2) (exemption from...",
           "ref" : "schedule-12-paragraph-11",
+          "id" : "schedule-12-paragraph-11",
+          "href" : "schedule/12/paragraph/11",
           "extent" : [ "E", "W", "S", "NI" ]
         }, {
           "name" : "item",
           "number" : "12",
           "title" : "Financial Services and Markets Act 2000 (Disclosure of Confidential Information) Regulations 2001",
           "ref" : "schedule-12-paragraph-12",
+          "id" : "schedule-12-paragraph-12",
+          "href" : "schedule/12/paragraph/12",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -5723,18 +6805,24 @@
       "number" : "SCHEDULE 13",
       "title" : "Insurers in financial difficulties: enforcement of contracts",
       "ref" : "schedule-13",
+      "id" : "schedule-13",
+      "href" : "schedule/13",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "part",
         "number" : "PART 1",
         "title" : "New Schedule 19C to FSMA 2000",
         "ref" : "schedule-13-part-1",
+        "id" : "schedule-13-part-1",
+        "href" : "schedule/13/part/1",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "1",
           "title" : "(1) Part 24 of FSMA 2000 (insolvency) is amended as...",
           "ref" : "schedule-13-paragraph-1",
+          "id" : "schedule-13-paragraph-1",
+          "href" : "schedule/13/paragraph/1",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       }, {
@@ -5742,12 +6830,16 @@
         "number" : "PART 2",
         "title" : "Consequential amendments",
         "ref" : "schedule-13-part-2",
+        "id" : "schedule-13-part-2",
+        "href" : "schedule/13/part/2",
         "extent" : [ "E", "W", "S", "NI" ],
         "children" : [ {
           "name" : "item",
           "number" : "2",
           "title" : "In section 429 of FSMA 2000 (Parliamentary control of statutory...",
           "ref" : "schedule-13-paragraph-2",
+          "id" : "schedule-13-paragraph-2",
+          "href" : "schedule/13/paragraph/2",
           "extent" : [ "E", "W", "S", "NI" ]
         } ]
       } ]
@@ -5756,102 +6848,136 @@
       "number" : "SCHEDULE 14",
       "title" : "Credit unions",
       "ref" : "schedule-14",
+      "id" : "schedule-14",
+      "href" : "schedule/14",
       "extent" : [ "E", "W", "S" ],
       "children" : [ {
         "name" : "item",
         "number" : "1",
         "title" : "Introductory",
         "ref" : "schedule-14-paragraph-1",
+        "id" : "schedule-14-paragraph-1",
+        "href" : "schedule/14/paragraph/1",
         "extent" : [ "E", "W", "S" ]
       }, {
         "name" : "item",
         "number" : "2",
         "title" : "Specified financial activities",
         "ref" : "schedule-14-paragraph-2",
+        "id" : "schedule-14-paragraph-2",
+        "href" : "schedule/14/paragraph/2",
         "extent" : [ "E", "W", "S" ]
       }, {
         "name" : "item",
         "number" : "3",
         "title" : "After section 1 insert— Specified financial activities (1) The financial activities specified for the purposes of the...",
         "ref" : "schedule-14-paragraph-3",
+        "id" : "schedule-14-paragraph-3",
+        "href" : "schedule/14/paragraph/3",
         "extent" : [ "E", "W", "S" ]
       }, {
         "name" : "item",
         "number" : "4",
         "title" : "In section 2 (supplementary and transitional provisions as to registration),...",
         "ref" : "schedule-14-paragraph-4",
+        "id" : "schedule-14-paragraph-4",
+        "href" : "schedule/14/paragraph/4",
         "extent" : [ "E", "W", "S" ]
       }, {
         "name" : "item",
         "number" : "5",
         "title" : "Shares",
         "ref" : "schedule-14-paragraph-5",
+        "id" : "schedule-14-paragraph-5",
+        "href" : "schedule/14/paragraph/5",
         "extent" : [ "E", "W", "S" ]
       }, {
         "name" : "item",
         "number" : "6",
         "title" : "Ancillary services",
         "ref" : "schedule-14-paragraph-6",
+        "id" : "schedule-14-paragraph-6",
+        "href" : "schedule/14/paragraph/6",
         "extent" : [ "E", "W", "S" ]
       }, {
         "name" : "item",
         "number" : "7",
         "title" : "Loans",
         "ref" : "schedule-14-paragraph-7",
+        "id" : "schedule-14-paragraph-7",
+        "href" : "schedule/14/paragraph/7",
         "extent" : [ "E", "W", "S" ]
       }, {
         "name" : "item",
         "number" : "8",
         "title" : "Conditional sale and hire purchase agreements",
         "ref" : "schedule-14-paragraph-8",
+        "id" : "schedule-14-paragraph-8",
+        "href" : "schedule/14/paragraph/8",
         "extent" : [ "E", "W", "S" ]
       }, {
         "name" : "item",
         "number" : "9",
         "title" : "Insurance distribution activities",
         "ref" : "schedule-14-paragraph-9",
+        "id" : "schedule-14-paragraph-9",
+        "href" : "schedule/14/paragraph/9",
         "extent" : [ "E", "W", "S" ]
       }, {
         "name" : "item",
         "number" : "10",
         "title" : "Minor and consequential amendments",
         "ref" : "schedule-14-paragraph-10",
+        "id" : "schedule-14-paragraph-10",
+        "href" : "schedule/14/paragraph/10",
         "extent" : [ "E", "W", "S" ]
       }, {
         "name" : "item",
         "number" : "11",
         "title" : "In section 23A (power to make provision corresponding to provision...",
         "ref" : "schedule-14-paragraph-11",
+        "id" : "schedule-14-paragraph-11",
+        "href" : "schedule/14/paragraph/11",
         "extent" : [ "E", "W", "S" ]
       }, {
         "name" : "item",
         "number" : "12",
         "title" : "In section 29 (orders and regulations), in subsection (2) for...",
         "ref" : "schedule-14-paragraph-12",
+        "id" : "schedule-14-paragraph-12",
+        "href" : "schedule/14/paragraph/12",
         "extent" : [ "E", "W", "S" ]
       }, {
         "name" : "item",
         "number" : "13",
         "title" : "(1) Section 31 (interpretation, etc.) is amended as follows. ",
         "ref" : "schedule-14-paragraph-13",
+        "id" : "schedule-14-paragraph-13",
+        "href" : "schedule/14/paragraph/13",
         "extent" : [ "E", "W", "S" ]
       }, {
         "name" : "item",
         "number" : "14",
         "title" : "In Schedule 1 (matters to be provided for in rules...",
         "ref" : "schedule-14-paragraph-14",
+        "id" : "schedule-14-paragraph-14",
+        "href" : "schedule/14/paragraph/14",
         "extent" : [ "E", "W", "S" ]
       }, {
         "name" : "item",
         "number" : "15",
         "title" : "Transitional provision",
         "ref" : "schedule-14-paragraph-15",
+        "id" : "schedule-14-paragraph-15",
+        "href" : "schedule/14/paragraph/15",
         "extent" : [ "E", "W", "S" ]
       }, {
         "name" : "item",
         "number" : "16",
         "title" : "The amendment made by paragraph 13(4)(b) does not apply in...",
         "ref" : "schedule-14-paragraph-16",
+        "id" : "schedule-14-paragraph-16",
+        "href" : "schedule/14/paragraph/16",
         "extent" : [ "E", "W", "S" ]
       } ]
     } ]

--- a/src/test/resources/ukpga_Geo6_6-7_48/ukpga-Geo6-6-7-48-contents-1991-02-01.json
+++ b/src/test/resources/ukpga_Geo6_6-7_48/ukpga-Geo6-6-7-48-contents-1991-02-01.json
@@ -45,6 +45,8 @@
       "number" : null,
       "title" : "Introductory Text",
       "ref" : "introduction",
+      "id" : null,
+      "href" : null,
       "extent" : [ "E", "W", "S", "NI" ]
     },
     "body" : [ {
@@ -52,18 +54,24 @@
       "number" : "Parts I, II",
       "title" : null,
       "ref" : "part-1",
+      "id" : "part-1",
+      "href" : "part/1",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "1—25",
         "title" : ". . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . ",
         "ref" : "section-125",
+        "id" : "section-125",
+        "href" : "section/125",
         "extent" : [ "E", "W", "S", "NI" ]
       }, {
         "name" : "item",
         "number" : "26–33",
         "title" : ". . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . ",
         "ref" : "section-2633",
+        "id" : "section-2633",
+        "href" : "section/2633",
         "extent" : [ "E", "W", "S", "NI" ]
       } ]
     }, {
@@ -71,12 +79,16 @@
       "number" : "Part III",
       "title" : " Meeting of Parliament when Prorogued",
       "ref" : "part-III",
+      "id" : "part-III",
+      "href" : "part/III",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "34",
         "title" : " Time for summoning parliament during prorogation.",
         "ref" : "section-34",
+        "id" : "section-34",
+        "href" : "section/34",
         "extent" : [ "E", "W", "S", "NI" ]
       } ]
     }, {
@@ -84,12 +96,16 @@
       "number" : "Part IV",
       "title" : " General",
       "ref" : "part-IV",
+      "id" : "part-IV",
+      "href" : "part/IV",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "35",
         "title" : " Short title.",
         "ref" : "section-35",
+        "id" : "section-35",
+        "href" : "section/35",
         "extent" : [ "E", "W", "S", "NI" ]
       } ]
     } ],
@@ -98,12 +114,16 @@
       "number" : "FIRST AND SECOND SCHEDULES",
       "title" : null,
       "ref" : "schedule-1",
+      "id" : "schedule-1",
+      "href" : "schedule/1",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "",
         "title" : ". . . . . . . . . ....",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ ]
       } ]
     }, {
@@ -111,12 +131,16 @@
       "number" : "SCHEDULE THREE",
       "title" : null,
       "ref" : "schedule-THREE",
+      "id" : "schedule-THREE",
+      "href" : "schedule/THREE",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "",
         "title" : ". . . . . . . . . ....",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ ]
       } ]
     }, {
@@ -124,12 +148,16 @@
       "number" : "SCHEDULE FOUR",
       "title" : null,
       "ref" : "schedule-FOUR",
+      "id" : "schedule-FOUR",
+      "href" : "schedule/FOUR",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "",
         "title" : ". . . . . . . . . ....",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ ]
       } ]
     }, {
@@ -137,12 +165,16 @@
       "number" : "SCHEDULE FIVE",
       "title" : null,
       "ref" : "schedule-FIVE",
+      "id" : "schedule-FIVE",
+      "href" : "schedule/FIVE",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "",
         "title" : ". . . . . . . . . ....",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ ]
       } ]
     }, {
@@ -150,12 +182,16 @@
       "number" : "SCHEDULE SIX",
       "title" : null,
       "ref" : "schedule-SIX",
+      "id" : "schedule-SIX",
+      "href" : "schedule/SIX",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "",
         "title" : ". . . . . . . . . ....",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ ]
       } ]
     }, {
@@ -163,12 +199,16 @@
       "number" : "SCHEDULE SEVEN",
       "title" : null,
       "ref" : "schedule-SEVEN",
+      "id" : "schedule-SEVEN",
+      "href" : "schedule/SEVEN",
       "extent" : [ "E", "W", "S", "NI" ],
       "children" : [ {
         "name" : "item",
         "number" : "",
         "title" : ". . . . . . . . . ....",
-        "ref" : "",
+        "ref" : null,
+        "id" : null,
+        "href" : null,
         "extent" : [ ]
       } ]
     } ]

--- a/src/test/resources/ukpga_Geo6_6-7_48/ukpga-Geo6-6-7-48-part-1-1991-02-01.json
+++ b/src/test/resources/ukpga_Geo6_6-7_48/ukpga-Geo6-6-7-48-part-1-1991-02-01.json
@@ -41,23 +41,23 @@
     "fragmentInfo" : {
       "element" : "Part",
       "id" : "part-1",
-      "href" : "ukpga/Geo6/6-7/48/part/1/1991-02-01",
+      "href" : "part/1",
       "number" : "Parts I, II",
       "title" : null,
       "label" : "Parts I, II"
     },
     "prevInfo" : {
-      "href" : "ukpga/Geo6/6-7/48/introduction/1991-02-01",
+      "href" : "introduction",
       "label" : "Introduction"
     },
     "nextInfo" : {
-      "href" : "ukpga/Geo6/6-7/48/part/III/1991-02-01",
+      "href" : "part/III",
       "label" : "Part"
     },
     "ancestors" : [ {
       "element" : "Part",
       "id" : "part-1",
-      "href" : "ukpga/Geo6/6-7/48/part/1/1991-02-01",
+      "href" : "part/1",
       "number" : "Parts I, II",
       "title" : null,
       "label" : "Parts I, II"
@@ -65,21 +65,21 @@
     "descendants" : [ {
       "element" : "Part",
       "id" : "part-1",
-      "href" : "ukpga/Geo6/6-7/48/part/1/1991-02-01",
+      "href" : "part/1",
       "number" : "Parts I, II",
       "title" : null,
       "label" : "Parts I, II"
     }, {
       "element" : "P1",
       "id" : "section-125",
-      "href" : "ukpga/Geo6/6-7/48/section/125/1991-02-01",
+      "href" : "section/125",
       "number" : "1",
       "title" : ". . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .",
       "label" : "Section 125"
     }, {
       "element" : "P1",
       "id" : "section-2633",
-      "href" : "ukpga/Geo6/6-7/48/section/2633/1991-02-01",
+      "href" : "section/2633",
       "number" : "26–33",
       "title" : ". . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .",
       "label" : "Section 2633"

--- a/src/test/resources/uksi_2025_3/uksi-2025-3-contents-made.json
+++ b/src/test/resources/uksi_2025_3/uksi-2025-3-contents-made.json
@@ -49,6 +49,8 @@
       "number" : null,
       "title" : "Introductory Text",
       "ref" : "introduction",
+      "id" : null,
+      "href" : null,
       "extent" : [ "E", "W", "S", "NI" ]
     },
     "body" : [ {
@@ -56,42 +58,56 @@
       "number" : "1",
       "title" : "Citation, commencement and extent",
       "ref" : "regulation-1",
+      "id" : "regulation-1",
+      "href" : "regulation/1",
       "extent" : [ "E", "W", "S", "NI" ]
     }, {
       "name" : "item",
       "number" : "2",
       "title" : "Amendment of the State Pension Credit Regulations 2002",
       "ref" : "regulation-2",
+      "id" : "regulation-2",
+      "href" : "regulation/2",
       "extent" : [ "E", "W", "S", "NI" ]
     }, {
       "name" : "item",
       "number" : "3",
       "title" : "Amendment of the Housing Benefit Regulations 2006",
       "ref" : "regulation-3",
+      "id" : "regulation-3",
+      "href" : "regulation/3",
       "extent" : [ "E", "W", "S", "NI" ]
     }, {
       "name" : "item",
       "number" : "4",
       "title" : "Amendment of the Housing Benefit (Persons who have attained the qualifying age for state pension credit) Regulations 2006",
       "ref" : "regulation-4",
+      "id" : "regulation-4",
+      "href" : "regulation/4",
       "extent" : [ "E", "W", "S", "NI" ]
     }, {
       "name" : "item",
       "number" : "5",
       "title" : "Amendment of the Universal Credit Regulations 2013",
       "ref" : "regulation-5",
+      "id" : "regulation-5",
+      "href" : "regulation/5",
       "extent" : [ "E", "W", "S", "NI" ]
     }, {
       "name" : "item",
       "number" : "6",
       "title" : "Amendment of the Universal Credit (Transitional Provisions) Regulations 2014",
       "ref" : "regulation-6",
+      "id" : "regulation-6",
+      "href" : "regulation/6",
       "extent" : [ "E", "W", "S", "NI" ]
     }, {
       "name" : "item",
       "number" : "7",
       "title" : "Amendment of the Welfare Reform Act 2012 (Commencement No. 32 and Savings and Transitional Provisions) Order 2019",
       "ref" : "regulation-7",
+      "id" : "regulation-7",
+      "href" : "regulation/7",
       "extent" : [ "E", "W", "S", "NI" ]
     } ],
     "signature" : {
@@ -99,6 +115,8 @@
       "number" : null,
       "title" : "Signature",
       "ref" : "signature",
+      "id" : null,
+      "href" : null,
       "extent" : [ "E", "W", "S", "NI" ]
     },
     "explanatoryNote" : {
@@ -106,6 +124,8 @@
       "number" : null,
       "title" : "Explanatory Note",
       "ref" : "note",
+      "id" : null,
+      "href" : null,
       "extent" : [ "E", "W", "S", "NI" ]
     }
   }

--- a/src/test/resources/uksi_2025_3/uksi-2025-3-regulation-2-made.json
+++ b/src/test/resources/uksi_2025_3/uksi-2025-3-regulation-2-made.json
@@ -45,23 +45,23 @@
     "fragmentInfo" : {
       "element" : "P1",
       "id" : "regulation-2",
-      "href" : "uksi/2025/3/regulation/2/made",
+      "href" : "regulation/2",
       "number" : "2",
       "title" : "Amendment of the State Pension Credit Regulations 2002",
       "label" : "Regulation 2"
     },
     "prevInfo" : {
-      "href" : "uksi/2025/3/regulation/1/made",
+      "href" : "regulation/1",
       "label" : "Provision"
     },
     "nextInfo" : {
-      "href" : "uksi/2025/3/regulation/3/made",
+      "href" : "regulation/3",
       "label" : "Provision"
     },
     "ancestors" : [ {
       "element" : "P1",
       "id" : "regulation-2",
-      "href" : "uksi/2025/3/regulation/2/made",
+      "href" : "regulation/2",
       "number" : "2",
       "title" : "Amendment of the State Pension Credit Regulations 2002",
       "label" : "Regulation 2"
@@ -69,49 +69,49 @@
     "descendants" : [ {
       "element" : "P1",
       "id" : "regulation-2",
-      "href" : "uksi/2025/3/regulation/2/made",
+      "href" : "regulation/2",
       "number" : "2",
       "title" : "Amendment of the State Pension Credit Regulations 2002",
       "label" : "Regulation 2"
     }, {
       "element" : "P2",
       "id" : "regulation-2-1",
-      "href" : "uksi/2025/3/regulation/2/1/made",
+      "href" : "regulation/2/1",
       "number" : "1",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P2",
       "id" : "regulation-2-2",
-      "href" : "uksi/2025/3/regulation/2/2/made",
+      "href" : "regulation/2/2",
       "number" : "2",
       "title" : null,
       "label" : "P2"
     }, {
       "element" : "P3",
       "id" : "regulation-2-2-a",
-      "href" : "uksi/2025/3/regulation/2/2/a/made",
+      "href" : "regulation/2/2/a",
       "number" : "a",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P3",
       "id" : "regulation-2-2-b",
-      "href" : "uksi/2025/3/regulation/2/2/b/made",
+      "href" : "regulation/2/2/b",
       "number" : "b",
       "title" : null,
       "label" : "P3"
     }, {
       "element" : "P4",
       "id" : "regulation-2-2-b-i",
-      "href" : "uksi/2025/3/regulation/2/2/b/i/made",
+      "href" : "regulation/2/2/b/i",
       "number" : "i",
       "title" : null,
       "label" : "P4"
     }, {
       "element" : "P4",
       "id" : "regulation-2-2-b-ii",
-      "href" : "uksi/2025/3/regulation/2/2/b/ii/made",
+      "href" : "regulation/2/2/b/ii",
       "number" : "ii",
       "title" : null,
       "label" : "P4"


### PR DESCRIPTION
**Summary**
  - Harden metadata versioning so the API can reliably report the active snapshot and complete version
  list when MarkLogic only supplies a mix of `"current"` markers, sporadic dates, or implicit prospective
  entries.
  - Surface fragment-level status/start/end dates all the way through the simplified model and JSON
  responses.
  - Stop hand-munging fragment slugs: reuse the canonical `href` fragments from the feed so crossheading
  links keep their in-name dashes intact.

  **Background**
  - docs/notes/2025-10-16-metadata-versioning-problem.md captures the pain points we’ve been seeing in
  the feeds: `"current"` sometimes means “prospective”, first publications suppress their own `enacted/
  made/...` label, fragment `dct:valid` can lag behind document revisions, and the prospective flag only
  appears on the first descendant node. The UI needs both a trustworthy scalar `version()` and an ordered
  `versions()` set; until now we couldn’t reconcile them whenever the feed got sparse or mixed human
  labels with ISO dates.
  - Separately, the Django UI was tripping over fragment URLs because we forced every ID to replace `-`
  with `/`, so a level like `crossheading-final-provisions` became `crossheading/final/provisions` and the
  link died.

  **What’s in this PR**
  - `Metadata.version()` now walks the normalised version set to prefer real ISO dates, falling back to a
  detected prospective flag or the raw `dct:valid` only when we truly have no dated material. `versions()`
  removes the noisy `"current"` stub, re-injects the authoritative `dct:valid` date when needed,
  guarantees the first-version label for `status="final"` snapshots, and keeps the scalar/set pairing in
  sync when we infer “prospective”.
  - We thread fragment status plus `RestrictStartDate/RestrictEndDate` through `Level` so the REST
  responses expose them; new fixtures and regression tests cover the updated shape.
  - `Links.extractFragmentIdentifierFromLink(..)` now works with a `URI`, and both the XSLT and converters
  stash the canonical `href` fragment in the simplified model. The API responses (and downstream clients)
  can therefore link to crossheadings and other multi-word fragments without corrupting the slug.

