### PR TITLE
Added XSLT Logic to Include Ancestors and Descendants for Attachments…

### DIFF
--- a/src/main/resources/transforms/simplify/metadata.xsl
+++ b/src/main/resources/transforms/simplify/metadata.xsl
@@ -98,6 +98,9 @@
         <xsl:when test="matches($fallback-id, '/(annexes|schedules)$')">
             <xsl:sequence select="/*/*/Schedules" />
         </xsl:when>
+        <xsl:when test="matches($fallback-id, '/attachments$')">
+            <xsl:sequence select="/*/*/Attachments" />
+        </xsl:when>
     </xsl:choose>
 </xsl:variable>
 

--- a/src/main/resources/transforms/simplify/metadata.xsl
+++ b/src/main/resources/transforms/simplify/metadata.xsl
@@ -99,7 +99,10 @@
             <xsl:sequence select="/*/*/Schedules" />
         </xsl:when>
         <xsl:when test="matches($fallback-id, '/attachments$')">
-            <xsl:sequence select="/*/*/Attachments" />
+            <!-- A document can have more than one Attachments element, but MarkLogic
+                 only returns the first. The [1] here documents that behavior and guards
+                 against future changes in MarkLogic. -->
+            <xsl:sequence select="/*/*/Attachments[1]" />
         </xsl:when>
     </xsl:choose>
 </xsl:variable>


### PR DESCRIPTION
Changes:
$target Variable Update:
Updated the $target variable to include Attachments alongside Schedules and Annexes. The regular expression now matches any of these document types (/schedules, /annexes, /attachments) and selects the corresponding element from the XML.