### PR TITLE
SectionRange containment for effects filtering

### DIFF
--- a/docs/numbering-of-inserted-provisions.md
+++ b/docs/numbering-of-inserted-provisions.md
@@ -1,0 +1,40 @@
+## 6.4 Numbering of inserted provisions
+
+### At the beginning of a series
+
+6.4.1  Number as follows when inserting a new whole provision at the beginning of an existing series of provisions (eg a subsection at the beginning of a section or a Schedule before the first Schedule).
+- New sections inserted before the first section of an Act are preceded by a letter, starting with "A" (A1, B1, C1 and so on).
+- The same approach is taken in relation to all other divisions of text (other than lettered paragraphs).
+  > Thus the Insolvency Act 2000 inserted a Schedule A1 before Schedule 1 to the Insolvency Act 1986, and the Enterprise Act 2002 inserted a new Schedule B1 after Schedule A1.
+- A provision inserted before "A1" (or "ai") is "ZA1" or ("zai").
+- In the case of lettered paragraphs, new paragraphs inserted before paragraph (a) are (za), (zb) etc.
+- And paragraphs inserted before (za) are (zza), (zzb) etc.
+
+### At the end of a series
+
+6.4.2  Where adding a provision at the end of an existing series of provisions of the same kind (eg a subsection at the end of a section or a Schedule at the end of the Schedules), the numbering should continue in sequence.
+
+### Between existing provisions
+
+6.4.3  The following applies when inserting whole provisions between existing provisions.
+- New provisions inserted between 1 and 2 are 1A, 1B, 1C etc.
+- New provisions inserted between 1A and 1B are 1AA, 1AB, 1AC etc.
+- New provisions inserted between 1 and 1A are 1ZA, 1ZB, 1ZC etc. (and not 1AA etc.)
+- New provisions inserted between 1A and 1AA are 1AZA, 1AZB, 1AZC etc.
+
+6.4.4  Do not generate a lower level identifier unless you have to.
+- A new provision between 1AA and 1B is 1AB not 1AAA.
+- But a new provision between 1AA and 1AB is 1AAA.
+
+6.4.5  The above recommendations apply equally to sub-paragraphs with roman numerals and lettered paragraphs.
+- New sub-paragraphs between sub-paragraphs (i) and (ii) are (ia), (ib), (ic) etc.
+- New paragraphs between paragraphs (a) and (b) are (aa), (ab), (ac) etc.
+- New paragraphs between paragraphs (a) and (aa) are (aza), (azb), (azc) etc.
+
+### Series of more than 26
+
+6.4.6  After Z use Z1, Z2, Z3 etc. For example, after section 360Z insert sections 360Z1, 360Z2 and so on; after paragraph (z) insert paragraphs (z1), (z2), (z3).
+
+### Re-using numbers
+
+6.4.7  If you are inserting new text at a place where there has previously been a repeal, do not re-use the number.

--- a/src/main/java/uk/gov/legislation/util/Effects.java
+++ b/src/main/java/uk/gov/legislation/util/Effects.java
@@ -49,11 +49,7 @@ public class Effects {
         return ids.stream().anyMatch(id -> rangeIncludes(range, id));
     }
     static boolean rangeIncludes(RichTextNode.Range range, String id) {
-        if (range.start.equals(id))
-            return true;
-        if (range.end.equals(id))
-            return true;
-        return false;
+        return SectionRangeContainment.contains(range.start, range.end, id);
     }
 
     static boolean relatesTo(Effect effect, Set<String> ids, boolean includeWhole) {

--- a/src/main/java/uk/gov/legislation/util/Roman.java
+++ b/src/main/java/uk/gov/legislation/util/Roman.java
@@ -21,4 +21,43 @@ class Roman {
         return roman.toString();
     }
 
+    /**
+     * Parses a roman numeral string, returning its integer value,
+     * or 0 if the string is not a valid roman numeral.
+     * Uses roundtrip validation via {@link #toUpperRoman}.
+     */
+    static int parse(String s) {
+        String upper = s.toUpperCase();
+        int result = 0;
+        int prev = 0;
+        for (int i = upper.length() - 1; i >= 0; i--) {
+            int value = charValue(upper.charAt(i));
+            if (value == 0)
+                return 0;
+            if (value < prev)
+                result -= value;
+            else
+                result += value;
+            prev = value;
+        }
+        if (result <= 0 || result > 3999)
+            return 0;
+        if (!toUpperRoman(result).equals(upper))
+            return 0;
+        return result;
+    }
+
+    private static int charValue(char c) {
+        return switch (c) {
+            case 'I' -> 1;
+            case 'V' -> 5;
+            case 'X' -> 10;
+            case 'L' -> 50;
+            case 'C' -> 100;
+            case 'D' -> 500;
+            case 'M' -> 1000;
+            default -> 0;
+        };
+    }
+
 }

--- a/src/main/java/uk/gov/legislation/util/SectionRangeContainment.java
+++ b/src/main/java/uk/gov/legislation/util/SectionRangeContainment.java
@@ -85,21 +85,33 @@ class SectionRangeContainment {
 
     /* token comparison */
 
-    private static final Pattern NUMBER_ALPHA = Pattern.compile("^(\\d+)([a-zA-Z]*)$");
+    // optional alpha prefix + digits + optional alphanumeric suffix
+    // e.g. "1", "1A", "10ZA", "360Z10", "ZA1", "A1", "B1"
+    private static final Pattern PROVISION_NUMBER = Pattern.compile("^([a-zA-Z]*)(\\d+)([a-zA-Z0-9]*)$");
     private static final Pattern ROMAN_CHARS = Pattern.compile("^[ivxlcdm]+$", Pattern.CASE_INSENSITIVE);
+    private static final Pattern ALPHA_ONLY = Pattern.compile("^[a-zA-Z]+$");
 
     private static int compareTokens(String a, String b) {
         if (a.equalsIgnoreCase(b))
             return 0;
 
-        // numeric, with optional alpha suffix (e.g. "1", "10", "1A", "10ZA")
-        Matcher ma = NUMBER_ALPHA.matcher(a);
-        Matcher mb = NUMBER_ALPHA.matcher(b);
+        // provision numbers: prefix < bare < suffix (ZA1 < A1 < 1 < 1ZA < 1A)
+        Matcher ma = PROVISION_NUMBER.matcher(a);
+        Matcher mb = PROVISION_NUMBER.matcher(b);
         if (ma.matches() && mb.matches()) {
-            int cmp = Integer.compare(Integer.parseInt(ma.group(1)), Integer.parseInt(mb.group(1)));
+            int cmp = Integer.compare(Integer.parseInt(ma.group(2)), Integer.parseInt(mb.group(2)));
             if (cmp != 0)
                 return cmp;
-            return ma.group(2).compareToIgnoreCase(mb.group(2));
+            // category: has-prefix (0) < bare (1) < has-suffix (2)
+            int catA = !ma.group(1).isEmpty() ? 0 : ma.group(3).isEmpty() ? 1 : 2;
+            int catB = !mb.group(1).isEmpty() ? 0 : mb.group(3).isEmpty() ? 1 : 2;
+            if (catA != catB)
+                return Integer.compare(catA, catB);
+            if (catA == 0)
+                return compareSuffix(ma.group(1), mb.group(1));
+            if (catA == 2)
+                return compareSuffix(ma.group(3), mb.group(3));
+            return 0;
         }
 
         // roman numerals: both tokens consist of roman characters, and at least one
@@ -112,8 +124,69 @@ class SectionRangeContainment {
                 return Integer.compare(ra, rb);
         }
 
-        // alphabetic or fallback: case-insensitive lexicographic
+        // alphabetic (paragraph labels, etc.) using insertion ordering
+        if (ALPHA_ONLY.matcher(a).matches() && ALPHA_ONLY.matcher(b).matches())
+            return compareSuffix(a, b);
+
+        // fallback: case-insensitive lexicographic
         return a.compareToIgnoreCase(b);
+    }
+
+    /* suffix comparison for inserted provisions */
+
+    /**
+     * Compares two provision suffixes according to UK legislation insertion conventions.
+     * <p>The ordering follows the guidance in section 6.4 of Statutory Instrument Practice:
+     * <ul>
+     *   <li>Z followed by a letter is a prefix meaning "before" (ZA, ZB... sort before A)</li>
+     *   <li>Letters A through Y are ordered normally</li>
+     *   <li>Z at the end (or followed by a digit) is the letter Z (sorts after Y)</li>
+     *   <li>The convention is recursive: ZZA sorts before ZA, which sorts before A</li>
+     * </ul>
+     * <p>Example ordering: ZZA &lt; ZA &lt; ZB &lt; A &lt; AZA &lt; AA &lt; AB &lt; AZ &lt; B &lt; ... &lt; Z
+     */
+    static int compareSuffix(String s1, String s2) {
+        if (s1.equalsIgnoreCase(s2))
+            return 0;
+        if (s1.isEmpty())
+            return -1;
+        if (s2.isEmpty())
+            return 1;
+
+        // Numeric sub-suffixes (e.g. "10" in "Z10"): compare numerically
+        if (Character.isDigit(s1.charAt(0)) && Character.isDigit(s2.charAt(0))) {
+            int i1 = 0;
+            while (i1 < s1.length() && Character.isDigit(s1.charAt(i1))) i1++;
+            int i2 = 0;
+            while (i2 < s2.length() && Character.isDigit(s2.charAt(i2))) i2++;
+            int cmp = Integer.compare(
+                Integer.parseInt(s1.substring(0, i1)),
+                Integer.parseInt(s2.substring(0, i2)));
+            if (cmp != 0)
+                return cmp;
+            return compareSuffix(s1.substring(i1), s2.substring(i2));
+        }
+
+        int rank1 = suffixRank(s1);
+        int rank2 = suffixRank(s2);
+        if (rank1 != rank2)
+            return Integer.compare(rank1, rank2);
+
+        // Same rank: strip first character and recurse
+        return compareSuffix(s1.substring(1), s2.substring(1));
+    }
+
+    /**
+     * Returns the sort rank of the first character of a suffix string.
+     * Z followed by a letter = 0 (before everything).
+     * A through Y = 1 through 25.
+     * Z at end or followed by a digit = 26 (after Y).
+     */
+    private static int suffixRank(String s) {
+        char first = Character.toUpperCase(s.charAt(0));
+        if (first == 'Z' && s.length() > 1 && Character.isLetter(s.charAt(1)))
+            return 0;
+        return first - 'A' + 1;
     }
 
 }

--- a/src/main/java/uk/gov/legislation/util/SectionRangeContainment.java
+++ b/src/main/java/uk/gov/legislation/util/SectionRangeContainment.java
@@ -1,0 +1,119 @@
+package uk.gov.legislation.util;
+
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Determines whether a provision identifier falls within a range defined by
+ * start and end provision identifiers.
+ *
+ * <p>Provision identifiers are hyphen-separated tokens such as "section-1",
+ * "schedule-14-paragraph-3", or "section-395-13-bc". A range like
+ * "section-249-1" to "section-249-3" includes "section-249-2".
+ *
+ * <p>Handles hierarchical containment in both directions:
+ * <ul>
+ *   <li>"part-2-section-5" is within range "part-1" to "part-3" (descendant)</li>
+ *   <li>"section-1" contains range "section-1-a" to "section-1-c" (ancestor)</li>
+ * </ul>
+ *
+ * <p>Uses a top-down approach: strips matching prefix tokens, then checks
+ * containment of the remaining tokens. This naturally handles the ancestor case
+ * (id exhausted after prefix stripping) and the descendant case (id truncated
+ * to range depth before comparison).
+ *
+ * <p>Ported from the legacy MarkLogic XQuery function utils:contains-section,
+ * with improvements for hierarchical containment, alphabetic tokens, and
+ * roman numeral handling.
+ */
+class SectionRangeContainment {
+
+    /**
+     * Tests whether {@code id} falls within the range [{@code start}, {@code end}] (inclusive).
+     */
+    static boolean contains(String start, String end, String id) {
+        String[] startTokens = tokenize(start);
+        String[] endTokens = tokenize(end);
+        String[] idTokens = tokenize(id);
+
+        // Strip common prefix (tokens matching in all three)
+        int i = 0;
+        while (i < startTokens.length && i < endTokens.length && i < idTokens.length
+                && startTokens[i].equalsIgnoreCase(endTokens[i])
+                && startTokens[i].equalsIgnoreCase(idTokens[i])) {
+            i++;
+        }
+
+        // If id is exhausted, it's an ancestor of the range — it contains it
+        if (i >= idTokens.length)
+            return true;
+
+        // Truncate id to the depth of the range boundaries, so that
+        // descendants of a boundary are treated as being at that boundary
+        int rangeDepth = Math.max(startTokens.length, endTokens.length);
+        if (idTokens.length > rangeDepth)
+            idTokens = Arrays.copyOf(idTokens, rangeDepth);
+
+        // Check start <= id <= end using the remaining tokens
+        return compareFrom(startTokens, idTokens, i) <= 0
+            && compareFrom(idTokens, endTokens, i) <= 0;
+    }
+
+    /**
+     * Compares two provision identifiers. A shorter ID sorts before a longer one
+     * when all leading tokens match (e.g. "part-2" &lt; "part-2-section-5").
+     */
+    static int compare(String id1, String id2) {
+        return compareFrom(tokenize(id1), tokenize(id2), 0);
+    }
+
+    private static int compareFrom(String[] a, String[] b, int from) {
+        int len = Math.max(a.length, b.length);
+        for (int i = from; i < len; i++) {
+            if (i >= a.length) return -1;
+            if (i >= b.length) return 1;
+            int cmp = compareTokens(a[i], b[i]);
+            if (cmp != 0) return cmp;
+        }
+        return 0;
+    }
+
+    private static String[] tokenize(String id) {
+        return id.replace("--", "-").split("-");
+    }
+
+    /* token comparison */
+
+    private static final Pattern NUMBER_ALPHA = Pattern.compile("^(\\d+)([a-zA-Z]*)$");
+    private static final Pattern ROMAN_CHARS = Pattern.compile("^[ivxlcdm]+$", Pattern.CASE_INSENSITIVE);
+
+    private static int compareTokens(String a, String b) {
+        if (a.equalsIgnoreCase(b))
+            return 0;
+
+        // numeric, with optional alpha suffix (e.g. "1", "10", "1A", "10ZA")
+        Matcher ma = NUMBER_ALPHA.matcher(a);
+        Matcher mb = NUMBER_ALPHA.matcher(b);
+        if (ma.matches() && mb.matches()) {
+            int cmp = Integer.compare(Integer.parseInt(ma.group(1)), Integer.parseInt(mb.group(1)));
+            if (cmp != 0)
+                return cmp;
+            return ma.group(2).compareToIgnoreCase(mb.group(2));
+        }
+
+        // roman numerals: both tokens consist of roman characters, and at least one
+        // is multi-character (to avoid misclassifying single-letter paragraph labels)
+        if (ROMAN_CHARS.matcher(a).matches() && ROMAN_CHARS.matcher(b).matches()
+                && (a.length() > 1 || b.length() > 1)) {
+            int ra = Roman.parse(a);
+            int rb = Roman.parse(b);
+            if (ra > 0 && rb > 0)
+                return Integer.compare(ra, rb);
+        }
+
+        // alphabetic or fallback: case-insensitive lexicographic
+        return a.compareToIgnoreCase(b);
+    }
+
+}

--- a/src/test/java/uk/gov/legislation/util/SectionRangeContainmentTest.java
+++ b/src/test/java/uk/gov/legislation/util/SectionRangeContainmentTest.java
@@ -248,6 +248,172 @@ class SectionRangeContainmentTest {
     }
 
     @Nested
+    @DisplayName("compareSuffix: inserted provision ordering (section 6.4)")
+    class InsertedProvisionOrdering {
+
+        @ParameterizedTest(name = "[{index}] {0} vs {1} => {2}")
+        @MethodSource
+        @DisplayName("compare: full identifier examples from section 6.4 guidance")
+        void testGuidanceCompare(String id1, String id2, int expectedSign) {
+            int result = SectionRangeContainment.compare(id1, id2);
+            assertEquals(expectedSign, Integer.signum(result),
+                String.format("Expected comparison of '%s' vs '%s' to have sign %d but got %d",
+                    id1, id2, expectedSign, Integer.signum(result)));
+        }
+
+        static Stream<Arguments> testGuidanceCompare() {
+            return Stream.of(
+                // beginning of a series: ZA1, A1, B1, ... then 1
+                Arguments.of("schedule-ZA1", "schedule-A1", -1),
+                Arguments.of("schedule-A1", "schedule-B1", -1),
+                Arguments.of("schedule-B1", "schedule-1", -1),
+
+                // inserted between existing provisions
+                Arguments.of("section-1", "section-1ZA", -1),
+                Arguments.of("section-1ZA", "section-1A", -1),
+                Arguments.of("section-1A", "section-1AZA", -1),
+                Arguments.of("section-1AZA", "section-1AA", -1),
+
+                // do not generate a lower level unless needed
+                Arguments.of("section-1AA", "section-1AB", -1),
+                Arguments.of("section-1AB", "section-1B", -1),
+                Arguments.of("section-1AA", "section-1AAA", -1),
+                Arguments.of("section-1AAA", "section-1AB", -1),
+
+                // lettered paragraphs
+                Arguments.of("section-1-zza", "section-1-za", -1),
+                Arguments.of("section-1-za", "section-1-a", -1),
+                Arguments.of("section-1-a", "section-1-aza", -1),
+                Arguments.of("section-1-aza", "section-1-aa", -1),
+                Arguments.of("section-1-aa", "section-1-ab", -1),
+                Arguments.of("section-1-ab", "section-1-b", -1),
+
+                // roman numeral equivalents
+                Arguments.of("section-1-a-i", "section-1-a-ia", -1),
+                Arguments.of("section-1-a-ia", "section-1-a-ib", -1),
+                Arguments.of("section-1-a-ib", "section-1-a-ii", -1),
+
+                // after Z use Z1, Z2, Z3, ...
+                Arguments.of("section-360Z", "section-360Z1", -1),
+                Arguments.of("section-360Z1", "section-360Z2", -1),
+                Arguments.of("section-360Z2", "section-360Z10", -1)
+            );
+        }
+
+        @ParameterizedTest(name = "[{index}] {0} vs {1} => {2}")
+        @MethodSource
+        void testCompareSuffix(String s1, String s2, int expectedSign) {
+            int result = SectionRangeContainment.compareSuffix(s1, s2);
+            assertEquals(expectedSign, Integer.signum(result),
+                String.format("Expected compareSuffix('%s', '%s') to have sign %d but got %d",
+                    s1, s2, expectedSign, Integer.signum(result)));
+        }
+
+        static Stream<Arguments> testCompareSuffix() {
+            return Stream.of(
+                // basic: empty < A < B < ... < Z
+                Arguments.of("", "A", -1),
+                Arguments.of("A", "B", -1),
+                Arguments.of("Y", "Z", -1),
+
+                // Z-prefix: ZA sorts before A (inserted before first sub-item)
+                Arguments.of("ZA", "A", -1),
+                Arguments.of("ZB", "A", -1),
+                Arguments.of("ZZ", "A", -1),
+
+                // recursive Z-prefix: ZZA before ZA before A
+                Arguments.of("ZZA", "ZA", -1),
+                Arguments.of("ZZA", "A", -1),
+
+                // sub-insertions: between A and B come AA, AB, ...
+                Arguments.of("A", "AA", -1),
+                Arguments.of("AA", "AB", -1),
+                Arguments.of("AZ", "B", -1),
+
+                // Z-prefix at deeper level: AZA before AA (inserted between A and AA)
+                Arguments.of("AZA", "AA", -1),
+                Arguments.of("AZB", "AA", -1),
+
+                // Z at end is the letter Z (sorts last among A-Z)
+                Arguments.of("Y", "Z", -1),
+                Arguments.of("Z", "ZA", 1),  // Z (letter) > ZA (prefix)
+
+                // case insensitive
+                Arguments.of("za", "A", -1),
+                Arguments.of("a", "B", -1),
+
+                // numeric sub-suffixes (e.g. Z1, Z10)
+                Arguments.of("Z9", "Z10", -1),
+                Arguments.of("Z2", "Z10", -1),
+                Arguments.of("A5", "A10", -1)
+            );
+        }
+
+        @Test
+        @DisplayName("contains with beginning-of-series whole provisions: ZA1 to 1")
+        void containsWithBeginningOfSeriesWholeProvisions() {
+            assertTrue(contains("schedule-ZA1", "schedule-1", "schedule-ZA1"));
+            assertTrue(contains("schedule-ZA1", "schedule-1", "schedule-A1"));
+            assertTrue(contains("schedule-ZA1", "schedule-1", "schedule-B1"));
+            assertTrue(contains("schedule-ZA1", "schedule-1", "schedule-1"));
+            assertFalse(contains("schedule-ZA1", "schedule-1", "schedule-2"));
+        }
+
+        @Test
+        @DisplayName("contains with inserted provisions: section-1ZA to section-1B")
+        void containsWithInsertedProvisions() {
+            // 1ZA is inserted before 1A; 1A and 1B are the first two insertions after 1
+            assertTrue(contains("section-1ZA", "section-1B", "section-1A"));
+            assertTrue(contains("section-1ZA", "section-1B", "section-1AA"));
+            assertFalse(contains("section-1ZA", "section-1B", "section-1C"));
+        }
+
+        @Test
+        @DisplayName("contains with inserted paragraphs before paragraph (a)")
+        void containsWithParagraphsBeforeA() {
+            assertTrue(contains("section-1-zza", "section-1-a", "section-1-za"));
+            assertFalse(contains("section-1-zza", "section-1-a", "section-1-aa"));
+        }
+
+        @Test
+        @DisplayName("contains with inserted paragraphs: (aza) to (b)")
+        void containsWithInsertedParagraphs() {
+            // aza is between a and aa; aa is between a and b
+            // order: a < aza < aa < ab < ... < az < b
+            assertTrue(contains("section-1-aza", "section-1-b", "section-1-aa"));
+            assertTrue(contains("section-1-aza", "section-1-b", "section-1-ab"));
+            assertFalse(contains("section-1-aza", "section-1-b", "section-1-a"));  // a is before aza
+            assertFalse(contains("section-1-aza", "section-1-b", "section-1-c"));
+        }
+
+        @Test
+        @DisplayName("contains with inserted roman sub-paragraphs: (i) to (ii)")
+        void containsWithInsertedRomanSubParagraphs() {
+            assertTrue(contains("section-1-a-i", "section-1-a-ii", "section-1-a-ia"));
+            assertTrue(contains("section-1-a-i", "section-1-a-ii", "section-1-a-ib"));
+            assertFalse(contains("section-1-a-i", "section-1-a-ii", "section-1-a-iii"));
+        }
+
+        @Test
+        @DisplayName("numeric sub-suffixes: section-360Z1 to section-360Z10")
+        void numericSubSuffixes() {
+            assertTrue(contains("section-360Z1", "section-360Z10", "section-360Z2"));
+            assertTrue(contains("section-360Z1", "section-360Z10", "section-360Z9"));
+            assertFalse(contains("section-360Z1", "section-360Z10", "section-360Z11"));
+        }
+
+        @Test
+        @DisplayName("1Z sorts after 1AA (Z is 26th letter, not a prefix)")
+        void zAsLetterSortsAfterAA() {
+            // 1Z is the last inserted section before 2
+            // 1AA is a sub-insertion after 1A
+            // So 1AA < 1AZ < 1B < ... < 1Z
+            assertFalse(contains("section-1AA", "section-1AZ", "section-1Z"));
+            assertTrue(contains("section-1AA", "section-1Z", "section-1B"));
+        }
+    }
+
+    @Nested
     @DisplayName("parseRoman: roman numeral validation")
     class ParseRomanTests {
 

--- a/src/test/java/uk/gov/legislation/util/SectionRangeContainmentTest.java
+++ b/src/test/java/uk/gov/legislation/util/SectionRangeContainmentTest.java
@@ -1,0 +1,287 @@
+package uk.gov.legislation.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SectionRangeContainmentTest {
+
+    @Nested
+    @DisplayName("contains: sibling ranges at the same structural depth")
+    class SiblingRanges {
+
+        @Test
+        @DisplayName("numeric subsections: section-249-1 to section-249-3")
+        void numericSubsections() {
+            String start = "section-249-1";
+            String end = "section-249-3";
+            assertTrue(contains(start, end, "section-249-1"));   // start boundary
+            assertTrue(contains(start, end, "section-249-2"));   // middle
+            assertTrue(contains(start, end, "section-249-3"));   // end boundary
+            assertFalse(contains(start, end, "section-249-4"));  // after
+            assertFalse(contains(start, end, "section-248-5"));  // different parent
+        }
+
+        @Test
+        @DisplayName("schedule paragraphs: schedule-14-paragraph-1 to schedule-14-paragraph-3")
+        void scheduleParagraphs() {
+            String start = "schedule-14-paragraph-1";
+            String end = "schedule-14-paragraph-3";
+            assertTrue(contains(start, end, "schedule-14-paragraph-1"));
+            assertTrue(contains(start, end, "schedule-14-paragraph-2"));
+            assertTrue(contains(start, end, "schedule-14-paragraph-3"));
+            assertFalse(contains(start, end, "schedule-14-paragraph-4"));
+            assertFalse(contains(start, end, "schedule-13-paragraph-2"));
+        }
+
+        @Test
+        @DisplayName("alphabetic sub-paragraphs: section-395-13-bc to section-395-13-be")
+        void alphabeticSubParagraphs() {
+            String start = "section-395-13-bc";
+            String end = "section-395-13-be";
+            assertTrue(contains(start, end, "section-395-13-bc"));
+            assertTrue(contains(start, end, "section-395-13-bd"));
+            assertTrue(contains(start, end, "section-395-13-be"));
+            assertFalse(contains(start, end, "section-395-13-bb"));
+            assertFalse(contains(start, end, "section-395-13-bf"));
+        }
+
+        @Test
+        @DisplayName("numeric+alpha suffixes: section-1A to section-1C")
+        void numericAlphaSuffix() {
+            String start = "section-1A";
+            String end = "section-1C";
+            assertTrue(contains(start, end, "section-1A"));
+            assertTrue(contains(start, end, "section-1B"));
+            assertTrue(contains(start, end, "section-1C"));
+            assertFalse(contains(start, end, "section-1D"));
+            assertFalse(contains(start, end, "section-2"));
+        }
+
+        @Test
+        @DisplayName("single letter sub-paragraphs: section-1-a to section-1-c")
+        void singleLetterSubParagraphs() {
+            String start = "section-1-a";
+            String end = "section-1-c";
+            assertTrue(contains(start, end, "section-1-a"));
+            assertTrue(contains(start, end, "section-1-b"));
+            assertTrue(contains(start, end, "section-1-c"));
+            assertFalse(contains(start, end, "section-1-d"));
+        }
+
+        @Test
+        @DisplayName("roman numeral sub-paragraphs: section-1-a-i to section-1-a-iv")
+        void romanNumeralSubParagraphs() {
+            String start = "section-1-a-i";
+            String end = "section-1-a-iv";
+            assertTrue(contains(start, end, "section-1-a-i"));
+            assertTrue(contains(start, end, "section-1-a-ii"));
+            assertTrue(contains(start, end, "section-1-a-iii"));
+            assertTrue(contains(start, end, "section-1-a-iv"));
+            assertFalse(contains(start, end, "section-1-a-v"));
+        }
+
+        @Test
+        @DisplayName("roman numerals crossing alphabetic boundary: ix to xi")
+        void romanNumeralsCrossingAlphabeticBoundary() {
+            // ix (9) to xi (11) — alphabetic ordering would give ix < xi, but
+            // x (10) would sort alphabetically AFTER xi, giving wrong result.
+            // Roman numeral comparison handles this correctly.
+            String start = "section-1-a-ix";
+            String end = "section-1-a-xi";
+            assertTrue(contains(start, end, "section-1-a-x"));
+        }
+
+        @Test
+        @DisplayName("single-character roman compared against multi-character: v to ix")
+        void singleCharRomanAgainstMultiChar() {
+            // v (5) to ix (9) — both consist of roman characters, and at least
+            // one is multi-character, so both are treated as roman numerals
+            String start = "section-1-a-v";
+            String end = "section-1-a-ix";
+            assertTrue(contains(start, end, "section-1-a-vi"));
+            assertTrue(contains(start, end, "section-1-a-viii"));
+            assertFalse(contains(start, end, "section-1-a-x"));
+        }
+
+        @Test
+        @DisplayName("single-letter roman chars treated as alphabetic paragraph labels")
+        void singleLetterRomanCharsAreAlphabetic() {
+            // c, l, m are valid roman characters but as single-letter tokens
+            // they are paragraph labels — c (3rd) is not between l (12th) and m (13th)
+            assertFalse(contains("section-1-l", "section-1-m", "section-1-c"));
+            // d (4th) is between c (3rd) and i (9th) alphabetically
+            assertTrue(contains("section-1-c", "section-1-i", "section-1-d"));
+        }
+    }
+
+    @Nested
+    @DisplayName("contains: hierarchical containment (id deeper than range)")
+    class DescendantContainment {
+
+        @Test
+        @DisplayName("id is a child of a provision within the range")
+        void childOfProvisionInRange() {
+            String start = "part-1";
+            String end = "part-3";
+            assertTrue(contains(start, end, "part-2-section-5"));
+            assertTrue(contains(start, end, "part-1-section-1")); // child of start
+            assertTrue(contains(start, end, "part-3-section-9")); // child of end
+            assertFalse(contains(start, end, "part-4-section-1"));
+        }
+
+        @Test
+        @DisplayName("id is a deeper descendant within the range")
+        void deeperDescendant() {
+            String start = "section-1";
+            String end = "section-3";
+            assertTrue(contains(start, end, "section-2-a-i"));
+        }
+    }
+
+    @Nested
+    @DisplayName("contains: ancestor containment (id shallower than range)")
+    class AncestorContainment {
+
+        @Test
+        @DisplayName("id is a parent of the range boundaries")
+        void parentOfRange() {
+            String start = "section-1-a";
+            String end = "section-1-c";
+            assertTrue(contains(start, end, "section-1"));
+        }
+
+        @Test
+        @DisplayName("id is a grandparent of the range boundaries")
+        void grandparentOfRange() {
+            String start = "section-1-a-i";
+            String end = "section-1-a-iii";
+            assertTrue(contains(start, end, "section-1"));
+            assertTrue(contains(start, end, "section-1-a"));
+        }
+
+        @Test
+        @DisplayName("id is a parent only if all prefix tokens match")
+        void notParentIfDifferentPrefix() {
+            String start = "section-1-a";
+            String end = "section-1-c";
+            assertFalse(contains(start, end, "section-2"));
+        }
+    }
+
+    @Nested
+    @DisplayName("contains: edge cases")
+    class EdgeCases {
+
+        @Test
+        @DisplayName("different structural keywords are not confused")
+        void differentKeywords() {
+            String start = "part-1";
+            String end = "part-3";
+            assertFalse(contains(start, end, "section-5"));
+        }
+
+        @Test
+        @DisplayName("double hyphens in IDs are handled")
+        void doubleHyphens() {
+            assertTrue(contains("section--1", "section--3", "section--2"));
+        }
+
+        @Test
+        @DisplayName("numeric ordering is not lexicographic")
+        void numericNotLexicographic() {
+            String start = "section-2";
+            String end = "section-10";
+            assertTrue(contains(start, end, "section-5"));
+            assertFalse(contains(start, end, "section-11"));
+        }
+    }
+
+    @Nested
+    @DisplayName("compare: ordering of provision identifiers")
+    class CompareTests {
+
+        @ParameterizedTest(name = "[{index}] {0} vs {1} => {2}")
+        @MethodSource
+        void testCompare(String id1, String id2, int expectedSign) {
+            int result = SectionRangeContainment.compare(id1, id2);
+            assertEquals(expectedSign, Integer.signum(result),
+                String.format("Expected comparison of '%s' vs '%s' to have sign %d but got %d",
+                    id1, id2, expectedSign, Integer.signum(result)));
+        }
+
+        static Stream<Arguments> testCompare() {
+            return Stream.of(
+                // identical
+                Arguments.of("section-1", "section-1", 0),
+
+                // numeric ordering
+                Arguments.of("section-1", "section-2", -1),
+                Arguments.of("section-10", "section-2", 1),
+
+                // numeric + alpha suffix
+                Arguments.of("section-1", "section-1A", -1),
+                Arguments.of("section-1A", "section-1B", -1),
+
+                // alphabetic tokens
+                Arguments.of("section-1-a", "section-1-b", -1),
+                Arguments.of("section-1-bc", "section-1-be", -1),
+
+                // roman numerals
+                Arguments.of("section-1-a-ii", "section-1-a-iv", -1),
+                Arguments.of("section-1-a-ix", "section-1-a-xi", -1),
+
+                // shorter ID before longer with same prefix
+                Arguments.of("part-2", "part-2-section-1", -1),
+
+                // different keyword at same position
+                Arguments.of("chapter-1", "section-1", -1)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("parseRoman: roman numeral validation")
+    class ParseRomanTests {
+
+        @Test
+        @DisplayName("valid roman numerals parse correctly")
+        void validRomanNumerals() {
+            assertEquals(1, Roman.parse("i"));
+            assertEquals(2, Roman.parse("ii"));
+            assertEquals(3, Roman.parse("iii"));
+            assertEquals(4, Roman.parse("iv"));
+            assertEquals(9, Roman.parse("ix"));
+            assertEquals(10, Roman.parse("x"));
+            assertEquals(14, Roman.parse("xiv"));
+            assertEquals(40, Roman.parse("xl"));
+        }
+
+        @Test
+        @DisplayName("invalid sequences return 0")
+        void invalidSequences() {
+            assertEquals(0, Roman.parse("iiii"));  // should be iv
+            assertEquals(0, Roman.parse("dd"));    // not valid
+            assertEquals(0, Roman.parse("vv"));    // not valid
+        }
+
+        @Test
+        @DisplayName("non-roman characters return 0")
+        void nonRomanCharacters() {
+            assertEquals(0, Roman.parse("bc"));
+            assertEquals(0, Roman.parse("az"));
+        }
+    }
+
+    private static boolean contains(String start, String end, String id) {
+        return SectionRangeContainment.contains(start, end, id);
+    }
+
+}


### PR DESCRIPTION
Complete the Effects.rangeIncludes() method which previously only checked exact matches on range start/end boundaries. The new SectionRangeContainment utility determines whether a provision ID falls within a range by:

- Stripping common prefix tokens (top-down approach)
- Handling ancestor containment (id shallower than range)
- Handling descendant containment (id deeper than range)
- Comparing tokens with proper numeric, alphabetic, and roman numeral ordering
- Supporting Statutory Instrument Practice conventions for inserted provision identifiers