### PR TITLE
Document possibility of missing date

### DIFF
--- a/src/main/java/uk/gov/legislation/api/responses/CommonMetadata.java
+++ b/src/main/java/uk/gov/legislation/api/responses/CommonMetadata.java
@@ -39,7 +39,7 @@ public abstract class CommonMetadata {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public String isbn;
 
-    @Schema(example = "2024-01-25")
+    @Schema(example = "2024-01-25", nullable = true)
     public LocalDate date;
 
     @Schema(example = "2024 c. 1")


### PR DESCRIPTION
This is a tiny, simple change, only to a Swagger annotation, to make clear that the document date might be missing.