### PR TITLE
Fix DocxTest delegate isolation by making XSLT processor per-instance

### DIFF
--- a/src/test/java/uk/gov/legislation/transform/clml2docx/DocxTest.java
+++ b/src/test/java/uk/gov/legislation/transform/clml2docx/DocxTest.java
@@ -2,6 +2,7 @@ package uk.gov.legislation.transform.clml2docx;
 
 import net.sf.saxon.s9api.SaxonApiException;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.legislation.transform.TransformHelper;
@@ -18,7 +19,7 @@ import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class DocxTest {
 
     public static Stream<String> provide() {

--- a/src/test/java/uk/gov/legislation/transform/clml2docx/DocxTestRedo.java
+++ b/src/test/java/uk/gov/legislation/transform/clml2docx/DocxTestRedo.java
@@ -1,0 +1,29 @@
+package uk.gov.legislation.transform.clml2docx;
+
+import uk.gov.legislation.transform.TransformHelper;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+public class DocxTestRedo {
+
+    public static void main(String[] args) throws Exception {
+        // Create a SINGLE instance and reuse it, matching the test's behavior
+        // with @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+        Clml2Docx transform = new Clml2Docx(new DocxTest.Delegate());
+        int updated = 0;
+        for (String id : DocxTest.provide().toList()) {
+            String clml = TransformHelper.read(id, "xml");
+            byte[] docx = transform.transform(new ByteArrayInputStream(clml.getBytes(StandardCharsets.UTF_8)));
+            String actual = DocxTest.extractDocumentXml(docx);
+            String expected = TransformHelper.read(id, DocxTest.DOCX_XML_EXT);
+            if (expected.equals(actual))
+                continue;
+            System.out.println("Updating fixture for: " + id);
+            TransformHelper.write(id, DocxTest.DOCX_XML_EXT, actual);
+            updated++;
+        }
+        System.out.println("Updated " + updated + " fixtures");
+    }
+
+}


### PR DESCRIPTION
## Problem:

When DocxTest ran as part of the full test suite, it would download real images from legislation.gov.uk instead of using dummy test images. This happened because:

  1. Spring Boot startup created the Clml2Docx @Service bean via the no-arg constructor, which instantiated LegislationApiDelegate
  2. The XSLT constructor registered Saxon extension functions that captured references to that LegislationApiDelegate
  3. The XsltExecutable was compiled and cached in a static field
  4. When DocxTest later created new Clml2Docx(new DocxTest.Delegate()), the XSLT constructor saw the static executable was already compiled and skipped recompilation, continuing to use the LegislationApiDelegate baked into the extension functions

Tests were not hermetic: behavior changed based on test execution context.

## Solution:

Remove static from XsltExecutable field so each Clml2Docx gets its own compiled executable with its own delegate.

## Regression:

This caused 5 test failures because JUnit 5 creates a new test instance for each @ParameterizedTest invocation by default. With 20 test cases creating 20 DocxTest instances (each with a fresh Saxon Processor), generate-id() produced different values than the fixtures expected. Fixed by adding @TestInstance(PER_CLASS) to share one DocxTest instance across all parameterized tests.

## Changes:
  - XSLT.java: Remove static from executable, docType, resourceURIs fields
  - XSLT.java: Remove if (executable == null) check, always compile
  - DocxTest.java: Add @TestInstance(TestInstance.Lifecycle.PER_CLASS)
  - DocxTestRedo.java: Update to match single-instance test behavior
  - Regenerate 5 test fixtures with consistent generate-id() output
