### PR TITLE
add title and modified fields to AssocMeta

### DIFF
--- a/src/main/java/uk/gov/legislation/api/responses/meta/AssocMeta.java
+++ b/src/main/java/uk/gov/legislation/api/responses/meta/AssocMeta.java
@@ -2,9 +2,16 @@ package uk.gov.legislation.api.responses.meta;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public class AssocMeta extends MetaCore {
+
+    @Schema
+    public String title;
+
+    @Schema
+    public LocalDate modified;
 
     @Schema
     public MetaCore associatedWith;

--- a/src/main/java/uk/gov/legislation/converters/ImpactAssessmentConverter.java
+++ b/src/main/java/uk/gov/legislation/converters/ImpactAssessmentConverter.java
@@ -19,6 +19,8 @@ public class ImpactAssessmentConverter {
     public static AssocMeta convert(ImpactAssessment.Metadata clml) {
         AssocMeta meta = new AssocMeta();
         meta.id = Links.shorten(clml.identifier);
+        meta.title = clml.title;
+        meta.modified = clml.modified;
         meta.longType = clml.impactAssessmentMetadata.documentClassification.documentMainType.value;
         meta.shortType = "ukia";
         meta.year = clml.impactAssessmentMetadata.year.value;


### PR DESCRIPTION
Both fields are available in the MarkLogic response but were not being mapped through to the API. title is constructed by the XQuery from the associated legislation's title; modified is standard Dublin Core.