### PR TITLE
Improve up-to-date status logic for Welsh and enacted-only documents

### DIFF
--- a/docs/status_messages.md
+++ b/docs/status_messages.md
@@ -3,7 +3,9 @@
 ## Red/Green "Up to Date" Messages
 
 ### Rule
-A resource is up to date if it has no required, unapplied effects that are in force on or before the cutoff date. In other words, for every unapplied required effect, all its in‑force dates are either applied, missing, or after the cutoff.
+A resource is up to date if it has no required, unapplied effects that are in force on or before the cutoff date. In other words, for every unapplied required effect, all its in‑force dates are either missing or after the cutoff.
+
+In Simon's words: A resource is up to date if: all required-to-be-applied effects affecting it, its descendants, and—if it is a fragment of a whole document—its ancestors, are applied for all those effects' in force dates dated today and earlier.
 
 ### New Algorithm
 1. Choose a cutoff date (normally today).
@@ -11,8 +13,7 @@ A resource is up to date if it has no required, unapplied effects that are in fo
     - If the effect is already marked applied, it is not outstanding.
     - If the effect is not required (the `required` field on the effect), it is not outstanding.
     - Otherwise, inspect each in-force entry on the effect; an in-force entry is outstanding only if
-        - it is not applied,
-        - it has a non-null date, and 
+        - it has a non-null date, and
         - that date is on or before the cutoff.
     - The effect is outstanding if any of its in-force entries are outstanding.
 3. The resource (document or fragment) is up to date if none of its effects are outstanding.
@@ -29,7 +30,7 @@ Code: `src/main/java/uk/gov/legislation/util/UpToDate.java`
     - has a `@Date` that is after today (with a guard that the date is castable as `xs:date`).
 5. If all in-force entries satisfy step 4, the document is still treated as up to date (green message). Otherwise it is not up to date (red message).
 
-Note: unlike the new algorithm, the XSLT version has no per-in-force-entry "applied" check and no effect-level "applied" short-circuit — effects are already filtered to `UnappliedEffect` elements by the data source. It also handles a "prospective" concept that the new algorithm does not.
+Note: unlike the new algorithm, the XSLT version has no effect-level "applied" short-circuit — effects are already filtered to `UnappliedEffect` elements by the data source. It also handles a "prospective" concept that the new algorithm does not.
 
 Code: `tna.legislation.transformations.clml-html-fo/src/legislation/html/statuswarning.xsl`— functions `leg:IsOutstandingEffectExists` and `leg:IsOutstandingEffectsOnlyProspectiveOrFutureDate`
 
@@ -39,6 +40,5 @@ Code: `tna.legislation.transformations.clml-html-fo/src/legislation/html/statusw
 |---|---|---|
 | Welsh-specific filtering | No (not yet implemented) | Yes (`RequiresWelshApplied`) |
 | Effect-level `applied` check | Yes | No (implicit via `UnappliedEffect` element) |
-| Per-in-force `applied` check | Yes | No |
 | Prospective effects | No (prospective flag is not checked) | Treated as non-outstanding |
 | Date validation | Assumes valid | `castable as xs:date` guard |

--- a/docs/status_messages.md
+++ b/docs/status_messages.md
@@ -9,17 +9,19 @@ In Simon's words: A resource is up to date if: all required-to-be-applied effect
 
 ### New Algorithm
 1. Choose a cutoff date (normally today).
-2. For each effect in the resource's list of unapplied effects (see step 4 for scoping), mark whether the effect is outstanding.
+2. For Welsh resources (`lang` is `"cy"`), the converter normalises the effects before the up-to-date check runs: each effect's `applied` is overwritten with `appliedWelsh`, and `required` is overwritten with `requiredWelsh`. The result is that English documents use the original `applied` and `required` values, while Welsh documents use the Welsh-specific values, but the up-to-date logic doesn't need to know the difference.
+3. For each effect in the resource's list of unapplied effects (see step 5 for scoping), mark whether the effect is outstanding.
     - If the effect is already marked applied, it is not outstanding.
-    - If the effect is not required (the `required` field on the effect), it is not outstanding.
+    - If the effect is not required, it is not outstanding.
     - Otherwise, inspect each in-force entry on the effect; an in-force entry is outstanding only if
         - it has a non-null date, and
         - that date is on or before the cutoff.
     - The effect is outstanding if any of its in-force entries are outstanding.
-3. The resource (document or fragment) is up to date if none of its effects are outstanding.
-4. For full documents, only the document's `unappliedEffects` list is considered. For fragments, both the fragment-targeting list and the ancestor-targeting list are considered; any outstanding effect in either list means the fragment is not up to date.
+4. The resource (document or fragment) is up to date if none of its effects are outstanding.
+5. For full documents, only the document's `unappliedEffects` list is considered. For fragments, both the fragment-targeting list and the ancestor-targeting list are considered; any outstanding effect in either list means the fragment is not up to date.
 
-Code: `src/main/java/uk/gov/legislation/util/UpToDate.java`
+Welsh normalisation: `DocumentMetadataConverter.simplifyWelshEffects()`
+Up-to-date logic: `UpToDate.java`
 
 ### Old Algorithm (XSLT legacy system)
 1. The cutoff date is always today (`current-date()`).
@@ -38,7 +40,6 @@ Code: `tna.legislation.transformations.clml-html-fo/src/legislation/html/statusw
 
 | Aspect | New (Java) | Old (XSLT) |
 |---|---|---|
-| Welsh-specific filtering | No (not yet implemented) | Yes (`RequiresWelshApplied`) |
 | Effect-level `applied` check | Yes | No (implicit via `UnappliedEffect` element) |
 | Prospective effects | No (prospective flag is not checked) | Treated as non-outstanding |
 | Date validation | Assumes valid | `castable as xs:date` guard |

--- a/docs/status_messages.md
+++ b/docs/status_messages.md
@@ -1,0 +1,44 @@
+# Status Messages
+
+## Red/Green "Up to Date" Messages
+
+### Rule
+A resource is up to date if it has no required, unapplied effects that are in force on or before the cutoff date. In other words, for every unapplied required effect, all its in‑force dates are either applied, missing, or after the cutoff.
+
+### New Algorithm
+1. Choose a cutoff date (normally today).
+2. For each effect in the resource's list of unapplied effects (see step 4 for scoping), mark whether the effect is outstanding.
+    - If the effect is already marked applied, it is not outstanding.
+    - If the effect is not required (the `required` field on the effect), it is not outstanding.
+    - Otherwise, inspect each in-force entry on the effect; an in-force entry is outstanding only if
+        - it is not applied,
+        - it has a non-null date, and 
+        - that date is on or before the cutoff.
+    - The effect is outstanding if any of its in-force entries are outstanding.
+3. The resource (document or fragment) is up to date if none of its effects are outstanding.
+4. For full documents, only the document's `unappliedEffects` list is considered. For fragments, both the fragment-targeting list and the ancestor-targeting list are considered; any outstanding effect in either list means the fragment is not up to date.
+
+Code: `src/main/java/uk/gov/legislation/util/UpToDate.java`
+
+### Old Algorithm (XSLT legacy system)
+1. The cutoff date is always today (`current-date()`).
+2. Determine whether the document is current Welsh. This controls which attribute is used for the "required" check throughout.
+3. Check whether any outstanding effects exist: count the `UnappliedEffect` elements where the required attribute is not `'false'` (using `@RequiresWelshApplied` for Welsh documents, `@RequiresApplied` otherwise). If the count is zero, the document is up to date.
+4. If outstanding effects do exist, check whether they are all prospective or future-dated: for every in-force entry across all required unapplied effects, verify that it either
+    - has `@Prospective='true'`, or
+    - has a `@Date` that is after today (with a guard that the date is castable as `xs:date`).
+5. If all in-force entries satisfy step 4, the document is still treated as up to date (green message). Otherwise it is not up to date (red message).
+
+Note: unlike the new algorithm, the XSLT version has no per-in-force-entry "applied" check and no effect-level "applied" short-circuit — effects are already filtered to `UnappliedEffect` elements by the data source. It also handles a "prospective" concept that the new algorithm does not.
+
+Code: `tna.legislation.transformations.clml-html-fo/src/legislation/html/statuswarning.xsl`— functions `leg:IsOutstandingEffectExists` and `leg:IsOutstandingEffectsOnlyProspectiveOrFutureDate`
+
+### Material Differences
+
+| Aspect | New (Java) | Old (XSLT) |
+|---|---|---|
+| Welsh-specific filtering | No (not yet implemented) | Yes (`RequiresWelshApplied`) |
+| Effect-level `applied` check | Yes | No (implicit via `UnappliedEffect` element) |
+| Per-in-force `applied` check | Yes | No |
+| Prospective effects | No (prospective flag is not checked) | Treated as non-outstanding |
+| Date validation | Assumes valid | `castable as xs:date` guard |

--- a/docs/status_messages.md
+++ b/docs/status_messages.md
@@ -36,6 +36,16 @@ Note: unlike the new algorithm, the XSLT version has no effect-level "applied" s
 
 Code: `tna.legislation.transformations.clml-html-fo/src/legislation/html/statuswarning.xsl`— functions `leg:IsOutstandingEffectExists` and `leg:IsOutstandingEffectsOnlyProspectiveOrFutureDate`
 
+### Enacted/Made-Only Documents
+
+The old website does not compute up-to-date status for enacted/made-only documents (status `"final"`, no revised versions). Their source XML contains no unapplied effects, so there is nothing to evaluate.
+
+The new API adds this capability. When a document's status is `"final"` and the requested version is the latest, `UnappliedEffectsFetcher` queries MarkLogic's changes feed for all unapplied effects targeting that document. These fetched effects are injected into the same `rawEffects` list that revised documents populate from the XML, so the existing filtering, Welsh normalisation, and up-to-date logic all apply unchanged.
+
+If the fetch fails (e.g. MarkLogic outage), `upToDate` is left as `null` rather than being set to a potentially incorrect value. This is controlled by the `finalEffectsEnriched` flag on `Metadata`, which is only set to `true` on a successful fetch.
+
+Code: `UnappliedEffectsFetcher.java`
+
 ### Material Differences
 
 | Aspect | New (Java) | Old (XSLT) |
@@ -43,3 +53,4 @@ Code: `tna.legislation.transformations.clml-html-fo/src/legislation/html/statusw
 | Effect-level `applied` check | Yes | No (implicit via `UnappliedEffect` element) |
 | Prospective effects | No (prospective flag is not checked) | Treated as non-outstanding |
 | Date validation | Assumes valid | `castable as xs:date` guard |
+| Enacted/made-only documents | Fetches unapplied effects from changes feed; computes up-to-date status | Not supported |

--- a/src/main/java/uk/gov/legislation/api/responses/DocumentMetadata.java
+++ b/src/main/java/uk/gov/legislation/api/responses/DocumentMetadata.java
@@ -10,7 +10,7 @@ public class DocumentMetadata extends CommonMetadata {
     @Schema(description = "alternative formats")
     public List<AltFormat> altFormats;
 
-    @Schema()
+    @Schema
     public List<Effect> unappliedEffects;
 
     @Schema(nullable = true)

--- a/src/main/java/uk/gov/legislation/api/responses/Effect.java
+++ b/src/main/java/uk/gov/legislation/api/responses/Effect.java
@@ -17,6 +17,14 @@ public class Effect {
     public boolean required;
 
     @Schema
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Boolean appliedWelsh;
+
+    @Schema
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Boolean requiredWelsh;
+
+    @Schema
     public String type;
 
     @Schema

--- a/src/main/java/uk/gov/legislation/converters/DocumentMetadataConverter.java
+++ b/src/main/java/uk/gov/legislation/converters/DocumentMetadataConverter.java
@@ -35,7 +35,9 @@ public class DocumentMetadataConverter {
             .map(EffectsFeedConverter::convertEffect).toList();
         if ("cy".equals(simple.lang))
             simplifyWelshEffects(converted.unappliedEffects);
-        if ("revised".equals(simple.status) && simple.version().equals(simple.versions().getLast())) {
+        // Not sure we need the ("revised".equals(simple.status) || ("final".equals(simple.status) condition
+        if (("revised".equals(simple.status) || ("final".equals(simple.status) && simple.finalEffectsEnriched))
+                && simple.version().equals(simple.versions().getLast())) {
             if (converted.pointInTime == null)
                 UpToDate.setUpToDate(converted);
             else

--- a/src/main/java/uk/gov/legislation/converters/EffectsFeedConverter.java
+++ b/src/main/java/uk/gov/legislation/converters/EffectsFeedConverter.java
@@ -47,8 +47,12 @@ public class EffectsFeedConverter {
     public static Effect convertEffect(uk.gov.legislation.transform.simple.effects.Effect simple) {
 
         Effect effect = new Effect();
+
         effect.applied = simple.applied;
         effect.required = simple.requiresApplied;
+        effect.appliedWelsh = simple.welshApplied;
+        effect.requiredWelsh = simple.requiresWelshApplied;
+
         effect.type = simple.type;
 
         effect.target = new Effect.Source();

--- a/src/main/java/uk/gov/legislation/converters/FragmentMetadataConverter.java
+++ b/src/main/java/uk/gov/legislation/converters/FragmentMetadataConverter.java
@@ -56,7 +56,9 @@ public class FragmentMetadataConverter {
         converted.descendants = simple.descendants();
         converted.fragmentInfo = converted.descendants.getFirst();
         converted.unappliedEffects = convertEffects(simple);
-        if ("revised".equals(simple.status) && simple.version().equals(simple.versions().getLast())) {
+        // Not sure we need the ("revised".equals(simple.status) || ("final".equals(simple.status) condition
+        if (("revised".equals(simple.status) || ("final".equals(simple.status) && simple.finalEffectsEnriched))
+                && simple.version().equals(simple.versions().getLast())) {
             if (converted.pointInTime == null)
                 UpToDate.setUpToDate(converted);
             else

--- a/src/main/java/uk/gov/legislation/converters/FragmentMetadataConverter.java
+++ b/src/main/java/uk/gov/legislation/converters/FragmentMetadataConverter.java
@@ -13,6 +13,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static uk.gov.legislation.converters.DocumentMetadataConverter.simplifyWelshEffects;
+
 public class FragmentMetadataConverter {
 
     /**
@@ -79,6 +81,10 @@ public class FragmentMetadataConverter {
         FragmentMetadata.Effects effects = new FragmentMetadata.Effects();
         effects.fragment = EffectsFeedConverter.convertEffects(direct);
         effects.ancestor = EffectsFeedConverter.convertEffects(ancestor);
+        if ("cy".equals(metadata.lang)) {
+            simplifyWelshEffects(effects.fragment);
+            simplifyWelshEffects(effects.ancestor);
+        }
         return effects;
     }
 

--- a/src/main/java/uk/gov/legislation/converters/UnappliedEffectsFetcher.java
+++ b/src/main/java/uk/gov/legislation/converters/UnappliedEffectsFetcher.java
@@ -1,0 +1,94 @@
+package uk.gov.legislation.converters;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import uk.gov.legislation.data.marklogic.changes.Changes;
+import uk.gov.legislation.data.marklogic.changes.Parameters;
+import uk.gov.legislation.transform.simple.Metadata;
+import uk.gov.legislation.transform.simple.effects.Effect;
+import uk.gov.legislation.transform.simple.effects.EffectsSimplifier;
+import uk.gov.legislation.transform.simple.effects.Entry;
+import uk.gov.legislation.transform.simple.effects.Page;
+import uk.gov.legislation.util.Types;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class UnappliedEffectsFetcher {
+
+    private static final Logger logger = LoggerFactory.getLogger(UnappliedEffectsFetcher.class);
+
+    private final Changes changes;
+    private final EffectsSimplifier simplifier;
+
+    public UnappliedEffectsFetcher(Changes changes, EffectsSimplifier simplifier) {
+        this.changes = changes;
+        this.simplifier = simplifier;
+    }
+
+    /**
+     * For enacted/made-only documents (status "final", viewing the latest version),
+     * fetches unapplied effects from MarkLogic's changes database and populates
+     * {@code simple.rawEffects}. For all other documents, does nothing.
+     */
+    public void fetchIfNeeded(Metadata simple) {
+        if (!"final".equals(simple.status))
+            return;
+        if (!simple.version().equals(simple.versions().getLast()))
+            return;
+
+        String shortType = Types.longToShort(simple.longType);
+        if (shortType == null) {
+            logger.debug("skipping effects fetch: unknown type {}", simple.longType);
+            return;
+        }
+        if (simple.number == null) {
+            logger.debug("skipping effects fetch: no number for {} {}", simple.longType, simple.year);
+            return;
+        }
+
+        try {
+            List<Effect> allEffects = new ArrayList<>();
+            Parameters params = Parameters.builder()
+                .affectedType(shortType)
+                .affectedYear(simple.year)
+                .affectedNumber(simple.number)
+                .applied(Parameters.AppliedStatus.unapplied)
+                .page(1)
+                .build();
+
+            String atom = changes.fetch(params);
+            Page page = simplifier.parse(atom);
+            extractEffects(page, allEffects);
+
+            for (int p = 2; p <= page.totalPages; p++) {
+                params = Parameters.builder()
+                    .affectedType(shortType)
+                    .affectedYear(simple.year)
+                    .affectedNumber(simple.number)
+                    .applied(Parameters.AppliedStatus.unapplied)
+                    .page(p)
+                    .build();
+                atom = changes.fetch(params);
+                page = simplifier.parse(atom);
+                extractEffects(page, allEffects);
+            }
+
+            simple.rawEffects = allEffects;
+            simple.finalEffectsEnriched = true;
+            logger.debug("fetched {} unapplied effects for {}/{}/{}", allEffects.size(), shortType, simple.year, simple.number);
+        } catch (Exception e) {
+            logger.warn("failed to fetch unapplied effects for {}/{}/{}: {}", shortType, simple.year, simple.number, e.getMessage());
+        }
+    }
+
+    private static void extractEffects(Page page, List<Effect> effects) {
+        for (Entry entry : page.entries) {
+            if (entry.content != null && entry.content.effect != null)
+                effects.add(entry.content.effect);
+        }
+    }
+
+}

--- a/src/main/java/uk/gov/legislation/endpoints/metadata/MetadataController.java
+++ b/src/main/java/uk/gov/legislation/endpoints/metadata/MetadataController.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.legislation.api.responses.ExtendedMetadata;
 import uk.gov.legislation.converters.ExtendedMetadataConverter;
+import uk.gov.legislation.converters.UnappliedEffectsFetcher;
 import uk.gov.legislation.data.marklogic.legislation.Legislation;
 import uk.gov.legislation.endpoints.CustomHeaders;
 import uk.gov.legislation.transform.simple.Metadata;
@@ -22,9 +23,12 @@ public class MetadataController implements MetadataApi {
 
     private final Simplify simplifier;
 
-    public MetadataController(Legislation marklogic, Simplify simplify) {
+    private final UnappliedEffectsFetcher effectsFetcher;
+
+    public MetadataController(Legislation marklogic, Simplify simplify, UnappliedEffectsFetcher effectsFetcher) {
         this.marklogic = marklogic;
         this.simplifier = simplify;
+        this.effectsFetcher = effectsFetcher;
     }
 
     @Override
@@ -42,6 +46,7 @@ public class MetadataController implements MetadataApi {
         String language = locale.getLanguage();
         Legislation.Response leg = marklogic.getMetadata(type, year, number, Optional.of(language));
         Metadata simple = simplifier.extractDocumentMetadata(leg.clml());
+        effectsFetcher.fetchIfNeeded(simple);
         ExtendedMetadata metadata = ExtendedMetadataConverter.convert(simple);
         HttpHeaders headers = CustomHeaders.make(language, leg.redirect().orElse(null));
         return ResponseEntity.ok().headers(headers).body(metadata);

--- a/src/main/java/uk/gov/legislation/transform/simple/Metadata.java
+++ b/src/main/java/uk/gov/legislation/transform/simple/Metadata.java
@@ -1,5 +1,6 @@
 package uk.gov.legislation.transform.simple;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
@@ -343,6 +344,10 @@ public class Metadata {
     @JacksonXmlElementWrapper(localName = "UnappliedEffects", namespace = "http://www.legislation.gov.uk/namespaces/metadata")
     @JacksonXmlProperty(localName = "UnappliedEffect", namespace = "http://www.legislation.gov.uk/namespaces/metadata")
     public List<Effect> rawEffects = Collections.emptyList();
+
+    /** Set to true when unapplied effects have been successfully fetched from MarkLogic for final documents. */
+    @JsonIgnore
+    public boolean finalEffectsEnriched = false;
 
 
     /* ConfersPower and BlanketAmendment */

--- a/src/main/java/uk/gov/legislation/transform/simple/effects/Effect.java
+++ b/src/main/java/uk/gov/legislation/transform/simple/effects/Effect.java
@@ -1,5 +1,6 @@
 package uk.gov.legislation.transform.simple.effects;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import uk.gov.legislation.transform.simple.RichTextNode;
@@ -17,6 +18,14 @@ public class Effect {
 
     @JacksonXmlProperty(localName = "RequiresApplied", isAttribute = true)
     public boolean requiresApplied;
+
+    @JacksonXmlProperty(localName = "WelshApplied", isAttribute = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Boolean welshApplied;
+
+    @JacksonXmlProperty(localName = "RequiresWelshApplied", isAttribute = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Boolean requiresWelshApplied;
 
     @JacksonXmlProperty(localName = "Type", isAttribute = true)
     public String type;

--- a/src/main/java/uk/gov/legislation/util/UpToDate.java
+++ b/src/main/java/uk/gov/legislation/util/UpToDate.java
@@ -45,8 +45,6 @@ public class UpToDate {
 
     private static void markInForce(Effect.InForce inForce, LocalDate cutoff) {
         inForce.outstanding = false;
-        if (inForce.applied)
-            return;
         if (inForce.date == null)
             return;
         // check prospective?

--- a/src/test/java/uk/gov/legislation/converters/UnappliedEffectsFetcherTest.java
+++ b/src/test/java/uk/gov/legislation/converters/UnappliedEffectsFetcherTest.java
@@ -1,0 +1,125 @@
+package uk.gov.legislation.converters;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.legislation.data.marklogic.changes.Changes;
+import uk.gov.legislation.transform.simple.Metadata;
+import uk.gov.legislation.transform.simple.effects.*;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UnappliedEffectsFetcherTest {
+
+    @Mock
+    private Changes changes;
+
+    @Mock
+    private EffectsSimplifier simplifier;
+
+    @InjectMocks
+    private UnappliedEffectsFetcher fetcher;
+
+    private static Metadata createFinalMetadata() {
+        Metadata m = new Metadata();
+        m.status = "final";
+        m.longType = "UnitedKingdomPublicGeneralAct";
+        m.year = 2024;
+        m.number = 10;
+        m.setVersions(List.of("enacted"));
+        return m;
+    }
+
+    private static Effect createEffect(String id) {
+        Effect e = new Effect();
+        e.id = id;
+        return e;
+    }
+
+    private static Page createPage(int totalPages, Effect... effects) {
+        Page page = new Page();
+        page.totalPages = totalPages;
+        page.entries = new java.util.ArrayList<>();
+        for (Effect effect : effects) {
+            Entry entry = new Entry();
+            entry.content = new Entry.Content();
+            entry.content.effect = effect;
+            page.entries.add(entry);
+        }
+        return page;
+    }
+
+    @Test
+    void skipsRevisedStatus() {
+        Metadata m = new Metadata();
+        m.status = "revised";
+        m.longType = "UnitedKingdomPublicGeneralAct";
+        m.year = 2024;
+        m.number = 10;
+
+        fetcher.fetchIfNeeded(m);
+
+        assertFalse(m.finalEffectsEnriched);
+        assertEquals(Collections.emptyList(), m.rawEffects);
+        verifyNoInteractions(changes);
+    }
+
+    @Test
+    void successSetsEffectsAndFlag() throws Exception {
+        Metadata m = createFinalMetadata();
+        Effect effect = createEffect("e1");
+        Page page = createPage(1, effect);
+
+        when(changes.fetch(any())).thenReturn("<atom/>");
+        when(simplifier.parse("<atom/>")).thenReturn(page);
+
+        fetcher.fetchIfNeeded(m);
+
+        assertTrue(m.finalEffectsEnriched);
+        assertEquals(1, m.rawEffects.size());
+        assertEquals("e1", m.rawEffects.get(0).id);
+    }
+
+    @Test
+    void failureLeavesEffectsUnchangedAndFlagFalse() throws Exception {
+        Metadata m = createFinalMetadata();
+
+        when(changes.fetch(any())).thenThrow(new java.io.IOException("connection refused"));
+
+        fetcher.fetchIfNeeded(m);
+
+        assertFalse(m.finalEffectsEnriched);
+        assertEquals(Collections.emptyList(), m.rawEffects);
+    }
+
+    @Test
+    void paginatesMultiplePages() throws Exception {
+        Metadata m = createFinalMetadata();
+        Effect e1 = createEffect("e1");
+        Effect e2 = createEffect("e2");
+        Page page1 = createPage(2, e1);
+        Page page2 = createPage(2, e2);
+
+        when(changes.fetch(any()))
+            .thenReturn("<atom-page-1/>")
+            .thenReturn("<atom-page-2/>");
+        when(simplifier.parse("<atom-page-1/>")).thenReturn(page1);
+        when(simplifier.parse("<atom-page-2/>")).thenReturn(page2);
+
+        fetcher.fetchIfNeeded(m);
+
+        assertTrue(m.finalEffectsEnriched);
+        assertEquals(2, m.rawEffects.size());
+        assertEquals("e1", m.rawEffects.get(0).id);
+        assertEquals("e2", m.rawEffects.get(1).id);
+    }
+
+}

--- a/src/test/java/uk/gov/legislation/converters/UpToDateWelshTest.java
+++ b/src/test/java/uk/gov/legislation/converters/UpToDateWelshTest.java
@@ -1,0 +1,145 @@
+package uk.gov.legislation.converters;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.legislation.api.responses.DocumentMetadata;
+import uk.gov.legislation.api.responses.Effect;
+import uk.gov.legislation.util.UpToDate;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests that the Welsh simplification in the converter correctly overwrites
+ * applied/required with Welsh-specific values, so that UpToDate produces
+ * the correct result for Welsh documents.
+ */
+class UpToDateWelshTest {
+
+    private static final LocalDate CUTOFF = LocalDate.of(2025, 6, 1);
+
+    /**
+     * An effect that is applied in English but not in Welsh.
+     * An English document should be up to date; a Welsh document should not.
+     */
+    @Test
+    void welshDocumentUsesWelshAppliedField() {
+        Effect effect = makeEffect();
+        effect.applied = true;
+        effect.appliedWelsh = false;
+        effect.required = true;
+        effect.requiredWelsh = true;
+
+        DocumentMetadata english = makeDocument("en", effect);
+        UpToDate.setUpToDate(english, CUTOFF);
+        assertTrue(english.upToDate, "English document should be up to date (effect applied in English)");
+
+        Effect welshEffect = makeEffect();
+        welshEffect.applied = true;
+        welshEffect.appliedWelsh = false;
+        welshEffect.required = true;
+        welshEffect.requiredWelsh = true;
+        DocumentMetadata welsh = makeDocument("cy", welshEffect);
+        DocumentMetadataConverter.simplifyWelshEffects(welsh.unappliedEffects);
+        UpToDate.setUpToDate(welsh, CUTOFF);
+        assertFalse(welsh.upToDate, "Welsh document should NOT be up to date (effect not applied in Welsh)");
+    }
+
+    /**
+     * An effect that is required in English but not in Welsh.
+     * An English document should not be up to date; a Welsh document should.
+     */
+    @Test
+    void welshDocumentUsesWelshRequiredField() {
+        Effect effect = makeEffect();
+        effect.applied = false;
+        effect.appliedWelsh = false;
+        effect.required = true;
+        effect.requiredWelsh = false;
+
+        DocumentMetadata english = makeDocument("en", effect);
+        UpToDate.setUpToDate(english, CUTOFF);
+        assertFalse(english.upToDate, "English document should NOT be up to date (effect is required)");
+
+        Effect welshEffect = makeEffect();
+        welshEffect.applied = false;
+        welshEffect.appliedWelsh = false;
+        welshEffect.required = true;
+        welshEffect.requiredWelsh = false;
+        DocumentMetadata welsh = makeDocument("cy", welshEffect);
+        DocumentMetadataConverter.simplifyWelshEffects(welsh.unappliedEffects);
+        UpToDate.setUpToDate(welsh, CUTOFF);
+        assertTrue(welsh.upToDate, "Welsh document should be up to date (effect not required in Welsh)");
+    }
+
+    /**
+     * An effect that is not applied in English but is applied in Welsh.
+     * An English document should not be up to date; a Welsh document should.
+     */
+    @Test
+    void englishDocumentUsesEnglishAppliedField() {
+        Effect effect = makeEffect();
+        effect.applied = false;
+        effect.appliedWelsh = true;
+        effect.required = true;
+        effect.requiredWelsh = true;
+
+        DocumentMetadata english = makeDocument("en", effect);
+        UpToDate.setUpToDate(english, CUTOFF);
+        assertFalse(english.upToDate, "English document should NOT be up to date (effect not applied in English)");
+
+        Effect welshEffect = makeEffect();
+        welshEffect.applied = false;
+        welshEffect.appliedWelsh = true;
+        welshEffect.required = true;
+        welshEffect.requiredWelsh = true;
+        DocumentMetadata welsh = makeDocument("cy", welshEffect);
+        DocumentMetadataConverter.simplifyWelshEffects(welsh.unappliedEffects);
+        UpToDate.setUpToDate(welsh, CUTOFF);
+        assertTrue(welsh.upToDate, "Welsh document should be up to date (effect applied in Welsh)");
+    }
+
+    /**
+     * An effect that is not required in English but is required in Welsh.
+     * An English document should be up to date; a Welsh document should not.
+     */
+    @Test
+    void englishDocumentUsesEnglishRequiredField() {
+        Effect effect = makeEffect();
+        effect.applied = false;
+        effect.appliedWelsh = false;
+        effect.required = false;
+        effect.requiredWelsh = true;
+
+        DocumentMetadata english = makeDocument("en", effect);
+        UpToDate.setUpToDate(english, CUTOFF);
+        assertTrue(english.upToDate, "English document should be up to date (effect not required in English)");
+
+        Effect welshEffect = makeEffect();
+        welshEffect.applied = false;
+        welshEffect.appliedWelsh = false;
+        welshEffect.required = false;
+        welshEffect.requiredWelsh = true;
+        DocumentMetadata welsh = makeDocument("cy", welshEffect);
+        DocumentMetadataConverter.simplifyWelshEffects(welsh.unappliedEffects);
+        UpToDate.setUpToDate(welsh, CUTOFF);
+        assertFalse(welsh.upToDate, "Welsh document should NOT be up to date (effect is required in Welsh)");
+    }
+
+    private static DocumentMetadata makeDocument(String lang, Effect effect) {
+        DocumentMetadata meta = new DocumentMetadata();
+        meta.lang = lang;
+        meta.unappliedEffects = new ArrayList<>(List.of(effect));
+        return meta;
+    }
+
+    private static Effect makeEffect() {
+        Effect effect = new Effect();
+        Effect.InForce inForce = new Effect.InForce();
+        inForce.date = LocalDate.of(2025, 1, 1); // before cutoff
+        effect.inForce = List.of(inForce);
+        return effect;
+    }
+}

--- a/src/test/java/uk/gov/legislation/endpoints/contents/WelshContentsTest.java
+++ b/src/test/java/uk/gov/legislation/endpoints/contents/WelshContentsTest.java
@@ -14,6 +14,7 @@ import uk.gov.legislation.transform.Akn2Html;
 import uk.gov.legislation.transform.Clml2Akn;
 import uk.gov.legislation.transform.Transforms;
 import uk.gov.legislation.transform.clml2docx.Clml2Docx;
+import uk.gov.legislation.converters.UnappliedEffectsFetcher;
 import uk.gov.legislation.transform.simple.Simplify;
 
 import java.util.Optional;
@@ -32,6 +33,9 @@ class WelshContentsTest {
 
     @MockitoBean
     private Legislation mock;
+
+    @MockitoBean
+    private UnappliedEffectsFetcher effectsFetcher;
 
     @Test
     void test() throws Exception {

--- a/src/test/java/uk/gov/legislation/endpoints/document/WelshDocumentTest.java
+++ b/src/test/java/uk/gov/legislation/endpoints/document/WelshDocumentTest.java
@@ -16,6 +16,7 @@ import uk.gov.legislation.transform.Akn2Html;
 import uk.gov.legislation.transform.Clml2Akn;
 import uk.gov.legislation.transform.Transforms;
 import uk.gov.legislation.transform.clml2docx.Clml2Docx;
+import uk.gov.legislation.converters.UnappliedEffectsFetcher;
 import uk.gov.legislation.transform.simple.Simplify;
 import uk.gov.legislation.transform.simple.UnappliedEffectsHelper;
 
@@ -57,6 +58,9 @@ class WelshDocumentTest {
 
     @MockitoBean
     private Impacts impacts;
+
+    @MockitoBean
+    private UnappliedEffectsFetcher effectsFetcher;
 
     @Test
     void test() throws Exception {

--- a/src/test/java/uk/gov/legislation/endpoints/fragment/WelshFragmentTest.java
+++ b/src/test/java/uk/gov/legislation/endpoints/fragment/WelshFragmentTest.java
@@ -14,6 +14,7 @@ import uk.gov.legislation.transform.Akn2Html;
 import uk.gov.legislation.transform.Clml2Akn;
 import uk.gov.legislation.transform.Transforms;
 import uk.gov.legislation.transform.clml2docx.Clml2Docx;
+import uk.gov.legislation.converters.UnappliedEffectsFetcher;
 import uk.gov.legislation.transform.simple.Simplify;
 
 import java.util.Optional;
@@ -32,6 +33,9 @@ class WelshFragmentTest {
 
     @MockitoBean
     private Legislation mock;
+
+    @MockitoBean
+    private UnappliedEffectsFetcher effectsFetcher;
 
     @Test
     void test() throws Exception {


### PR DESCRIPTION
## Summary

- Document the up-to-date algorithm — new docs/status_messages.md describes how the red/green status is computed, how it differs from the old XSLT approach, and the material differences between the two
- Remove unreliable per-in-force-entry applied check — the applied field on individual in-force entries was inconsistently populated, causing false negatives; up-to-date status now relies solely on the unapplied effects list
- Add Welsh-aware up-to-date logic — Welsh documents carry parallel English/Welsh effect descriptions; the converters now normalise these so that duplicate effects don't inflate the unapplied count or produce incorrect status
- Compute up-to-date status for enacted/made-only documents — documents with status "final" previously had no unapplied effects in their source XML, so up-to-date was never computed; UnappliedEffectsFetcher now queries the MarkLogic changes feed and injects results into the existing pipeline

## Tests

- UnappliedEffectsFetcherTest — covers skip conditions, single-page fetch, pagination, and failure graceful degradation
- UpToDateWelshTest — verifies Welsh effect normalisation doesn't affect up-to-date outcome
- WelshContentsTest, WelshDocumentTest, WelshFragmentTest — updated to mock the new UnappliedEffectsFetcher dependency
