### PR TITLE
Improve MarkLogic error parsing

### DIFF
--- a/src/main/java/uk/gov/legislation/data/marklogic/Error.java
+++ b/src/main/java/uk/gov/legislation/data/marklogic/Error.java
@@ -1,14 +1,9 @@
 package uk.gov.legislation.data.marklogic;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import tools.jackson.core.JacksonException;
-import tools.jackson.databind.DeserializationFeature;
-import tools.jackson.databind.ObjectReader;
-import tools.jackson.dataformat.xml.XmlMapper;
-import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
-import tools.jackson.dataformat.xml.annotation.JacksonXmlText;
+import tools.jackson.core.exc.StreamReadException;
 
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
@@ -17,79 +12,35 @@ import javax.xml.stream.XMLStreamReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.PushbackInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-@JacksonXmlRootElement
-@JsonIgnoreProperties(ignoreUnknown = false)
 public class Error {
 
-    public static Error parse(String xml) throws JacksonException {
-        Error error = READER.readValue(xml);
-        validate(error);
-        return error;
-    }
+    private static final Logger logger = LoggerFactory.getLogger(Error.class);
 
     private static final XMLInputFactory factory = XMLInputFactory.newFactory();
 
-    public static Optional<Error> parse(PushbackInputStream input) throws IOException {
-        byte[] peek = input.readNBytes(1024);
-        if (peek.length == 0)
-            return Optional.empty();
-        boolean isError;
-        try (ByteArrayInputStream sample = new ByteArrayInputStream(peek)) {
-            XMLStreamReader reader = factory.createXMLStreamReader(sample);
-            try {
-                int event = reader.nextTag();
-                isError = event == XMLStreamConstants.START_ELEMENT && "error".equals(reader.getLocalName());
-            } finally {
-                reader.close();
-            }
-        } catch (XMLStreamException e) {
-            input.unread(peek, 0, peek.length);
-            return Optional.empty();
-        }
-        input.unread(peek, 0, peek.length);
-        if (!isError)
-            return Optional.empty();
-        Error error = READER.readValue(input);
-        validate(error);
-        return Optional.of(error);
-    }
+    /**
+     * Result of classifying the root element of a MarkLogic response.
+     *
+     * <p>Note: {@link #MALFORMED} is only returned by the {@code String} overload of
+     * {@link #classifyRoot}. The {@code PushbackInputStream} overload is best-effort: it
+     * operates on a fixed-size peek buffer, so an {@link javax.xml.stream.XMLStreamException}
+     * on the sample is treated as {@link #OTHER} rather than {@link #MALFORMED} — the
+     * full stream may still be valid XML.</p>
+     */
+    public enum RootClassification { ERROR, OTHER, MALFORMED }
 
-    private static final XmlMapper MAPPER = XmlMapper.builder()
-        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true)
-        .build();
-
-    private static final ObjectReader READER = MAPPER.readerFor(Error.class);
-
-    @JacksonXmlProperty(localName = "status-code")
     public int statusCode;
 
     public String message;
 
     public Header header;
 
-    @JacksonXmlElementWrapper(useWrapping = false)
-    @JacksonXmlProperty(localName = "link")
     public List<Link> links;
-
-    private static void validate(Error error) {
-        if (error.statusCode == 0) {
-            throw new IllegalArgumentException("MarkLogic error response missing status code");
-        }
-        if (error.statusCode >= 300 && error.statusCode < 400) {
-            if (error.header == null) {
-                throw new IllegalArgumentException("MarkLogic redirect response missing header");
-            }
-            if (error.header.name == null || error.header.name.isEmpty()) {
-                throw new IllegalArgumentException("MarkLogic redirect header missing name");
-            }
-            if (error.header.value == null || error.header.value.isEmpty()) {
-                throw new IllegalArgumentException("MarkLogic redirect header missing value");
-            }
-        }
-    }
 
     public static class Header {
 
@@ -101,12 +52,193 @@ public class Error {
 
     public static class Link {
 
-        @JacksonXmlProperty(isAttribute = true)
         public String href;
 
-        @JacksonXmlText
         public String text;
 
+    }
+
+    /**
+     * Parses an {@code <error>} payload from a String.
+     *
+     * <p>Unlike {@link #parseAssumingError(PushbackInputStream)}, this method validates that
+     * the root element is {@code <error>} and throws {@link tools.jackson.core.exc.StreamReadException}
+     * if it is not. Use {@link #classifyRoot(String)} first if the root is uncertain.</p>
+     */
+    public static Error parse(String xml) throws JacksonException {
+        try (ByteArrayInputStream input = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))) {
+            XMLStreamReader reader = factory.createXMLStreamReader(input);
+            try {
+                return parseError(reader);
+            } finally {
+                closeQuietly(reader);
+            }
+        } catch (IOException | XMLStreamException e) {
+            throw new StreamReadException(null, "Failed to parse error response: " + e.getMessage(), e);
+        }
+    }
+
+    public static RootClassification classifyRoot(String xml) {
+        try (ByteArrayInputStream input = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))) {
+            XMLStreamReader reader = factory.createXMLStreamReader(input);
+            try {
+                return classifyRoot(reader);
+            } finally {
+                closeQuietly(reader);
+            }
+        } catch (IOException | XMLStreamException e) {
+            return RootClassification.MALFORMED;
+        }
+    }
+
+    public static RootClassification classifyRoot(PushbackInputStream input) throws IOException {
+        byte[] peek = input.readNBytes(1024);
+        if (peek.length == 0)
+            return RootClassification.OTHER;
+        try (ByteArrayInputStream sample = new ByteArrayInputStream(peek)) {
+            XMLStreamReader reader = factory.createXMLStreamReader(sample);
+            try {
+                return classifyRoot(reader);
+            } finally {
+                closeQuietly(reader);
+            }
+        } catch (XMLStreamException e) {
+            // Stream classification is best-effort: a parse failure on the sample does not
+            // mean the full document is malformed, so fall through to OTHER.
+            return RootClassification.OTHER;
+        } finally {
+            input.unread(peek, 0, peek.length);
+        }
+    }
+
+    public static Optional<Error> parse(PushbackInputStream input) throws IOException {
+        RootClassification classification = classifyRoot(input);
+        if (classification != RootClassification.ERROR)
+            return Optional.empty();
+        return Optional.of(parseAssumingError(input));
+    }
+
+    /**
+     * Parses an <error> payload without first peeking at the root element.
+     * Callers must have already verified that the root is <error>, e.g. via {@link #classifyRoot(PushbackInputStream)}.
+     */
+    public static Error parseAssumingError(PushbackInputStream input) throws IOException {
+        try {
+            XMLStreamReader reader = factory.createXMLStreamReader(input);
+            try {
+                return parseError(reader);
+            } finally {
+                closeQuietly(reader);
+            }
+        } catch (XMLStreamException e) {
+            throw new IOException("Failed to parse error response", e);
+        }
+    }
+
+    private static RootClassification classifyRoot(XMLStreamReader reader) throws XMLStreamException {
+        int event = reader.nextTag();
+        return event == XMLStreamConstants.START_ELEMENT && "error".equals(reader.getLocalName())
+            ? RootClassification.ERROR
+            : RootClassification.OTHER;
+    }
+
+    private static Error parseError(XMLStreamReader reader) throws XMLStreamException, StreamReadException {
+        if (classifyRoot(reader) != RootClassification.ERROR)
+            throw new StreamReadException(null, "Expected <error> root element");
+
+        Error error = new Error();
+        int event;
+        while (reader.hasNext()) {
+            event = reader.next();
+            if (event == XMLStreamConstants.START_ELEMENT) {
+                switch (reader.getLocalName()) {
+                    case "status-code" -> parseStatusCode(reader, error);
+                    case "message" -> error.message = reader.getElementText();
+                    case "header" -> error.header = parseHeader(reader);
+                    case "link" -> addLink(error, parseLink(reader));
+                    default -> {
+                        logger.debug("Unexpected element <{}> under <error>; skipping", reader.getLocalName());
+                        skipElement(reader);
+                    }
+                }
+            } else if (event == XMLStreamConstants.END_ELEMENT && "error".equals(reader.getLocalName())) {
+                break;
+            }
+        }
+        return error;
+    }
+
+    private static void parseStatusCode(XMLStreamReader reader, Error error) throws XMLStreamException {
+        String text = reader.getElementText().trim();
+        try {
+            error.statusCode = Integer.parseInt(text);
+        } catch (NumberFormatException e) {
+            logger.warn("Unparseable <status-code> value: {}", text);
+        }
+    }
+
+    private static Header parseHeader(XMLStreamReader reader) throws XMLStreamException {
+        Header header = new Header();
+        while (reader.hasNext()) {
+            int event = reader.next();
+            if (event == XMLStreamConstants.START_ELEMENT) {
+                switch (reader.getLocalName()) {
+                    case "name" -> header.name = reader.getElementText();
+                    case "value" -> header.value = reader.getElementText();
+                    default -> {
+                        logger.debug("Unexpected element <{}> under <header>; skipping", reader.getLocalName());
+                        skipElement(reader);
+                    }
+                }
+            } else if (event == XMLStreamConstants.END_ELEMENT && "header".equals(reader.getLocalName())) {
+                return header;
+            }
+        }
+        return header;
+    }
+
+    private static Link parseLink(XMLStreamReader reader) throws XMLStreamException {
+        Link link = new Link();
+        link.href = reader.getAttributeValue(null, "href");
+        StringBuilder text = new StringBuilder();
+        while (reader.hasNext()) {
+            int event = reader.next();
+            if (event == XMLStreamConstants.CHARACTERS || event == XMLStreamConstants.CDATA || event == XMLStreamConstants.SPACE) {
+                text.append(reader.getText());
+            } else if (event == XMLStreamConstants.START_ELEMENT) {
+                logger.debug("Unexpected element <{}> under <link>; skipping", reader.getLocalName());
+                skipElement(reader);
+            } else if (event == XMLStreamConstants.END_ELEMENT && "link".equals(reader.getLocalName())) {
+                link.text = text.toString();
+                return link;
+            }
+        }
+        link.text = text.toString();
+        return link;
+    }
+
+    private static void addLink(Error error, Link link) {
+        if (error.links == null)
+            error.links = new ArrayList<>();
+        error.links.add(link);
+    }
+
+    private static void skipElement(XMLStreamReader reader) throws XMLStreamException {
+        int depth = 1;
+        while (depth > 0 && reader.hasNext()) {
+            int event = reader.next();
+            if (event == XMLStreamConstants.START_ELEMENT) depth++;
+            else if (event == XMLStreamConstants.END_ELEMENT) depth--;
+        }
+    }
+
+    private static void closeQuietly(XMLStreamReader reader) {
+        if (reader == null)
+            return;
+        try {
+            reader.close();
+        } catch (XMLStreamException ignored) {
+        }
     }
 
 }

--- a/src/main/java/uk/gov/legislation/data/marklogic/impacts/Impacts.java
+++ b/src/main/java/uk/gov/legislation/data/marklogic/impacts/Impacts.java
@@ -3,17 +3,12 @@ package uk.gov.legislation.data.marklogic.impacts;
 import org.springframework.stereotype.Repository;
 import uk.gov.legislation.data.marklogic.Error;
 import uk.gov.legislation.data.marklogic.MarkLogic;
+import uk.gov.legislation.exceptions.MarkLogicRequestException;
 import uk.gov.legislation.transform.simple.SimpleXmlMapper;
 
-import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLStreamConstants;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamReader;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PushbackInputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 @Repository
@@ -27,33 +22,23 @@ public class Impacts {
         this.db = db;
     }
 
-    private static final XMLInputFactory factory = XMLInputFactory.newFactory();
-
-    boolean isError(String xml) throws IOException {
-        try (ByteArrayInputStream sample = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))) {
-            XMLStreamReader reader = factory.createXMLStreamReader(sample);
-            try {
-                return reader.nextTag() == XMLStreamConstants.START_ELEMENT && "error".equals(reader.getLocalName());
-            } finally {
-                reader.close();
-            }
-        } catch (XMLStreamException e) {
-            return false;
-        }
-    }
-
     public Optional<String> getXml(int year, int number) throws IOException, InterruptedException {
         String query = "?impacttype=ukia&impactyear=%d&impactnumber=%d".formatted(year, number);
         String xml = db.get(ENDPOINT, query);
-        return isError(xml) ? Optional.empty() : Optional.of(xml);
+        Error.RootClassification classification = Error.classifyRoot(xml);
+        if (classification == Error.RootClassification.MALFORMED)
+            throw new MarkLogicRequestException("MarkLogic response is not well-formed XML");
+        return classification == Error.RootClassification.OTHER ? Optional.of(xml) : Optional.empty();
     }
 
     public Optional<InputStream> getStream(int year, int number) throws IOException, InterruptedException {
         String query = "?impacttype=ukia&impactyear=%d&impactnumber=%d".formatted(year, number);
         PushbackInputStream stream = db.getStream(ENDPOINT, query);
         try {
-            Optional<Error> maybeError = Error.parse(stream);
-            if (maybeError.isPresent()) {
+            Error.RootClassification classification = Error.classifyRoot(stream);
+            // classifyRoot on a PushbackInputStream never returns MALFORMED (see RootClassification),
+            // so != OTHER is equivalent to == ERROR here.
+            if (classification != Error.RootClassification.OTHER) {
                 stream.close();
                 return Optional.empty();
             }

--- a/src/main/java/uk/gov/legislation/data/marklogic/legislation/Legislation.java
+++ b/src/main/java/uk/gov/legislation/data/marklogic/legislation/Legislation.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Repository;
 import uk.gov.legislation.data.marklogic.Error;
 import uk.gov.legislation.data.marklogic.MarkLogic;
+import tools.jackson.core.JacksonException;
 import uk.gov.legislation.exceptions.DocumentFetchException;
 import uk.gov.legislation.exceptions.MarkLogicRequestException;
 import uk.gov.legislation.exceptions.NoDocumentException;
@@ -131,35 +132,46 @@ public class Legislation {
             throw new DocumentFetchException("Failed to fetch document due to interruption", e);
         }
 
-        // test to see whether the XML is an <error> response
-        Error error;
-        try {
-            error = Error.parse(xml);
-        } catch (Exception e) {
-            // the XML was not an <error> response, so it's good CLML; return it
+        Error.RootClassification classification = Error.classifyRoot(xml);
+        if (classification == Error.RootClassification.MALFORMED)
+            throw new MarkLogicRequestException("MarkLogic response is not well-formed XML");
+        if (classification == Error.RootClassification.OTHER) {
             Optional<Redirect> redirect = Redirect.make(afterRedirect, params);
             return new Response(xml, redirect);
         }
-        // the response from MarkLogic was an <error>, so try to follow the redirect
-        return handleError(error, params);
+        Error error;
+        try {
+            error = Error.parse(xml);
+        } catch (JacksonException e) {
+            throw new MarkLogicRequestException("Failed to parse MarkLogic <error> payload", e);
+        }
+        return getAndFollowRedirect(buildRedirectParams(error, params), true);
     }
 
-    private Response handleError(Error error, Parameters oldParams) {
+    private Parameters buildRedirectParams(Error error, Parameters oldParams) {
         if (error.statusCode >= 400)
             throw new NoDocumentException(error);  // don't use error.toString()
-        if (!error.header.name.equals("Location"))
-            throw new MarkLogicRequestException("Error parsing MarkLogic error response");
-        String location = error.header.value;
+        String location = extractRedirectLocation(error);
         logger.debug("MarkLogic redirecting to {}", location);
         Links.Components comp = Links.parse(location);
         if (comp == null)
             throw new IllegalStateException("Invalid redirect location: " + location);
-        Parameters newParams = new Parameters(comp.type(), comp.year(), comp.number())
+        return new Parameters(comp.type(), comp.year(), comp.number())
             .version(comp.version())
             .view(oldParams.view())
             .section(comp.fragment().map(fragment -> fragment.replace('/', '-')))
             .lang(comp.language());
-        return getAndFollowRedirect(newParams, true);
+    }
+
+    private static String extractRedirectLocation(Error error) {
+        if (error.statusCode < 300)
+            throw new MarkLogicRequestException("Expected redirect status (3xx) but got " + error.statusCode);
+        if (error.header == null || !"Location".equals(error.header.name))
+            throw new MarkLogicRequestException("MarkLogic redirect <header> missing 'Location' name");
+        String location = error.header.value;
+        if (location == null || location.isEmpty())
+            throw new MarkLogicRequestException("MarkLogic redirect Location header is empty");
+        return location;
     }
 
     private StreamResponse getAndFollowRedirect2(Parameters params) {
@@ -185,14 +197,20 @@ public class Legislation {
     private StreamResponse handleStream(PushbackInputStream stream, Parameters params, boolean afterRedirect) {
         boolean keepOpen = false;
         try {
-            Optional<Error> maybeError = Error.parse(stream);
-            if (maybeError.isEmpty()) {
+            // classifyRoot on a PushbackInputStream never returns MALFORMED (see RootClassification),
+            // so the only non-OTHER result is ERROR.
+            Error.RootClassification classification = Error.classifyRoot(stream);
+            if (classification == Error.RootClassification.OTHER) {
                 keepOpen = true;
                 return new StreamResponse(stream, Redirect.make(afterRedirect, params));
             }
-            Parameters redirect = getNewParametersFromError(maybeError.get())
-                .view(params.view());
-            return getAndFollowRedirect2(redirect, true);
+            Error error;
+            try {
+                error = Error.parseAssumingError(stream);
+            } catch (IOException e) {
+                throw new MarkLogicRequestException("Failed to parse MarkLogic <error> stream", e);
+            }
+            return getAndFollowRedirect2(buildRedirectParams(error, params), true);
         } catch (IOException e) {
             throw new DocumentFetchException("Failed to fetch document due to I/O exception", e);
         } finally {
@@ -200,26 +218,9 @@ public class Legislation {
                 try {
                     stream.close();
                 } catch (IOException ignored) {
-                    // nothing else we can do
                 }
             }
         }
-    }
-
-    private Parameters getNewParametersFromError(Error error) {
-        if (error.statusCode >= 400)
-            throw new NoDocumentException(error);
-        if (!error.header.name.equals("Location"))
-            throw new MarkLogicRequestException("Error parsing MarkLogic error response");
-        String location = error.header.value;
-        logger.debug("MarkLogic redirecting to {}", location);
-        Links.Components comp = Links.parse(location);
-        if (comp == null)
-            throw new IllegalStateException("Invalid redirect location: " + location);
-        return new Parameters(comp.type(), comp.year(), comp.number())
-            .version(comp.version())
-            .section(comp.fragment().map(fragment -> fragment.replace('/', '-')))
-            .lang(comp.language());
     }
 
 }

--- a/src/main/java/uk/gov/legislation/exceptions/MarkLogicRequestException.java
+++ b/src/main/java/uk/gov/legislation/exceptions/MarkLogicRequestException.java
@@ -4,4 +4,7 @@ public class MarkLogicRequestException extends RuntimeException{
     public MarkLogicRequestException(String message){
         super(message);
     }
+    public MarkLogicRequestException(String message, Throwable cause){
+        super(message, cause);
+    }
 }

--- a/src/test/java/uk/gov/legislation/data/marklogic/ErrorParsingTest.java
+++ b/src/test/java/uk/gov/legislation/data/marklogic/ErrorParsingTest.java
@@ -6,12 +6,72 @@ import org.springframework.core.io.ClassPathResource;
 import tools.jackson.core.JacksonException;
 
 import java.io.IOException;
+import java.io.PushbackInputStream;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ErrorParsingTest {
+
+    @Test
+    @DisplayName("Error.classifyRoot recognizes MarkLogic error payloads")
+    void classifyRootRecognizesErrorXml() {
+        String xml = """
+            <error xmlns="">
+                <status-code>404</status-code>
+                <message>Document not found</message>
+            </error>
+            """;
+
+        assertEquals(Error.RootClassification.ERROR, Error.classifyRoot(xml));
+    }
+
+    @Test
+    @DisplayName("Error.classifyRoot distinguishes CLML from error payloads")
+    void classifyRootRecognizesNonErrorXml() throws IOException {
+        ClassPathResource resource = new ClassPathResource("ukpga_2023_29/ukpga-2023-29-2024-11-01.xml");
+        String xml = resource.getContentAsString(StandardCharsets.UTF_8);
+
+        assertEquals(Error.RootClassification.OTHER, Error.classifyRoot(xml));
+    }
+
+    @Test
+    @DisplayName("Error.classifyRoot returns malformed for malformed XML")
+    void classifyRootRejectsMalformedXml() {
+        assertEquals(Error.RootClassification.MALFORMED, Error.classifyRoot("<error xmlns=\"\""));
+    }
+
+    @Test
+    @DisplayName("Error.classifyRoot accepts XML with a leading UTF-8 BOM")
+    void classifyRootAcceptsBomPrefixedXml() {
+        String xml = "\uFEFF<error xmlns=\"\"><status-code>404</status-code><message>m</message></error>";
+
+        assertEquals(Error.RootClassification.ERROR, Error.classifyRoot(xml));
+    }
+
+    @Test
+    @DisplayName("Error.parse accepts XML with a leading UTF-8 BOM")
+    void parseAcceptsBomPrefixedXml() throws JacksonException {
+        String xml = "\uFEFF<error xmlns=\"\"><status-code>404</status-code><message>m</message></error>";
+
+        Error error = Error.parse(xml);
+
+        assertEquals(404, error.statusCode);
+        assertEquals("m", error.message);
+    }
+
+    @Test
+    @DisplayName("Error.classifyRoot(stream) is best-effort: returns OTHER when it cannot classify the sample")
+    void classifyRootStreamIsBestEffort() throws IOException {
+        try (PushbackInputStream input = TestMarkLogic.asStream("<error xmlns=\"\"")) {
+            assertEquals(Error.RootClassification.OTHER, Error.classifyRoot(input));
+        }
+    }
 
     @Test
     @DisplayName("Error.parse succeeds on MarkLogic <error> payloads")
@@ -28,6 +88,111 @@ class ErrorParsingTest {
     }
 
     @Test
+    @DisplayName("Error.parse succeeds on whitespace text nodes between repeated links")
+    void parseValidErrorXmlWithWhitespaceBetweenLinks() {
+        String xml = """
+            <error xmlns="">
+                <status-code>404</status-code>
+                <message>The item of legislation you've requested isn't available on this site and we can't find any references to it. Perhaps the link is slightly wrong.</message>
+                <link href="http://www.legislation.gov.uk/uksi/2025">Browse for other legislation of this type from 2025</link>
+
+                <link href="http://www.legislation.gov.uk/uksi">Browse for other legislation of this type</link>
+            </error>
+            """;
+
+        assertDoesNotThrow(() -> Error.parse(xml));
+    }
+
+    @Test
+    @DisplayName("Error.parse returns an Error object for malformed error payloads")
+    void parseMalformedErrorWithUnexpectedChild() throws JacksonException {
+        String xml = """
+            <error xmlns="">
+                <status-code>404</status-code>
+                <message>Unexpected child element</message>
+                <unexpected>not allowed</unexpected>
+            </error>
+            """;
+
+        Error error = Error.parse(xml);
+
+        assertEquals(404, error.statusCode);
+        assertEquals("Unexpected child element", error.message);
+    }
+
+    @Test
+    @DisplayName("Error.parse returns an Error object for malformed redirect payloads")
+    void parseMalformedRedirectError() throws JacksonException {
+        String xml = """
+            <error xmlns="">
+                <status-code>307</status-code>
+                <message>Redirecting but the response shape is incomplete</message>
+                <header>
+                    <name>Location</name>
+                    <unexpected>not allowed</unexpected>
+                    <value>http://www.legislation.gov.uk/uksi/2025/1059/made</value>
+                </header>
+            </error>
+            """;
+
+        Error error = Error.parse(xml);
+
+        assertEquals(307, error.statusCode);
+        assertEquals("Redirecting but the response shape is incomplete", error.message);
+        assertNotNull(error.header);
+        assertEquals("Location", error.header.name);
+    }
+
+    @Test
+    @DisplayName("Error.parse preserves link href and text when links are separated by punctuation")
+    void parseMixedContentBetweenLinksPreservesLinkData() throws JacksonException {
+        String xml = """
+            <error xmlns="">
+                <status-code>404</status-code>
+                <message>That item of legislation isn't available on this site and we can't find any references to it either. Perhaps the link is slightly wrong.</message>
+                <link href="http://www.legislation.gov.uk/ukpga/2024">Browse for other legislation of this type from 2024</link>,
+                <link href="http://www.legislation.gov.uk/ukpga">Browse for other legislation of this type</link>
+            </error>
+            """;
+
+        Error error = Error.parse(xml);
+
+        assertNotNull(error.links);
+        assertEquals(2, error.links.size());
+        assertEquals("http://www.legislation.gov.uk/ukpga/2024", error.links.get(0).href);
+        assertEquals("Browse for other legislation of this type from 2024", error.links.get(0).text);
+        assertEquals("http://www.legislation.gov.uk/ukpga", error.links.get(1).href);
+        assertEquals("Browse for other legislation of this type", error.links.get(1).text);
+        assertEquals("That item of legislation isn't available on this site and we can't find any references to it either. Perhaps the link is slightly wrong.", error.message);
+    }
+
+    @Test
+    @DisplayName("Error.parse(stream) handles mixed content between repeated links")
+    void parseMixedContentBetweenLinksFromStream() throws IOException {
+        String xml = """
+            <error xmlns="">
+                <status-code>404</status-code>
+                <message>That item of legislation isn't available on this site and we can't find any references to it either. Perhaps the link is slightly wrong.</message>
+                <link href="http://www.legislation.gov.uk/ukpga/2024">Browse for other legislation of this type from 2024</link>,
+                <link href="http://www.legislation.gov.uk/ukpga">Browse for other legislation of this type</link>
+            </error>
+            """;
+
+        try (PushbackInputStream input = TestMarkLogic.asStream(xml)) {
+            var maybeError = Error.parse(input);
+
+            assertTrue(maybeError.isPresent());
+            Error error = maybeError.orElseThrow();
+            assertNotNull(error.links);
+            assertEquals(2, error.links.size());
+            assertEquals("http://www.legislation.gov.uk/ukpga/2024", error.links.get(0).href);
+            assertEquals("Browse for other legislation of this type from 2024", error.links.get(0).text);
+            assertEquals("http://www.legislation.gov.uk/ukpga", error.links.get(1).href);
+            assertEquals("Browse for other legislation of this type", error.links.get(1).text);
+        }
+    }
+
+    @Test
     @DisplayName("Error.parse rejects CLML responses")
     void parseRejectsClmlXml() throws IOException {
         ClassPathResource resource = new ClassPathResource("ukpga_2023_29/ukpga-2023-29-2024-11-01.xml");
@@ -37,20 +202,50 @@ class ErrorParsingTest {
     }
 
     @Test
-    @DisplayName("Error.parse rejects MarkLogic errors missing status code")
-    void parseRejectsMissingStatusXml() {
+    @DisplayName("Error.parse returns an Error object when status code is missing")
+    void parseMissingStatusXml() throws JacksonException {
         String xml = """
             <error xmlns="">
                 <message>Missing status code</message>
             </error>
             """;
 
-        assertThrows(IllegalArgumentException.class, () -> Error.parse(xml));
+        Error error = Error.parse(xml);
+
+        assertEquals(0, error.statusCode);
+        assertEquals("Missing status code", error.message);
+        assertNull(error.header);
+    }
+
+    @Test
+    @DisplayName("Error.classifyRoot(stream) can be followed by Error.parseAssumingError(stream)")
+    void classifyRootThenParseAssumingErrorFromStream() throws IOException {
+        String xml = """
+            <error xmlns="">
+                <status-code>307</status-code>
+                <message>Redirecting</message>
+                <header>
+                    <name>Location</name>
+                    <value>http://www.legislation.gov.uk/uksi/2025/1059/made</value>
+                </header>
+            </error>
+            """;
+
+        try (PushbackInputStream input = TestMarkLogic.asStream(xml)) {
+            assertEquals(Error.RootClassification.ERROR, Error.classifyRoot(input));
+
+            Error error = Error.parseAssumingError(input);
+
+            assertEquals(307, error.statusCode);
+            assertNotNull(error.header);
+            assertEquals("Location", error.header.name);
+            assertEquals("http://www.legislation.gov.uk/uksi/2025/1059/made", error.header.value);
+        }
     }
 
     @Test
     @DisplayName("Error.parse succeeds on MarkLogic redirect errors")
-    void parseValidRedirectErrorXml() {
+    void parseValidRedirectErrorXml() throws JacksonException {
         String xml = """
             <error xmlns="">
                 <status-code>307</status-code>
@@ -62,7 +257,13 @@ class ErrorParsingTest {
             </error>
             """;
 
-        assertDoesNotThrow(() -> Error.parse(xml));
+        Error error = Error.parse(xml);
+
+        assertEquals(307, error.statusCode);
+        assertEquals("Redirecting you to The East Yorkshire Solar Farm (Correction) Order 2025 as made", error.message);
+        assertNotNull(error.header);
+        assertEquals("Location", error.header.name);
+        assertEquals("http://www.legislation.gov.uk/uksi/2025/1059/made", error.header.value);
     }
 
 }

--- a/src/test/java/uk/gov/legislation/data/marklogic/TestMarkLogic.java
+++ b/src/test/java/uk/gov/legislation/data/marklogic/TestMarkLogic.java
@@ -1,0 +1,39 @@
+package uk.gov.legislation.data.marklogic;
+
+import org.springframework.mock.env.MockEnvironment;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.PushbackInputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Base MarkLogic stub for tests. Supplies the minimal property set the real MarkLogic
+ * constructor reads. Subclasses override {@link #get} or {@link #getStream} as needed;
+ * both throw by default so tests fail loudly if they hit an unmocked path.
+ */
+public class TestMarkLogic extends MarkLogic {
+
+    public TestMarkLogic() {
+        super(new MockEnvironment()
+            .withProperty("MARKLOGIC_HOST", "localhost")
+            .withProperty("MARKLOGIC_PORT", "8080")
+            .withProperty("MARKLOGIC_USERNAME", "user")
+            .withProperty("MARKLOGIC_PASSWORD", "password"));
+    }
+
+    @Override
+    public String get(String endpoint, String query) throws IOException, InterruptedException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PushbackInputStream getStream(String endpoint, String query) throws IOException, InterruptedException {
+        throw new UnsupportedOperationException();
+    }
+
+    public static PushbackInputStream asStream(String xml) {
+        return new PushbackInputStream(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)), 1024);
+    }
+
+}

--- a/src/test/java/uk/gov/legislation/data/marklogic/impacts/ImpactsTest.java
+++ b/src/test/java/uk/gov/legislation/data/marklogic/impacts/ImpactsTest.java
@@ -1,0 +1,66 @@
+package uk.gov.legislation.data.marklogic.impacts;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import uk.gov.legislation.data.marklogic.TestMarkLogic;
+import uk.gov.legislation.exceptions.MarkLogicRequestException;
+
+import java.io.PushbackInputStream;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ImpactsTest {
+
+    private final StubMarkLogic db = new StubMarkLogic();
+    private final Impacts impacts = new Impacts(db);
+
+    @Test
+    @DisplayName("getXml treats error-root responses as empty")
+    void getXmlTreatsErrorRootAsEmpty() throws Exception {
+        db.getResponse = """
+            <error xmlns="">
+                <status-code>404</status-code>
+                <message>Impact assessment not found</message>
+            </error>
+            """;
+
+        assertEquals(Optional.empty(), impacts.getXml(2024, 1));
+    }
+
+    @Test
+    @DisplayName("getXml throws MarkLogicRequestException for malformed XML")
+    void getXmlThrowsForMalformedXml() {
+        db.getResponse = "<error xmlns=\"\"";
+
+        assertThrows(MarkLogicRequestException.class, () -> impacts.getXml(2024, 1));
+    }
+
+    @Test
+    @DisplayName("getStream treats an unclassifiable stream as a non-error response (best-effort classification)")
+    void getStreamTreatsUnclassifiableStreamAsNonError() throws Exception {
+        db.streamResponse = TestMarkLogic.asStream("<error xmlns=\"\"");
+
+        assertTrue(impacts.getStream(2024, 1).isPresent());
+    }
+
+    private static final class StubMarkLogic extends TestMarkLogic {
+
+        private String getResponse;
+        private PushbackInputStream streamResponse;
+
+        @Override
+        public String get(String endpoint, String query) {
+            return getResponse;
+        }
+
+        @Override
+        public PushbackInputStream getStream(String endpoint, String query) {
+            return streamResponse;
+        }
+
+    }
+
+}

--- a/src/test/java/uk/gov/legislation/data/marklogic/legislation/LegislationTest.java
+++ b/src/test/java/uk/gov/legislation/data/marklogic/legislation/LegislationTest.java
@@ -1,0 +1,150 @@
+package uk.gov.legislation.data.marklogic.legislation;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import uk.gov.legislation.data.marklogic.TestMarkLogic;
+import uk.gov.legislation.exceptions.MarkLogicRequestException;
+import uk.gov.legislation.exceptions.NoDocumentException;
+
+import java.io.PushbackInputStream;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class LegislationTest {
+
+    private final StubMarkLogic db = new StubMarkLogic();
+    private final Legislation legislation = new Legislation(db);
+
+    @Test
+    @DisplayName("getDocument treats malformed 404 error payloads as document-not-found, not CLML")
+    void getDocumentHandlesMalformed404ErrorPayload() throws Exception {
+        String xml = """
+            <error xmlns="">
+                <status-code>404</status-code>
+                <message>Document not found</message>
+                <unexpected>not allowed</unexpected>
+            </error>
+            """;
+        db.getResponse = xml;
+
+        NoDocumentException ex = assertThrows(NoDocumentException.class,
+            () -> legislation.getDocument("ukpga", "2024", 1, Optional.empty(), Optional.empty()));
+
+        assertEquals("Document not found", ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("getDocument rejects malformed redirect error payloads instead of treating them as CLML")
+    void getDocumentRejectsMalformedRedirectPayload() throws Exception {
+        String xml = """
+            <error xmlns="">
+                <status-code>307</status-code>
+                <message>Redirecting but missing location header</message>
+            </error>
+            """;
+        db.getResponse = xml;
+
+        assertThrows(MarkLogicRequestException.class,
+            () -> legislation.getDocument("ukpga", "2024", 1, Optional.empty(), Optional.empty()));
+    }
+
+    @Test
+    @DisplayName("getDocument rejects malformed error XML instead of treating it as CLML")
+    void getDocumentRejectsMalformedErrorXml() throws Exception {
+        String xml = """
+            <error xmlns="">
+                <status-code>404</status-code>
+                <message>Broken error payload
+            """;
+        db.getResponse = xml;
+
+        assertThrows(MarkLogicRequestException.class,
+            () -> legislation.getDocument("ukpga", "2024", 1, Optional.empty(), Optional.empty()));
+    }
+
+    @Test
+    @DisplayName("getDocument rejects XML malformed before the root can be classified")
+    void getDocumentRejectsMalformedXmlDuringClassification() throws Exception {
+        db.getResponse = "<error xmlns=\"\"";
+
+        assertThrows(MarkLogicRequestException.class,
+            () -> legislation.getDocument("ukpga", "2024", 1, Optional.empty(), Optional.empty()));
+    }
+
+    @Test
+    @DisplayName("getDocumentStream treats malformed 404 error payloads as document-not-found, not CLML")
+    void getDocumentStreamHandlesMalformed404ErrorPayload() throws Exception {
+        String xml = """
+            <error xmlns="">
+                <status-code>404</status-code>
+                <message>Document not found</message>
+                <unexpected>not allowed</unexpected>
+            </error>
+            """;
+        db.streamResponse = TestMarkLogic.asStream(xml);
+
+        NoDocumentException ex = assertThrows(NoDocumentException.class,
+            () -> legislation.getDocumentStream("ukpga", "2024", 1, Optional.empty(), Optional.empty()));
+
+        assertEquals("Document not found", ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("getDocumentStream rejects malformed error XML instead of treating it as CLML")
+    void getDocumentStreamRejectsMalformedErrorXml() throws Exception {
+        String xml = """
+            <error xmlns="">
+                <status-code>404</status-code>
+                <message>Broken error payload
+            """;
+        db.streamResponse = TestMarkLogic.asStream(xml);
+
+        assertThrows(MarkLogicRequestException.class,
+            () -> legislation.getDocumentStream("ukpga", "2024", 1, Optional.empty(), Optional.empty()));
+    }
+
+    @Test
+    @DisplayName("getDocumentStream treats an unclassifiable stream as a non-error response (best-effort classification)")
+    void getDocumentStreamTreatsUnclassifiableStreamAsNonError() throws Exception {
+        db.streamResponse = TestMarkLogic.asStream("<error xmlns=\"\"");
+
+        Legislation.StreamResponse response =
+            legislation.getDocumentStream("ukpga", "2024", 1, Optional.empty(), Optional.empty());
+        assertEquals(Optional.empty(), response.redirect());
+    }
+
+    @Test
+    @DisplayName("getDocumentStream rejects malformed redirect error payloads instead of treating them as CLML")
+    void getDocumentStreamRejectsMalformedRedirectPayload() throws Exception {
+        String xml = """
+            <error xmlns="">
+                <status-code>307</status-code>
+                <message>Redirecting but missing location header</message>
+            </error>
+            """;
+        db.streamResponse = TestMarkLogic.asStream(xml);
+
+        assertThrows(MarkLogicRequestException.class,
+            () -> legislation.getDocumentStream("ukpga", "2024", 1, Optional.empty(), Optional.empty()));
+    }
+
+    private static final class StubMarkLogic extends TestMarkLogic {
+
+        private String getResponse;
+        private PushbackInputStream streamResponse;
+
+        @Override
+        public String get(String endpoint, String query) {
+            return getResponse;
+        }
+
+        @Override
+        public PushbackInputStream getStream(String endpoint, String query) {
+            return streamResponse;
+        }
+
+    }
+
+}

--- a/src/test/java/uk/gov/legislation/endpoints/pdf/PdfApiControllerTest.java
+++ b/src/test/java/uk/gov/legislation/endpoints/pdf/PdfApiControllerTest.java
@@ -1,0 +1,80 @@
+package uk.gov.legislation.endpoints.pdf;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import uk.gov.legislation.data.marklogic.Error;
+import uk.gov.legislation.data.marklogic.legislation.Legislation;
+import uk.gov.legislation.endpoints.pdf.controller.PdfApiController;
+import uk.gov.legislation.endpoints.pdf.service.PdfService;
+import uk.gov.legislation.exceptions.GlobalExceptionHandler;
+import uk.gov.legislation.exceptions.MarkLogicRequestException;
+import uk.gov.legislation.exceptions.NoDocumentException;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class PdfApiControllerTest {
+
+    private MockMvc mockMvc;
+
+    private StubPdfService pdfService;
+
+    @BeforeEach
+    void setUp() {
+        pdfService = new StubPdfService();
+        mockMvc = MockMvcBuilders.standaloneSetup(new PdfApiController(pdfService))
+            .setControllerAdvice(new GlobalExceptionHandler())
+            .build();
+    }
+
+    @Test
+    @DisplayName("Should return 404 when the PDF lookup raises NoDocumentException")
+    void shouldReturn404WhenPdfLookupThrowsNoDocumentException() throws Exception {
+        Error error = new Error();
+        error.statusCode = 404;
+        error.message = "Table of contents not found";
+        pdfService.failure = new NoDocumentException(error);
+
+        mockMvc.perform(get("/pdf/ukpga/2024/1").accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.error").value("Document Not Found"))
+            .andExpect(jsonPath("$.message").value("Table of contents not found"));
+    }
+
+    @Test
+    @DisplayName("Should return 500 when the PDF lookup raises MarkLogicRequestException")
+    void shouldReturn500WhenPdfLookupThrowsMarkLogicRequestException() throws Exception {
+        pdfService.failure = new MarkLogicRequestException("Error parsing MarkLogic error response");
+
+        mockMvc.perform(get("/pdf/ukpga/2024/1").accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isInternalServerError())
+            .andExpect(jsonPath("$.error").value("MarkLogic Error"))
+            .andExpect(jsonPath("$.message").value("Error parsing MarkLogic error response"));
+    }
+
+    private static final class StubPdfService extends PdfService {
+
+        private RuntimeException failure;
+
+        private StubPdfService() {
+            super(mock(Legislation.class), null);
+        }
+
+        @Override
+        public Optional<String> fetchPdfUrl(String type, String yearOrRegnal, int number, String version) {
+            if (failure != null)
+                throw failure;
+            return Optional.empty();
+        }
+
+    }
+
+}


### PR DESCRIPTION
The Jackson-based parser was brittle in two ways: it rejected unknown child elements (causing malformed error payloads to be misidentified as valid CLML), and it conflated root classification with full parsing (making the classify-then-parse pattern used by callers awkward).

The new StAX parser introduces an explicit RootClassification enum (ERROR / OTHER / MALFORMED) and separates classifyRoot() from parse(), so callers can detect malformed XML early and fail fast rather than passing bad data downstream. Unknown child elements are now skipped with a debug log rather than thrown as errors.

Adds TestMarkLogic base stub and unit tests for Error, Impacts, Legislation, and PdfApiController covering the new error paths.