### PR TITLE
Fix /annexes and /schedules fragment target resolution

### DIFF
--- a/src/main/resources/transforms/simplify/metadata.xsl
+++ b/src/main/resources/transforms/simplify/metadata.xsl
@@ -71,20 +71,34 @@
 
 <xsl:variable name="dc-identifier" as="xs:string" select="/Legislation/ukm:Metadata/dc:identifier[1]" />
 
-<xsl:key name="document-uri" match="*[not(self::InternalLink)]" use="@DocumentURI"/>
+<xsl:key name="document-uri" match="*[@DocumentURI][not(self::InternalLink)]" use="@DocumentURI" />
+
+<xsl:variable name="language-suffix-pattern" as="xs:string" select="'/(english|welsh)$'" />
+<xsl:variable name="version-suffix-pattern" as="xs:string"
+    select="'/(enacted|made|created|adopted|current|prospective|\d{4}-\d{2}-\d{2})$'" />
 
 <xsl:variable name="target" as="element()?">
-    <xsl:variable name="id" as="xs:string">
-        <xsl:choose>
-            <xsl:when test="ends-with($dc-identifier, '/contents')">
-                <xsl:sequence select="substring-before($dc-identifier, '/contents')" />
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:sequence select="$dc-identifier" />
-            </xsl:otherwise>
-        </xsl:choose>
+    <!-- $lookup-id is the dc:identifer; it should match a @DocumentURI attribute -->
+    <!-- We exclude any `/contents` component so a "contents" URI matches the whole document -->
+    <xsl:variable name="lookup-id" as="xs:string">
+        <xsl:sequence select="replace(replace($dc-identifier, '/contents/', '/'), '/contents$', '')" />
     </xsl:variable>
-    <xsl:sequence select="key('document-uri', $id)" />
+    <!-- $fallback-id removes any version or language components -->
+    <!-- It's purpose it to facilitate the /schedules check -->
+    <xsl:variable name="fallback-id" as="xs:string">
+        <xsl:variable name="fallback-id-no-language" as="xs:string">
+            <xsl:sequence select="replace($lookup-id, $language-suffix-pattern, '')" />
+        </xsl:variable>
+        <xsl:sequence select="replace($fallback-id-no-language, $version-suffix-pattern, '')" />
+    </xsl:variable>
+    <xsl:choose>
+        <xsl:when test="exists(key('document-uri', $lookup-id))">
+            <xsl:sequence select="key('document-uri', $lookup-id)" />
+        </xsl:when>
+        <xsl:when test="matches($fallback-id, '/(annexes|schedules)$')">
+            <xsl:sequence select="/*/*/Schedules" />
+        </xsl:when>
+    </xsl:choose>
 </xsl:variable>
 
 <xsl:variable name="id-components" as="xs:string+">
@@ -322,6 +336,11 @@
         </xsl:for-each>
     </ancestors>
     <descendants>
+        <xsl:for-each select="$target/self::Schedules[empty(@DocumentURI)]">
+            <xsl:call-template name="ancestor-or-descendant">
+                <xsl:with-param name="name" select="'descendant'" />
+            </xsl:call-template>
+        </xsl:for-each>
         <xsl:for-each select="$target/descendant-or-self::*[exists(@DocumentURI)]">
             <xsl:call-template name="ancestor-or-descendant">
                 <xsl:with-param name="name" select="'descendant'" />
@@ -335,7 +354,19 @@
     <xsl:element name="{ $name }">
         <xsl:attribute name="name" select="local-name(.)" />
         <xsl:copy-of select="@id" />
+        <xsl:if test="empty(@id) and . is $target">
+            <xsl:variable name="no-language">
+                <xsl:sequence select="replace($dc-identifier, $language-suffix-pattern, '')" />
+            </xsl:variable>
+            <xsl:variable name="no-version">
+                <xsl:sequence select="replace($no-language, $version-suffix-pattern, '')" />
+            </xsl:variable>
+            <xsl:attribute name="id" select="tokenize($no-version, '/')[last()]" />
+        </xsl:if>
         <xsl:copy-of select="@DocumentURI" />
+        <xsl:if test="empty(@DocumentURI) and . is $target">
+            <xsl:attribute name="DocumentURI" select="$dc-identifier" />
+        </xsl:if>
         <xsl:copy-of select="@Status | self::P1/parent::P1group/@Status" />
         <xsl:copy-of select="@RestrictStartDate | @RestrictEndDate" />
         <xsl:variable name="power" select="@ConfersPower | self::P1/parent::P1group/@ConfersPower"/>

--- a/src/test/resources/nia_2022_21/nia-2022-21-introduction-enacted.json
+++ b/src/test/resources/nia_2022_21/nia-2022-21-introduction-enacted.json
@@ -35,7 +35,7 @@
     "next" : "section/1",
     "fragmentInfo" : {
       "element" : "PrimaryPrelims",
-      "id" : null,
+      "id" : "introduction",
       "href" : "introduction",
       "number" : "2022 Chapter 21",
       "title" : "School Age Act (Northern Ireland) 2022",
@@ -49,7 +49,7 @@
     "ancestors" : [ ],
     "descendants" : [ {
       "element" : "PrimaryPrelims",
-      "id" : null,
+      "id" : "introduction",
       "href" : "introduction",
       "number" : "2022 Chapter 21",
       "title" : "School Age Act (Northern Ireland) 2022",


### PR DESCRIPTION
## Summary

This PR is intended to replace #168.

PR #168 worked around the null `$target` problem for URIs like `/eudr/2011/83/annexes` by adding defensive `xsl:choose` guards that emit placeholder `<ancestor/>` and `<descendant/>` elements when `$target` is absent. That approach treats the symptom rather than the cause.

This PR fixes the root cause: the `$target` variable now correctly resolves `/annexes` and `/schedules` URIs to the `Schedules` element in the document. When the lookup by `@DocumentURI` fails, a fallback strips version and language components from the URI and checks whether it ends with `/annexes` or `/schedules`, returning `/*/*/Schedules` in that case.

With `$target` genuinely populated, no null guards are needed, and the `ancestors`/`descendants` output reflects real document structure rather than placeholders.

Additional changes:
- Handles `Schedules` elements without `@DocumentURI` as descendants in the fragment info output
- Synthesizes an `@id` for elements that match `$target` but lack an `@id` attribute (e.g. introduction fragments)

## Test plan

- [ ] Test `/eudr/2011/83/annexes` returns meaningful ancestors/descendants (not nulls or placeholders)
- [ ] Test `/nia/2022/21/introduction/enacted` returns `"id": "introduction"` (not null)
- [ ] Test a standard fragment (e.g. a section) still returns correct ancestors/descendants
- [ ] Run full test suite: `./mvnw test`