### PR TITLE
Clarify metadata version derivation

### DIFF
--- a/docs/versions.md
+++ b/docs/versions.md
@@ -1,0 +1,460 @@
+# Versions
+
+This is the canonical version-derivation document for the Java API and the website rewrite.
+
+**Terminology:** *milestone* means a first-version keyword (`enacted`, `made`, `created`, `adopted`) or an ISO date; *label* means a milestone or the label-only `"prospective"` value.
+
+The practical question is:
+
+> Given any XML response for a document or fragment, can we derive every available version in scope, with both a user-facing identity and the correct way to fetch it?
+
+For modern observed data, the answer is yes, if we keep these concepts separate:
+
+- the human-readable milestone label
+- the URL component used to fetch that milestone
+- the point-in-time date requested or carried by the response URI
+- the `dct:valid` valid-from date of the returned revised representation
+
+## Core Model
+
+Each available version should be represented as:
+
+- **`label`**: the identity shown to users, such as `enacted`, `made`, `2024-01-01`, or `prospective`.
+- **`urlVersion`**: the version segment used in a legislation.gov.uk URL, when such a segment exists.
+- **Fetch strategy**: normally use `urlVersion`; when `urlVersion` is absent, use the versionless URL.
+
+In almost all cases, `label` and `urlVersion` are the same:
+
+- `label = "enacted"`, `urlVersion = "enacted"`
+- `label = "2024-01-01"`, `urlVersion = "2024-01-01"`
+
+The important modern-data exception is:
+
+- `label = "prospective"`
+- `urlVersion = null`
+- fetch via the versionless URL
+
+`"current"` is never a final `label` or `urlVersion`. It is an alias that must be replaced or ignored.
+
+The Java API `version` field is not the raw point-in-time date. It is the label yielded by the request. For ordinary revised XML, that means the latest emitted first-version or dated milestone that is not after `dct:valid`, treating `dct:valid` as the returned representation's valid-from date. For prospective revised XML, it is the label-only `"prospective"` value. The requested point-in-time or `dct:valid` date may be later than the selected ordinary milestone.
+
+## Scope
+
+- For a whole-document response, derive the versions of that document.
+- For a fragment response, derive the versions of that fragment only, not all versions of the whole document.
+- In bilingual XML, derive versions from the `hasVersion` links for the response language only. Do not merge English and Welsh milestone sets.
+- A version may be deduced from the XML plus stable endpoint rules. It does not need to be stated literally.
+- This document describes modern observed behavior. Legacy or anomalous data may expose raw `"prospective"` links or other patterns and should be handled separately if encountered.
+
+## Java API Contract
+
+The Java API should expose `versions` on every metadata response, including versioned responses. That differs from the MCP server, which currently suppresses `versions` for some versioned tool responses.
+
+The Java API `versions` field is a list of version labels in the relevant scope:
+
+- whole-document labels for whole-document responses
+- fragment labels for fragment responses
+- same-language labels for bilingual responses
+
+The `version` field identifies the label yielded by the request:
+
+- final/enacted or made XML uses the type-specific first-version keyword
+- prospective revised XML uses the label-only `"prospective"` value
+- ordinary revised XML uses the latest eligible label from `versions` that is not after `dct:valid`
+
+For ordinary revised XML, eligible labels are the type-specific first-version keyword and ISO date labels. The label-only `"prospective"` value can appear in `versions`; it is selected as the scalar `version` only when the returned revised target is prospective.
+
+Normally, `version` is one of the `versions` labels after normalisation. `dct:valid` may become `version` when it is added to `versions` under the non-prospective recovery rules below. If no first-version keyword or dated milestone on or before `dct:valid` can be derived from `versions`, the implementation falls back to `dct:valid` because that is the only value available that identifies the returned revised snapshot.
+
+### Mapping the Core Model to Java Fields
+
+The Java API flattens the `{label, urlVersion}` pair into plain strings: `version` is a single scalar, `versions` is a list of scalars. For every value except `"prospective"`, `label === urlVersion`, so no disambiguation is needed on the caller side. The one exception is `"prospective"`: it is a label-only value, and callers must know to fetch that content via the versionless URL rather than by appending `/prospective` to the path. The scalar `version` may also be `"prospective"` when the returned revised target is prospective.
+
+The `prospective` signal described below is used internally to synthesize the label-only `"prospective"` value. It is not surfaced as a top-level field on the metadata response; its effect on `versions` is mediated entirely through the list itself. Fragment responses do carry a per-level `prospective` boolean on `fragmentInfo` (and on every entry in `descendants`), which reflects the target fragment's own `@Status` attribute — that's a per-element field, not the top-level signal that drives `versions()`.
+
+## Data Sources
+
+### `hasVersion` Links
+
+The primary source is:
+
+```xml
+<atom:link rel="http://purl.org/dc/terms/hasVersion" ... />
+```
+
+The link `title` attribute contains the candidate label, typically:
+
+- a first-version keyword, such as `enacted`, `made`, `created`, or `adopted`
+- an ISO date, such as `2024-01-01`
+- the alias `current`
+- occasionally, in legacy/anomalous data, `prospective`
+
+In bilingual XML, `hasVersion` links may carry `hreflang="en"` or `hreflang="cy"`. English and Welsh milestone sets may differ.
+
+### `hreflang`
+
+`hreflang` identifies the language of an individual `hasVersion` link. It is the key to filtering bilingual XML. Untagged links remain in scope because older or single-language XML may not annotate every link.
+
+### Response Language
+
+Determine the response language before normalising version labels.
+
+In the Java API, this normally comes from the simplified metadata language value derived from the XML. If the response language cannot be determined, retain all `hasVersion` links rather than guessing.
+
+### `dct:valid`
+
+`dct:valid` contains the valid-from date of the returned revised representation. It says that the XML snapshot served in this response is valid from that date.
+
+For a fragment response, the returned representation is still served from a containing document snapshot. The requested fragment is the target content inside that snapshot. Therefore the representation's `dct:valid` date can move forward when some other part of the document changes, while the target fragment's own milestone remains unchanged.
+
+- It is absent for final/enacted or made XML.
+- It is present for revised XML.
+- It is not the requested point-in-time from the URL; that comes from the response URI / `dc:identifier`.
+- It is not, by definition, a version label. It may coincide with a version label, especially for whole-document revised responses.
+- It is not, by definition, a fragment milestone. A fragment can be served from a later revised representation even when the selected fragment milestone is earlier.
+- It can be later than the selected milestone and need not itself be a milestone.
+- Different point-in-time requests between two fragment milestones may return different `dct:valid` dates, but still select the same fragment milestone.
+
+### Document Status
+
+`DocumentStatus` controls major normalisation rules:
+
+- `final` means enacted/made/original text.
+- `revised` means a revised snapshot with `dct:valid`.
+
+For final XML, the first-version keyword is always derivable from legislation type.
+
+### Prospective Status
+
+`Status="Prospective"` on the target content means the content being viewed is prospective. For a whole document, the target is the root `<Legislation>` element. For a fragment, the target is the fragment element.
+
+The Java transformation produces a `prospective` signal from the target's `@Status` attribute. For `P1` fragments, the status may be carried by the parent `P1group` rather than the `P1` itself, so the target is treated as prospective if either the target element has `Status="Prospective"` or the target is a `P1` whose parent `P1group` has it. This matches the pattern already used when copying status onto descendants entries in `metadata.xsl`.
+
+The `prospective` signal is internal: it drives synthesis of the label-only `"prospective"` value for revised prospective content but is not itself surfaced on the API response.
+
+### First-Version Keyword
+
+Each legislation type has a type-specific first-version keyword:
+
+- primary legislation: `enacted`
+- secondary legislation: `made`
+- `ukmo` and `ukci`: `created`
+- EU retained legislation: `adopted`
+
+## Normalisation Algorithm
+
+Apply this algorithm to produce the Java API `versions` labels.
+
+1. Determine the response language.
+2. Collect `title` values from retained `hasVersion` links:
+   - retain a link if `hreflang` is absent
+   - for an English response, retain a link with `hreflang="en"`
+   - for a Welsh response, retain a link with `hreflang="cy"`
+   - if the response language cannot be determined, retain all links
+3. Strip any trailing `" repealed"` suffix on the retained labels. In practice only the latest dated label ever carries this suffix; stripping on every label is defensive rather than load-bearing.
+4. Remove `"current"` from the label set, while remembering whether it was present and whether it was the only retained link.
+5. If status is `final`, ensure the first-version keyword is present.
+6. If status is `final` and `"current"` was the only retained link, add `"prospective"` as a label-only entry.
+7. If status is not `final` and `prospective` is true, add `"prospective"` as a label-only entry.
+8. If status is not `final`, `prospective` is false, and `dct:valid` is present, decide whether to add `dct:valid` as a version label:
+   - add it if `"current"` was present in the retained links and either
+     - the response is whole-document (`dct:valid` is a document milestone), or
+     - the response is a fragment that has no other dated labels in the retained set (`dct:valid` stands in as the only date-indexed pointer to the returned representation).
+   - otherwise, do not add `dct:valid`.
+9. Sort: first-version keywords first, then dates chronologically, then `"prospective"`.
+
+In modern observed data, `"prospective"` enters the `versions` list via synthesis: final XML with standalone `current`, or revised XML whose returned target is prospective. Raw `"prospective"` hasVersion titles — occasionally seen in legacy/anomalous XML, where `/prospective` may resolve as a version path — are explicitly out of scope for this document (see Scope). The flat Java string model cannot distinguish a synthesised label-only `"prospective"` from a raw legacy link, so if such data is ever encountered, callers should assume the modern fetch rule (versionless URL). Handling raw legacy links would require an out-of-band mechanism this contract does not provide.
+
+### Scalar `version` Algorithm
+
+After producing `versions`, derive the Java API `version` field separately.
+
+1. If status is `revised` and `prospective` is true, return `"prospective"`.
+2. If `dct:valid` is absent, return the type-specific first-version keyword.
+3. If `dct:valid` is present, scan the sorted `versions` labels and keep only:
+   - the type-specific first-version keyword
+   - ISO date labels that are not after `dct:valid`
+4. Return the last retained label.
+5. If no label is retained, fall back to `dct:valid`: the response is still a revised snapshot valid from that date, and no eligible milestone from `versions` identifies it.
+
+This is why a fragment can have `dct:valid = "2007-01-01"` and `pointInTime = "2007-01-01"` while the API `version` is `"1991-02-01"`: the later date identifies the returned representation's valid-from date and the requested point-in-time, but `"1991-02-01"` is the selected fragment milestone.
+
+## Sort Order
+
+Version labels should sort as:
+
+- **Rank 0**: first-version keywords: `enacted`, `made`, `created`, `adopted`
+- **Rank 1**: ISO dates, sorted chronologically (which coincides with lexicographic order on `YYYY-MM-DD`)
+- **Rank 2**: the `"prospective"` label
+
+Within the same rank, labels sort lexicographically.
+
+## The `current` Alias
+
+`current` can appear in `hasVersion` links and in legislation.gov.uk URLs, but it is never a stable version identity.
+
+In final/enacted or made XML:
+
+- If `current` is present and no other retained version labels remain, there are effectively two versions: the first-version form and a current prospective form.
+- Represent the first-version form with the first-version keyword.
+- Represent the current prospective form as `label = "prospective"`, `urlVersion = null`, fetched via the versionless URL.
+- If `current` appears alongside dated versions, ignore it; the dated versions are the real version identities.
+- If `current` is absent, only the first-version form exists.
+
+In revised XML:
+
+- `current` may be added by legislation.gov.uk when a specific version was requested.
+- It aliases the latest available version and should be removed.
+- If the returned target is prospective, synthesize `"prospective"` as a label-only value.
+- Use `dct:valid` as a `versions` label only under the non-prospective recovery rules in the normalisation algorithm.
+
+## Why `dct:valid` Is Not Always a Version Label
+
+`dct:valid` identifies the valid-from date of the returned revised representation, but it is not always a milestone in the scope of the response.
+
+For whole-document responses:
+
+- `dct:valid` is the valid-from date of the document snapshot.
+- In unversioned revised whole-document XML, it normally appears in `hasVersion`.
+- If it is missing from `hasVersion` and the content is prospective, add `"prospective"` so the current revised label is not lost.
+- If it is missing from `hasVersion` and the content is not prospective, add `dct:valid` only under the non-prospective recovery rules.
+
+For fragment responses:
+
+- `hasVersion` links are fragment-scoped.
+- `dct:valid` remains the valid-from date of the returned representation.
+- The document can change on a date when the fragment itself did not change.
+- Therefore, do not add `dct:valid` as a fragment version merely because it is present.
+- Add `"prospective"` for prospective fragment content to represent the current prospective label.
+- Add `dct:valid` as a fallback only for non-prospective fragments when `current` was present and no dated fragment labels remain.
+
+This distinction is why a fragment response can legitimately have `dct:valid = "2024-11-01"` while `version` is an earlier fragment milestone from `versions`. The representation valid-from date is allowed to be later than the selected milestone.
+
+It also means that multiple document snapshots can map to the same fragment milestone. If a fragment last changed on `2021-02-27`, and other parts of the containing document changed on `2021-03-01` and `2021-04-26`, dated fragment requests served from those later document snapshots may carry `dct:valid = "2021-03-01"` or `dct:valid = "2021-04-26"` while the fragment's scalar `version` remains `"2021-02-27"`.
+
+## Language-Aware Version Extraction
+
+Version extraction must be language-aware per link. Do not first classify an entire XML response as bilingual and then apply a separate rule.
+
+Use this rule:
+
+- keep untagged `hasVersion` links
+- for English responses, keep `hreflang="en"`
+- for Welsh responses, keep `hreflang="cy"`
+- if the response language is unknown, keep all links
+- normalise only the retained links
+
+This matters because Welsh XML can include both Welsh and English `hasVersion` links in the same response, and the English set may continue later than the Welsh set.
+
+Observed April 2026:
+
+- `wsi/2020/1609/part/3/chapter/1/welsh` has Welsh fragment version links through `2021-02-27`.
+- The same Welsh XML also contains later English-only fragment version links, including dates through `2022-03-28`.
+- `dct:valid` on the Welsh fragment is `2021-04-26`.
+- `/wsi/2020/1609/part/3/chapter/1/2021-03-01/welsh` is also fetchable and has `dct:valid = 2021-03-01`, but the Welsh fragment milestone set still stops at `2021-02-27`.
+- A Welsh point-in-time URL such as `/2021-05-17/welsh` is fetchable, but the returned Welsh fragment still has `dct:valid = 2021-04-26`.
+
+So:
+
+- later accepted point-in-time dates are not automatically fragment milestone versions
+- `dct:valid` is not automatically the fragment's current milestone date
+- different containing-document snapshot dates can still select the same fragment milestone
+- same-language `hasVersion` links are the primary source for fragment versions
+- the API `version` is selected from the same-language milestone set, so a Welsh `dct:valid` of `2021-04-26` yields `version = "2021-02-27"` when `2021-02-27` is the latest Welsh milestone
+
+## Prospective Content
+
+### Fully Prospective Revised Documents
+
+Observed modern examples include `ukpga/2026/8` and `ukpga/2026/5`.
+
+Pattern:
+
+- `DocumentStatus` is `revised`.
+- `dct:valid` is present.
+- the root `<Legislation>` has `Status="Prospective"`.
+- `hasVersion` links may contain only the first-version keyword.
+- there is no `current` link on unversioned requests.
+- there is no resolvable `/prospective` version URL.
+
+Rule:
+
+- add `"prospective"` to `versions` as the current revised label
+- the scalar `version` then selects `"prospective"`
+- treat `"prospective"` as label-only: callers should fetch it via the versionless URL, not `/prospective`
+- keep `dct:valid` as the valid-from date of the returned representation, not as the exposed version label
+
+Without this rule, the version list would contain only `enacted` and would miss the current revised version.
+
+The legacy timeline UI supports this label choice. When the selected content is prospective and no `prospective` version link exists, it synthesizes a `prospective` pointer and treats that pointer as current. That supports exposing `prospective` as the label while still treating it as label-only rather than a URL token.
+
+### Explicit Enacted/Made XML With Standalone `current`
+
+Observed April 15, 2026:
+
+- `ukpga/2026/8/enacted/data.xml` has `DocumentStatus="final"` and only `hasVersion="current"`.
+- `ukpga/2026/8/data.xml` is prospective, has `dct:valid=2026-03-05`, and is fetched via the versionless URL.
+- `ukpga/2026/8/prospective/data.xml` returns `404`.
+- `ukpga/2026/8/section/1/enacted/data.xml` has only `hasVersion="current"`.
+- `ukpga/2026/8/section/1/data.xml` is prospective and fetched via the versionless fragment URL.
+- `ukpga/2026/8/section/1/prospective/data.xml` returns `404`.
+- `ukpga/2026/5` shows the same pattern.
+
+Rule:
+
+- remove `current`
+- add the first-version keyword
+- synthesize `prospective`
+- treat `prospective` as label-only: `urlVersion = null`, fetch via the versionless URL
+
+Older amended enacted XML supports the same interpretation:
+
+- `ukpga/2010/15/enacted/data.xml` contains dated `hasVersion` links plus `current`.
+- `ukpga/2010/15/section/1/enacted/data.xml` likewise contains dated fragment versions plus `current`.
+- In those cases, `current` is just an alias and should not synthesize `prospective`.
+
+### Prospective Fragments Within Revised Documents
+
+When an amendment inserts a provision that is not yet in force, the provision can appear in revised text with `Status="Prospective"`.
+
+Rule:
+
+- treat the fragment as prospective when the target fragment has prospective status
+- for `P1` fragments, also honor prospective status inherited from the parent `P1group`
+- use the prospective signal to add `"prospective"` as the current label
+- outside the prospective and fallback cases, do not use unrelated representation valid-from dates as fragment milestone labels when same-language fragment milestones already exist
+
+## Source-by-Source Rules
+
+### Unversioned Whole-Document XML
+
+Use same-language `hasVersion` links as the base list.
+
+If the document is final:
+
+- add the first-version keyword if needed
+
+If the document is revised and prospective:
+
+- add `"prospective"` as a label-only value
+
+In normal unversioned whole-document responses, `"current"` is not emitted by the server. If a synthetic or anomalous response does include `"current"`, treat it under the versioned whole-document rule: strip it, synthesize `"prospective"` for prospective content, and otherwise add `dct:valid` when it identifies a real version missing from the retained links.
+
+Conclusion: determinative for whole-document versions.
+
+### Unversioned Fragment XML
+
+Use same-language fragment-scoped `hasVersion` links as the base list.
+
+Rules:
+
+- do not treat the list as document-complete
+- do not merge language sets
+- do not treat `dct:valid` as a fragment version unless a recovery rule applies
+- add `"prospective"` for prospective fragment content
+- select scalar `version` from the retained fragment labels, not from `dct:valid` automatically; prospective revised fragments select `"prospective"`
+
+Conclusion: determinative for fragment-scoped versions.
+
+### Versioned Whole-Document XML
+
+Use same-language `hasVersion` links as the base list.
+
+Rules:
+
+- remove `current`
+- add `"prospective"` for prospective content
+- otherwise add `dct:valid` when it identifies a real version missing from the retained links
+- select scalar `version` from the normalised document labels
+
+Conclusion: determinative for whole-document versions.
+
+### Versioned Fragment XML
+
+Use same-language fragment-scoped `hasVersion` links as the base list.
+
+Rules:
+
+- remove `current`
+- do not add `dct:valid` when the fragment already has dated milestone labels
+- add `"prospective"` for prospective fragment content
+- add `dct:valid` only under the non-prospective fallback recovery rule
+- select scalar `version` from the normalised fragment labels
+
+Conclusion: determinative for fragment-scoped versions.
+
+### Final Unversioned XML
+
+If a document is final and unrevised:
+
+- `hasVersion` may be empty
+- `dct:valid` is absent
+- derive the first-version keyword from legislation type
+
+Conclusion: determinative.
+
+### Explicit Enacted/Made XML
+
+Rules:
+
+- if the only retained `hasVersion` is `current`, derive the first-version form plus a label-only `prospective` version
+- if dated versions are also present, ignore `current`
+- if `current` is absent, only the first-version form exists
+- scalar `version` is the first-version keyword, not `prospective`
+
+Conclusion: determinative under the two-field model.
+
+## Endpoint Behavior
+
+| Request | Endpoint | `dct:valid` | `current` in links | Java `versions` behavior | Java `version` behavior |
+|---------|----------|-------------|--------------------|--------------------------|-------------------------|
+| No version, no fragment | `/resources/data.xml` | Present for revised, absent for final | No | Use document milestones; synthesize `prospective` for prospective revised content | First-version keyword for final; `prospective` for prospective revised; otherwise latest document milestone not after `dct:valid` |
+| No version, fragment | `/fragment/data.xml` | Present for revised, absent for final | No | Use fragment milestones; synthesize `prospective` for prospective revised content; recover `dct:valid` only under non-prospective fallback rules | First-version keyword for final; `prospective` for prospective revised; otherwise latest fragment milestone not after `dct:valid` |
+| Version, no fragment | `/data.xml` | Present for revised | Yes | Strip `current`; synthesize `prospective` for prospective revised content; otherwise add `dct:valid` when needed | `prospective` for prospective revised; otherwise latest document milestone not after `dct:valid` |
+| Version, fragment | `/fragment/version/data.xml` | Present for revised | Yes | Strip `current`; synthesize `prospective` for prospective revised content; otherwise do not treat `dct:valid` as a fragment milestone unless recovery applies | `prospective` for prospective revised; otherwise latest fragment milestone not after `dct:valid` |
+| Enacted/made unversioned | `/resources/data.xml` | Absent | No | First-version keyword only | First-version keyword |
+| Enacted/made explicit | `/enacted/data.xml`, `/made/data.xml`, etc. | Absent | Yes when a non-enacted current version exists | Standalone `current` becomes label-only `prospective`; otherwise ignore `current` | First-version keyword |
+
+Notes:
+
+- `/resources/data.xml` returns 404 for versioned whole-document URLs; versioned whole-document requests use the full `/data.xml` endpoint.
+- Fragment `hasVersion` links are scoped to the fragment.
+- First-version keywords may be absent from fragment `hasVersion` links even for final XML; add them from legislation type.
+
+## Up-To-Date Gating
+
+The API should compute `upToDate` only for the latest selected label.
+
+Rule:
+
+- derive `versions`
+- derive scalar `version`
+- compute `upToDate` only when `versions` is non-empty and `version.equals(versions.last())`
+- for final XML, also require enriched final effects data
+- for revised XML, the latest-label check is sufficient
+
+Do not compare `pointInTime` or `dct:valid` directly with `versions.last()`. A fragment can be served for a later point-in-time because the document changed, while the fragment's selected milestone remains its last own milestone. That is still the latest fragment version and should be eligible for `upToDate`.
+
+## Bottom Line
+
+For modern observed data, the XML is determinative enough to derive every version in scope:
+
+- normally `label === urlVersion`
+- `current` is never surfaced directly
+- bilingual XML requires per-link language filtering
+- fragment versions are fragment-scoped
+- `dct:valid` is the representation valid-from date but only sometimes a version label in the response scope
+- scalar `version` is the selected label, not the raw point-in-time or `dct:valid` date
+- `"prospective"` is the modern label-only value: it can come from explicit final/enacted or made XML with standalone `current`, or from revised XML whose returned target is prospective
+
+## MCP Note
+
+The MCP server follows the same core derivation rules, but its tool responses are not the Java API contract.
+
+Current MCP deviations:
+
+- MCP suppresses `versions` for some versioned tool responses.
+- MCP represents prospective state separately from the `versions` labels where possible.
+- Tool documentation warns that `version = "prospective"` is not a valid input parameter; when `prospective` appears in `versions`, callers should omit the `version` input to fetch that content.
+
+The Java API should treat this document, not the MCP tool-response shape, as canonical.

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -48,7 +48,7 @@ The Java API `version` field is not the raw point-in-time date. It is the label 
 
 ## Java API Contract
 
-The Java API should expose `versions` on every metadata response, including versioned responses. That differs from the MCP server, which currently suppresses `versions` for some versioned tool responses.
+The Java API should expose `versions` on every metadata response, including versioned responses. The MCP server's metadata and table-of-contents responses now follow the same exposure rule, though MCP tool inputs remain a separate contract; see [MCP Note](#mcp-note).
 
 The Java API `versions` field is a list of version labels in the relevant scope:
 
@@ -449,12 +449,16 @@ For modern observed data, the XML is determinative enough to derive every versio
 
 ## MCP Note
 
-The MCP server follows the same core derivation rules, but its tool responses are not the Java API contract.
+The MCP server follows the same core derivation rules for metadata response fields:
 
-Current MCP deviations:
+- response `versions` is exposed for both unversioned and versioned metadata/table-of-contents responses
+- response `version` is the selected label of the returned representation, not the raw URL segment
+- `pointInTime` is exposed separately when the request URI contains an ISO date and the response is not final
 
-- MCP suppresses `versions` for some versioned tool responses.
-- MCP represents prospective state separately from the `versions` labels where possible.
-- Tool documentation warns that `version = "prospective"` is not a valid input parameter; when `prospective` appears in `versions`, callers should omit the `version` input to fetch that content.
+Remaining MCP-specific differences are tool-contract differences, not version-derivation differences:
 
-The Java API should treat this document, not the MCP tool-response shape, as canonical.
+- MCP tool input `version` still means the URL version segment to request, such as a first-version keyword or ISO date.
+- `version = "prospective"` is not a valid MCP input parameter; when `"prospective"` appears in response `versions`, callers should omit the `version` input to fetch that content.
+- MCP may expose helper fields such as `prospective`, and may suppress `unappliedEffects` and `upToDate` for versioned tool responses.
+
+The Java API should treat this document as canonical for derivation, and the MCP documentation should stay aligned with it.

--- a/src/main/java/uk/gov/legislation/converters/DocumentMetadataConverter.java
+++ b/src/main/java/uk/gov/legislation/converters/DocumentMetadataConverter.java
@@ -35,15 +35,33 @@ public class DocumentMetadataConverter {
             .map(EffectsFeedConverter::convertEffect).toList();
         if ("cy".equals(simple.lang))
             simplifyWelshEffects(converted.unappliedEffects);
-        // Not sure we need the ("revised".equals(simple.status) || ("final".equals(simple.status) condition
-        if (("revised".equals(simple.status) || ("final".equals(simple.status) && simple.finalEffectsEnriched))
-                && simple.version().equals(simple.versions().getLast())) {
+        if (shouldComputeUpToDate(simple)) {
             if (converted.pointInTime == null)
                 UpToDate.setUpToDate(converted);
             else
                 UpToDate.setUpToDate(converted, converted.pointInTime);
         }
         converted.altFormats = AlternateFormatConverter.convert(simple.alternatives);
+    }
+
+    static boolean shouldComputeUpToDate(Metadata simple) {
+        if (!isLatestVersion(simple))
+            return false;
+        if (Metadata.FINAL.equals(simple.status))
+            return simple.finalEffectsEnriched;
+        return Metadata.REVISED.equals(simple.status);
+    }
+
+    /**
+     * Latest-version predicate.
+     *
+     * <p>A payload is considered the latest iff the milestone selected by the request is the last
+     * milestone exposed in {@link Metadata#versions()}. The payload point-in-time may be later than
+     * that milestone, especially for fragments that have not changed at the document snapshot date.
+     */
+    private static boolean isLatestVersion(Metadata simple) {
+        var versions = simple.versions();
+        return !versions.isEmpty() && versions.last().equals(simple.version());
     }
 
     static void convertCommon(Metadata simple, CommonMetadata converted) {

--- a/src/main/java/uk/gov/legislation/converters/FragmentMetadataConverter.java
+++ b/src/main/java/uk/gov/legislation/converters/FragmentMetadataConverter.java
@@ -56,9 +56,7 @@ public class FragmentMetadataConverter {
         converted.descendants = simple.descendants();
         converted.fragmentInfo = converted.descendants.getFirst();
         converted.unappliedEffects = convertEffects(simple);
-        // Not sure we need the ("revised".equals(simple.status) || ("final".equals(simple.status) condition
-        if (("revised".equals(simple.status) || ("final".equals(simple.status) && simple.finalEffectsEnriched))
-                && simple.version().equals(simple.versions().getLast())) {
+        if (DocumentMetadataConverter.shouldComputeUpToDate(simple)) {
             if (converted.pointInTime == null)
                 UpToDate.setUpToDate(converted);
             else

--- a/src/main/java/uk/gov/legislation/converters/UnappliedEffectsFetcher.java
+++ b/src/main/java/uk/gov/legislation/converters/UnappliedEffectsFetcher.java
@@ -34,16 +34,15 @@ public class UnappliedEffectsFetcher {
      * {@code simple.rawEffects}. For all other documents, does nothing.
      */
     public void fetchIfNeeded(Metadata simple) {
-        if (!"final".equals(simple.status))
+        if (!Metadata.FINAL.equals(simple.status))
             return;
-        if (!simple.version().equals(simple.versions().getLast()))
-            return;
-
         String shortType = Types.longToShort(simple.longType);
         if (shortType == null) {
             logger.debug("skipping effects fetch: unknown type {}", simple.longType);
             return;
         }
+        if (!simple.versions().last().equals(simple.version()))
+            return;
         if (simple.number == null) {
             logger.debug("skipping effects fetch: no number for {} {}", simple.longType, simple.year);
             return;

--- a/src/main/java/uk/gov/legislation/transform/simple/Metadata.java
+++ b/src/main/java/uk/gov/legislation/transform/simple/Metadata.java
@@ -1,9 +1,11 @@
 package uk.gov.legislation.transform.simple;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import tools.jackson.dataformat.xml.annotation.JacksonXmlText;
 import uk.gov.legislation.transform.simple.effects.Effect;
 import uk.gov.legislation.util.FirstVersion;
 import uk.gov.legislation.util.Links;
@@ -20,7 +22,7 @@ public class Metadata {
     public String dcIdentifier;
 
     public Optional<LocalDate> getPointInTime() {
-        if ("final".equals(status))
+        if (FINAL.equals(status))
             return Optional.empty();
         Links.Components comps = Links.parse(dcIdentifier);
         if (comps == null)
@@ -75,54 +77,80 @@ public class Metadata {
 
     public LocalDate date;
 
+    /**
+     * {@code dct:valid}: valid-from date of the returned revised representation.
+     *
+     * <p>This is not necessarily the requested point-in-time from the URL, a version label, or a
+     * fragment milestone. For fragment responses it can be later than the selected fragment
+     * milestone when the fragment is served from a later revised representation.</p>
+     */
     private LocalDate valid;
     @JsonSetter("valid")
     public void setValid(String value) { valid = LocalDate.parse(value); }
 
-    private static Optional<LocalDate> tryParseDate(String s) {
-        try {
-            return Optional.of(LocalDate.parse(s));
-        } catch (DateTimeParseException e) {
-            return Optional.empty();
-        }
-    }
+    public static final String FINAL = "final";
+    public static final String REVISED = "revised";
 
     private static final String PROSPECTIVE = "prospective";
+    private static final String CURRENT = "current";
+    private static final String REPEALED = " repealed";
+
+    private String _computedVersion;
 
     /**
-     * Determines the most appropriate version label for the current payload.
+     * Label selected by the request.
      *
-     * <p>Rules applied in order:
-     * <ol>
-     * <li>No {@code dct:valid} → return the type-specific first-version label
-     *     (e.g. enacted, made, created, adopted).</li>
-     * <li>Scan {@link #versions()} from newest to oldest and pick the first ISO date available.
-     *     If none exist, fall back to either {@link #PROSPECTIVE} (when the current fragment is
-     *     marked {@code Status="Prospective"}) or the raw {@code dct:valid} string.</li>
-     * <li>If the fragment-level {@code dct:valid} is newer than the latest dated label
-     *     (typical for fragments lagging behind a whole-document revision), return that latest
-     *     dated label instead of the fragment {@code dct:valid}.</li>
-     * <li>Otherwise return the {@code dct:valid} value.</li>
-     * </ol>
+     * <p>{@code dct:valid} is the valid-from date of the returned revised representation and need
+     * not itself be a milestone. For ordinary revised responses, choose the latest emitted
+     * milestone that is not after that valid-from date. For prospective revised responses, use the
+     * label-only {@code prospective} value that mirrors legislation.gov.uk's timeline label.</p>
      */
-
     public String version() {
+        if (_computedVersion != null)
+            return _computedVersion;
+        _computedVersion = computeVersion();
+        return _computedVersion;
+    }
+
+    private String computeVersion() {
+        if (isProspectiveRevised())
+            return PROSPECTIVE;
         if (valid == null)
             return FirstVersion.getFirstVersion(longType);
-        Optional<LocalDate> last = versions().reversed().stream()
-            .map(Metadata::tryParseDate)
-            .filter(Optional::isPresent)
-            .map(Optional::get)
-            .findFirst();
-        if (last.isEmpty())
-            return descendants.stream()  // first entry mirrors the current level; see descendants() doc
-                .findFirst()
-                .filter(d -> "Prospective".equals(d.status)).isPresent()
-                ? PROSPECTIVE
-                : valid.toString();
-        if (valid.isAfter(last.get()))
-            return last.get().toString();
-        return valid.toString();
+        String selected = latestEligibleMilestoneNotAfter(valid);
+        // A null result means the normalised version set contains no first-version keyword and no
+        // dated milestone on or before dct:valid. The response is still a revised snapshot valid
+        // from dct:valid, so dct:valid is the only value we have that identifies the returned
+        // revision.
+        return selected == null ? valid.toString() : selected;
+    }
+
+    /**
+     * Selects the latest milestone in {@link #versions()} that can describe a revised snapshot
+     * valid from {@code dctValid}.
+     *
+     * <p>{@link #versions()} returns labels sorted by {@link Versions#COMPARATOR}: first-version
+     * keywords first, then ISO dates chronologically, then {@code prospective}. This method walks
+     * that set and keeps replacing {@code selected} when it sees an eligible label: the
+     * type-specific first-version keyword, or an ISO date that is not after {@code dctValid}.
+     * Non-date labels such as {@code prospective} are skipped. Because the scan is ordered, the
+     * value left in {@code selected} at the end is the latest eligible milestone.</p>
+     */
+    private String latestEligibleMilestoneNotAfter(LocalDate dctValid) {
+        String firstVersion = FirstVersion.getFirstVersion(longType);
+        String selected = null;
+        for (String label : versions()) {
+            if (label.equals(firstVersion)) {
+                selected = label;
+                continue;
+            }
+            try {
+                LocalDate milestone = LocalDate.parse(label);
+                if (!milestone.isAfter(dctValid))
+                    selected = label;
+            } catch (DateTimeParseException ignored) {}
+        }
+        return selected;
     }
 
     public String status;
@@ -141,70 +169,152 @@ public class Metadata {
 
     public LocalDate modified;
 
-    private List<String> _versions;
+    /**
+     * A single {@code <hasVersion>} entry, carrying the source link's {@code hreflang} attribute
+     * so language-aware filtering can tell Welsh links apart from English ones in bilingual XML.
+     */
+    public static class HasVersionEntry {
+
+        /**
+         * BCP 47 language tag of the source {@code atom:link} ({@code "en"} or {@code "cy"}),
+         * or {@code null} when the link carries no {@code @hreflang}. Untagged entries apply to
+         * both languages.
+         */
+        @JacksonXmlProperty(isAttribute = true)
+        public String hreflang;
+
+        /**
+         * The milestone label from the source link's {@code @title}. Either an ISO date
+         * ({@code "2024-11-22"}), a first-version keyword ({@code "enacted"}, {@code "made"},
+         * {@code "created"}, {@code "adopted"}), the {@code "current"} alias for the latest
+         * snapshot, a literal {@code "prospective"}, or a dated-and-repealed label
+         * ({@code "2020-12-31 repealed"}) which is normalised back to its base date by
+         * {@link #versions()}.
+         */
+        @JacksonXmlText
+        public String title;
+
+        public static HasVersionEntry of(String hreflang, String title) {
+            HasVersionEntry entry = new HasVersionEntry();
+            entry.hreflang = hreflang;
+            entry.title = title;
+            return entry;
+        }
+    }
+
+    private List<HasVersionEntry> _versions;
 
     @JacksonXmlElementWrapper(localName = "hasVersions")
     @JacksonXmlProperty(localName = "hasVersion")
     @JsonSetter
-    public void setVersions(List<String> value) { _versions = value; }
+    public void setVersions(List<HasVersionEntry> value) { _versions = value; }
 
-    private TreeSet<String> _versions2;
-
-    private static final String REPEALED = " repealed";
+    private TreeSet<String> _computedVersions;
 
     /**
-     * Produces a normalised, ordered set of version labels for this document or fragment.
+     * Normalised, ordered version labels available in this response's scope.
      *
-     * <p>Behavioural notes:
-     * <ul>
-     * <li>Start from the titles supplied via {@code atom:link[@rel='…hasVersion']}.</li>
-     * <li>Strip the noisy {@code current} marker and, when present, substitute the appropriate
-     *     fallback:
-     *     <ul>
-     *     <li>If {@link #status} is {@code final} and no other labels remain, assume a
-     *         prospective snapshot exists and inject {@link #PROSPECTIVE}.</li>
-     *     <li>Otherwise re-add the authoritative {@code dct:valid} date for this snapshot
-     *         (unless {@link #version()} already resolved to {@link #PROSPECTIVE}).</li>
-     *     </ul>
-     * </li>
-     * <li>Always ensure the type-specific first-version label is present for {@code final}
-     *     documents.</li>
-     * <li>Normalise any trailing {@code "… repealed"} markers back to their base date.</li>
-     * <li>If {@link #version()} resolved to {@link #PROSPECTIVE}, add it once so the scalar and
-     *     set stay in sync.</li>
-     * </ul>
+     * <p>The scope is the thing requested: whole-document responses expose document milestones;
+     * fragment responses expose fragment milestones. In bilingual XML, the scope is further
+     * narrowed to links for the response language, plus untagged links. The returned
+     * {@code dct:valid} date is not automatically in this scope; for a fragment it may identify a
+     * containing-document snapshot rather than a fragment milestone.</p>
      *
-     * @return version labels sorted by {@link Versions#COMPARATOR}
+     * <p>The method first builds the scoped label set from {@code hasVersion} links, then removes
+     * unstable aliases, and finally repairs the few cases where legislation.gov.uk omits a label
+     * that the API still needs to expose.</p>
+     *
+     * <ol>
+     *   <li>Keep {@code hasVersion} entries whose {@code hreflang} matches the response language,
+     *       plus any untagged entries.</li>
+     *   <li>Strip the trailing {@code " repealed"} suffix.</li>
+     *   <li>Remove the {@code current} alias; remember whether it was present and whether it was
+     *       the only retained link.</li>
+     *   <li>For {@code final} status, ensure the type-specific first-version keyword is present.</li>
+     *   <li>For {@code final} XML where {@code current} was the only retained entry, synthesise a
+     *       label-only {@code prospective} entry.</li>
+     *   <li>For prospective revised content, synthesise a label-only {@code prospective}
+     *       entry.</li>
+     *   <li>Otherwise, when {@code current} was present alongside {@code dct:valid}, add that date
+     *       if it identifies the returned representation in this scope: always for whole-document
+     *       responses, and for fragment responses only when no other dated fragment labels remain.</li>
+     * </ol>
      */
     public SortedSet<String> versions() {
-        if (_versions2 != null)
-            return _versions2;
-        _versions2 = new TreeSet<>(Versions.COMPARATOR);
-        _versions2.addAll(_versions);
-        if (_versions2.remove("current")) {
-            if ("final".equals(status)) {
-                if (_versions2.isEmpty())
-                    _versions2.add(PROSPECTIVE);
-            } else {
-                if (!PROSPECTIVE.equals(version()) && this.valid != null) // should never be null if !"final".equals(status)
-                    _versions2.add( this.valid.toString());
-            }
+        if (_computedVersions != null)
+            return _computedVersions;
+        if (_versions == null)
+            _versions = List.of();
+        TreeSet<String> result = new TreeSet<>(Versions.COMPARATOR);
+        for (HasVersionEntry entry : _versions) {
+            if (!matchesResponseLanguage(entry.hreflang))
+                continue;
+            result.add(stripRepealed(entry.title));
         }
-        if ("final".equals(status)) {
-            String first = FirstVersion.getFirstVersion(longType);
-            _versions2.add(first);
-        }
-        if (!_versions2.isEmpty()) {
-            String last = _versions2.last();
-            if (last.endsWith(REPEALED)) {
-                _versions2.pollLast();
-                String base = last.substring(0, last.length() - REPEALED.length());
-                _versions2.add(base);
-            }
-        }
-        if (PROSPECTIVE.equals(version()))
-            _versions2.add(PROSPECTIVE);
-        return _versions2;
+        boolean hadCurrent = result.remove(CURRENT);
+        boolean onlyCurrent = hadCurrent && result.isEmpty();
+        boolean isFinal = FINAL.equals(status);
+        if (isFinal)
+            result.add(FirstVersion.getFirstVersion(longType));
+        if (isFinal && onlyCurrent)
+            result.add(PROSPECTIVE);
+        if (isProspectiveRevised())
+            result.add(PROSPECTIVE);
+        else if (!isFinal && valid != null && shouldRecoverValidDate(hadCurrent, result))
+            result.add(valid.toString());
+        _computedVersions = result;
+        return _computedVersions;
+    }
+
+    /**
+     * Whether {@code dct:valid} should be added to {@link #versions()} as a recovered label.
+     *
+     * <p>Stripping the {@code current} alias can leave the result set with no label identifying
+     * the returned representation. {@code dct:valid} is the valid-from date of that
+     * representation, so using it as a label recovers the identity that was lost — but only when
+     * {@code current} was actually present in the scoped input; otherwise there is nothing to
+     * recover.</p>
+     *
+     * <p>The whole-document vs fragment asymmetry: a whole-document response's {@code dct:valid}
+     * identifies the returned document snapshot, so when {@code current} was stripped we recover
+     * it as the missing document label. A fragment response's {@code dct:valid} may be a
+     * containing-document snapshot date rather than a fragment milestone, so we recover it only
+     * when no other dated fragment label is already present — i.e. as a last-resort label when
+     * fragment-specific milestones are unavailable.</p>
+     */
+    private boolean shouldRecoverValidDate(boolean hadCurrent, SortedSet<String> labels) {
+        if (!hadCurrent)
+            return false;
+        return isWholeDocument() || !hasDatedLabel(labels);
+    }
+
+    private boolean isProspectiveRevised() {
+        return prospective && REVISED.equals(status);
+    }
+
+    private static boolean hasDatedLabel(SortedSet<String> labels) {
+        for (String s : labels)
+            if (Versions.isDateLabel(s))
+                return true;
+        return false;
+    }
+
+    /**
+     * True when the payload is a whole-document response rather than a fragment response.
+     * {@code simplify/metadata.xsl} only emits the {@code <fragment>} element (from which
+     * {@link #fragment} is populated) when the {@code is-fragment} parameter is true, so a null
+     * {@code fragment} uniquely indicates a whole-document request.
+     */
+    private boolean isWholeDocument() {
+        return fragment == null;
+    }
+
+    private boolean matchesResponseLanguage(String hreflang) {
+        return hreflang == null || lang == null || lang.equals(hreflang);
+    }
+
+    private static String stripRepealed(String title) {
+        return title.endsWith(REPEALED) ? title.substring(0, title.length() - REPEALED.length()) : title;
     }
 
     @JacksonXmlProperty
@@ -330,14 +440,31 @@ public class Metadata {
 
     public static class Descendant extends Level {}
 
+    /**
+     * Descendants of the current payload. Only populated for fragment requests.
+     *
+     * <p>By convention of {@code simplify/metadata.xsl}, the first entry describes the target
+     * fragment itself; {@link uk.gov.legislation.converters.FragmentMetadataConverter} relies on
+     * that to populate {@code fragmentInfo}.
+     */
     @JacksonXmlProperty(localName = "descendants")
     private List<Descendant> descendants = Collections.emptyList();
-
-    /* simplify/metadata.xsl places the current fragment as the first descendant; version() relies on that. */
 
     public List<uk.gov.legislation.api.responses.Level> descendants() {
         return descendants.stream().map(Level::convert).toList();
     }
+
+    /**
+     * True when the target element carries {@code Status="Prospective"}.
+     *
+     * <p>Set by {@code simplify/metadata.xsl} from the target's {@code @Status} attribute —
+     * the root {@code <Legislation>} for whole-document requests, or the fragment element for
+     * fragment requests. Drives the "add {@code prospective} to versions" rule for prospective
+     * revised content.
+     */
+    @JacksonXmlProperty
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    public boolean prospective;
 
     /* unapplied effects */
 

--- a/src/main/java/uk/gov/legislation/util/Versions.java
+++ b/src/main/java/uk/gov/legislation/util/Versions.java
@@ -7,6 +7,10 @@ public class Versions {
 
     private static final Pattern date = Pattern.compile("\\d{4}-\\d{2}-\\d{2}");
 
+    public static boolean isDateLabel(String s) {
+        return date.matcher(s).matches();
+    }
+
     public static boolean isVersionLabel(String s) {
         if (s.equals("enacted"))
             return true;

--- a/src/main/resources/transforms/simplify/metadata.xsl
+++ b/src/main/resources/transforms/simplify/metadata.xsl
@@ -29,6 +29,9 @@
         <xsl:apply-templates select="ukm:*/ukm:EnactmentDate" />
         <xsl:apply-templates select="ukm:*/ukm:Made" />
         <xsl:apply-templates select="ukm:*/ukm:DocumentClassification/ukm:DocumentStatus" />
+        <xsl:if test="$target/@Status = 'Prospective' or $target/self::P1/parent::P1group/@Status = 'Prospective'">
+            <prospective>true</prospective>
+        </xsl:if>
         <xsl:apply-templates select="dct:valid" />
         <xsl:apply-templates select="dc:title" />
         <xsl:call-template name="extent" />
@@ -237,6 +240,9 @@
 
 <xsl:template match="atom:link[@rel='http://purl.org/dc/terms/hasVersion']">
     <hasVersion>
+        <xsl:if test="@hreflang">
+            <xsl:attribute name="hreflang" select="@hreflang" />
+        </xsl:if>
         <xsl:value-of select="@title" />
     </hasVersion>
 </xsl:template>

--- a/src/test/java/uk/gov/legislation/converters/DocumentMetadataConverterTest.java
+++ b/src/test/java/uk/gov/legislation/converters/DocumentMetadataConverterTest.java
@@ -3,11 +3,47 @@ package uk.gov.legislation.converters;
 import org.junit.jupiter.api.Test;
 import uk.gov.legislation.api.responses.CommonMetadata;
 import uk.gov.legislation.transform.simple.Metadata;
+
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class DocumentMetadataConverterTest {
+
+    @Test
+    void revisedWholeDocument_withoutPointInTime_computesUpToDate() {
+        Metadata simple = new Metadata();
+        simple.longType = "UnitedKingdomPublicGeneralAct";
+        simple.status = Metadata.REVISED;
+        simple.setValid("2024-11-22");
+        simple.setVersions(List.of(Metadata.HasVersionEntry.of(null, "current")));
+
+        assertTrue(DocumentMetadataConverter.shouldComputeUpToDate(simple));
+    }
+
+    @Test
+    void revisedFragment_latestPayloadAfterLastFragmentMilestone_computesUpToDate() {
+        Metadata simple = new Metadata();
+        simple.longType = "ScottishOldAct";
+        simple.status = Metadata.REVISED;
+        simple.setValid("2007-01-01");
+        simple.setVersions(List.of(Metadata.HasVersionEntry.of(null, "1991-02-01")));
+
+        assertTrue(DocumentMetadataConverter.shouldComputeUpToDate(simple));
+    }
+
+    @Test
+    void revisedFragment_priorMilestone_doesNotComputeUpToDate() {
+        Metadata simple = new Metadata();
+        simple.longType = "ScottishOldAct";
+        simple.status = Metadata.REVISED;
+        simple.setValid("2000-01-01");
+        simple.setVersions(List.of(
+            Metadata.HasVersionEntry.of(null, "1991-02-01"),
+            Metadata.HasVersionEntry.of(null, "2007-01-01")));
+
+        assertFalse(DocumentMetadataConverter.shouldComputeUpToDate(simple));
+    }
 
     @Test
     void testConvertAltNumbersWithEmptyList() {

--- a/src/test/java/uk/gov/legislation/converters/UnappliedEffectsFetcherTest.java
+++ b/src/test/java/uk/gov/legislation/converters/UnappliedEffectsFetcherTest.java
@@ -30,11 +30,11 @@ class UnappliedEffectsFetcherTest {
 
     private static Metadata createFinalMetadata() {
         Metadata m = new Metadata();
-        m.status = "final";
+        m.status = Metadata.FINAL;
         m.longType = "UnitedKingdomPublicGeneralAct";
         m.year = 2024;
         m.number = 10;
-        m.setVersions(List.of("enacted"));
+        m.setVersions(List.of(Metadata.HasVersionEntry.of(null, "enacted")));
         return m;
     }
 
@@ -60,12 +60,27 @@ class UnappliedEffectsFetcherTest {
     @Test
     void skipsRevisedStatus() {
         Metadata m = new Metadata();
-        m.status = "revised";
+        m.status = Metadata.REVISED;
         m.longType = "UnitedKingdomPublicGeneralAct";
         m.year = 2024;
         m.number = 10;
 
         fetcher.fetchIfNeeded(m);
+
+        assertFalse(m.finalEffectsEnriched);
+        assertEquals(Collections.emptyList(), m.rawEffects);
+        verifyNoInteractions(changes);
+    }
+
+    @Test
+    void skipsUnknownTypeBeforeVersionCheck() {
+        Metadata m = new Metadata();
+        m.status = Metadata.FINAL;
+        m.longType = "UnknownType";
+        m.year = 2024;
+        m.number = 10;
+
+        assertDoesNotThrow(() -> fetcher.fetchIfNeeded(m));
 
         assertFalse(m.finalEffectsEnriched);
         assertEquals(Collections.emptyList(), m.rawEffects);

--- a/src/test/java/uk/gov/legislation/endpoints/fragment/FragmentVersioningTest.java
+++ b/src/test/java/uk/gov/legislation/endpoints/fragment/FragmentVersioningTest.java
@@ -1,0 +1,126 @@
+package uk.gov.legislation.endpoints.fragment;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.legislation.converters.UnappliedEffectsFetcher;
+import uk.gov.legislation.data.marklogic.legislation.Legislation;
+import uk.gov.legislation.transform.Akn2Html;
+import uk.gov.legislation.transform.Clml2Akn;
+import uk.gov.legislation.transform.Clml2Pdf;
+import uk.gov.legislation.transform.Transforms;
+import uk.gov.legislation.transform.clml2docx.Clml2Docx;
+import uk.gov.legislation.transform.simple.BilingualFragmentFixtures;
+import uk.gov.legislation.transform.simple.Simplify;
+import uk.gov.legislation.transform.simple.UnappliedEffectsHelper;
+
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(FragmentController.class)
+@Import({ Transforms.class, Clml2Akn.class, Akn2Html.class, Simplify.class })
+class FragmentVersioningTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private Legislation marklogic;
+
+    @MockitoBean
+    private Clml2Docx clml2Docx;
+
+    @MockitoBean
+    private Clml2Pdf clml2Pdf;
+
+    @MockitoBean
+    private UnappliedEffectsFetcher unappliedEffectsFetcher;
+
+    @Test
+    void currentUnversionedFragment_usesLastFragmentMilestoneAsVersion() throws Exception {
+        String clml = UnappliedEffectsHelper.read("/ukpga_2000_8/ukpga-2000-8-section-91.xml");
+        Legislation.Response response = new Legislation.Response(clml, Optional.empty());
+        when(marklogic.getDocumentSection("ukpga", "2000", 8, "section-91", Optional.empty(), Optional.of("en")))
+            .thenReturn(response);
+
+        mockMvc.perform(get("/fragment/ukpga/2000/8/section-91")
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Accept-Language", "en"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.meta.version").value("2024-01-30"))
+            .andExpect(jsonPath("$.meta.pointInTime").value(nullValue()))
+            .andExpect(jsonPath("$.meta.versions[0]").value("enacted"))
+            .andExpect(jsonPath("$.meta.versions[9]").value("2024-01-30"));
+    }
+
+    @Test
+    void welshFragmentVersions_areLanguageAware() throws Exception {
+        Legislation.Response response = new Legislation.Response(BilingualFragmentFixtures.welsh(), Optional.empty());
+        when(marklogic.getDocumentSection("wsi", "2020", 1609, "part-3-chapter-1", Optional.empty(), Optional.of("cy")))
+            .thenReturn(response);
+
+        mockMvc.perform(get("/fragment/wsi/2020/1609/part-3-chapter-1")
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Accept-Language", "cy"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.meta.version").value("2021-02-27"))
+            .andExpect(jsonPath("$.meta.pointInTime").value(nullValue()))
+            .andExpect(jsonPath("$.meta.versions", contains(
+                "made", "2020-12-20", "2020-12-24", "2021-01-09",
+                "2021-01-15", "2021-01-22", "2021-01-29", "2021-02-27")));
+    }
+
+    @Test
+    void versionedWelshFragment_pointInTimeDoesNotOverrideWelshFragmentVersion() throws Exception {
+        Legislation.Response response = new Legislation.Response(BilingualFragmentFixtures.welshPointInTime(), Optional.empty());
+        when(marklogic.getDocumentSection("wsi", "2020", 1609, "part-3-chapter-1", Optional.of("2021-05-17"), Optional.of("cy")))
+            .thenReturn(response);
+
+        mockMvc.perform(get("/fragment/wsi/2020/1609/part-3-chapter-1")
+                .param("version", "2021-05-17")
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Accept-Language", "cy"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.meta.version").value("2021-02-27"))
+            .andExpect(jsonPath("$.meta.pointInTime").value("2021-05-17"))
+            .andExpect(jsonPath("$.meta.versions", contains(
+                "made", "2020-12-20", "2020-12-24", "2021-01-09",
+                "2021-01-15", "2021-01-22", "2021-01-29", "2021-02-27")));
+    }
+
+    @Test
+    void englishFragmentVersions_areLanguageAware() throws Exception {
+        Legislation.Response response = new Legislation.Response(BilingualFragmentFixtures.english(), Optional.empty());
+        when(marklogic.getDocumentSection("wsi", "2020", 1609, "part-3-chapter-1", Optional.empty(), Optional.of("en")))
+            .thenReturn(response);
+
+        mockMvc.perform(get("/fragment/wsi/2020/1609/part-3-chapter-1")
+                .accept(MediaType.APPLICATION_JSON)
+                .header("Accept-Language", "en"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.meta.version").value("2022-03-28"))
+            .andExpect(jsonPath("$.meta.pointInTime").value(nullValue()))
+            .andExpect(jsonPath("$.meta.versions", contains(
+                "made", "2021-05-17", "2021-08-07", "2022-03-28")))
+            .andExpect(jsonPath("$.meta.versions", not(hasItems(
+                "2020-12-20", "2020-12-24", "2021-01-09",
+                "2021-01-15", "2021-01-22", "2021-01-29", "2021-02-27"))));
+    }
+}

--- a/src/test/java/uk/gov/legislation/transform/simple/BilingualFragmentFixtures.java
+++ b/src/test/java/uk/gov/legislation/transform/simple/BilingualFragmentFixtures.java
@@ -1,0 +1,83 @@
+package uk.gov.legislation.transform.simple;
+
+import java.io.IOException;
+
+/**
+ * Synthetic wsi/2020/1609/part/3/chapter/1 fragment with bilingual hasVersion links,
+ * built by mutating the committed fragment_wsi_2024_1002_regulation_2_cy.xml fixture.
+ *
+ * <p>Welsh-side links (hreflang="cy") stop at 2021-02-27; English-side links (hreflang="en")
+ * extend to 2022-03-28. The pair exists to exercise language-aware hasVersion filtering in
+ * both directions.
+ */
+public final class BilingualFragmentFixtures {
+
+    private BilingualFragmentFixtures() {}
+
+    public static String welsh() throws IOException {
+        return build(Side.WELSH, "/welsh", false);
+    }
+
+    public static String english() throws IOException {
+        return build(Side.ENGLISH, "", false);
+    }
+
+    public static String welshPointInTime() throws IOException {
+        return build(Side.WELSH, "/2021-05-17/welsh", true);
+    }
+
+    private enum Side { WELSH, ENGLISH }
+
+    private static final String BILINGUAL_HAS_VERSION_LINKS = """
+        <atom:link rel="http://purl.org/dc/terms/hasVersion" hreflang="cy" href="http://www.legislation.gov.uk/wsi/2020/1609/part/3/chapter/1/made/welsh" title="made"/>
+        <atom:link rel="http://purl.org/dc/terms/hasVersion" hreflang="cy" href="http://www.legislation.gov.uk/wsi/2020/1609/part/3/chapter/1/2020-12-20/welsh" title="2020-12-20"/>
+        <atom:link rel="http://purl.org/dc/terms/hasVersion" hreflang="cy" href="http://www.legislation.gov.uk/wsi/2020/1609/part/3/chapter/1/2020-12-24/welsh" title="2020-12-24"/>
+        <atom:link rel="http://purl.org/dc/terms/hasVersion" hreflang="cy" href="http://www.legislation.gov.uk/wsi/2020/1609/part/3/chapter/1/2021-01-09/welsh" title="2021-01-09"/>
+        <atom:link rel="http://purl.org/dc/terms/hasVersion" hreflang="cy" href="http://www.legislation.gov.uk/wsi/2020/1609/part/3/chapter/1/2021-01-15/welsh" title="2021-01-15"/>
+        <atom:link rel="http://purl.org/dc/terms/hasVersion" hreflang="cy" href="http://www.legislation.gov.uk/wsi/2020/1609/part/3/chapter/1/2021-01-22/welsh" title="2021-01-22"/>
+        <atom:link rel="http://purl.org/dc/terms/hasVersion" hreflang="cy" href="http://www.legislation.gov.uk/wsi/2020/1609/part/3/chapter/1/2021-01-29/welsh" title="2021-01-29"/>
+        <atom:link rel="http://purl.org/dc/terms/hasVersion" hreflang="cy" href="http://www.legislation.gov.uk/wsi/2020/1609/part/3/chapter/1/2021-02-27/welsh" title="2021-02-27"/>
+        <atom:link rel="http://purl.org/dc/terms/hasVersion" hreflang="en" href="http://www.legislation.gov.uk/wsi/2020/1609/part/3/chapter/1/made" title="made"/>
+        <atom:link rel="http://purl.org/dc/terms/hasVersion" hreflang="en" href="http://www.legislation.gov.uk/wsi/2020/1609/part/3/chapter/1/2021-05-17" title="2021-05-17"/>
+        <atom:link rel="http://purl.org/dc/terms/hasVersion" hreflang="en" href="http://www.legislation.gov.uk/wsi/2020/1609/part/3/chapter/1/2021-08-07" title="2021-08-07"/>
+        <atom:link rel="http://purl.org/dc/terms/hasVersion" hreflang="en" href="http://www.legislation.gov.uk/wsi/2020/1609/part/3/chapter/1/2022-03-28" title="2022-03-28"/>
+        """;
+
+    private static final String CURRENT_HAS_VERSION_LINKS = """
+        <atom:link rel="http://purl.org/dc/terms/hasVersion" hreflang="cy" href="http://www.legislation.gov.uk/wsi/2020/1609/part/3/chapter/1/welsh" title="current"/>
+        <atom:link rel="http://purl.org/dc/terms/hasVersion" hreflang="en" href="http://www.legislation.gov.uk/wsi/2020/1609/part/3/chapter/1" title="current"/>
+        """;
+
+    private static String build(Side side, String identifierSuffix, boolean includeCurrentLinks) throws IOException {
+        // Welsh translation lags English, so the Welsh-side dct:valid is earlier than the English one.
+        String validDate = side == Side.WELSH ? "2021-04-26" : "2022-03-28";
+
+        String clml = UnappliedEffectsHelper.read("/fragment_wsi_2024_1002_regulation_2_cy.xml");
+
+        clml = requireReplace(clml,
+            "title=\"HTML5 snippet\"/>",
+            "title=\"HTML5 snippet\"/>\n" + BILINGUAL_HAS_VERSION_LINKS + (includeCurrentLinks ? CURRENT_HAS_VERSION_LINKS : ""));
+
+        clml = requireReplace(clml,
+            "http://www.legislation.gov.uk/wsi/2024/1002/regulation/2/made/welsh",
+            "http://www.legislation.gov.uk/wsi/2020/1609/part/3/chapter/1" + identifierSuffix);
+
+        clml = requireReplace(clml,
+            "<dc:modified>2024-10-09</dc:modified><dc:subject scheme=\"SIheading\">ADDYSG, CYMRU</dc:subject>",
+            "<dc:modified>2024-10-09</dc:modified><dct:valid>" + validDate + "</dct:valid><dc:subject scheme=\"SIheading\">ADDYSG, CYMRU</dc:subject>");
+
+        clml = requireReplace(clml, "<ukm:DocumentStatus Value=\"final\"/>", "<ukm:DocumentStatus Value=\"revised\"/>");
+
+        if (side == Side.ENGLISH) {
+            clml = requireReplace(clml, "<dc:language>cy</dc:language>", "<dc:language>en</dc:language>");
+        }
+
+        return clml;
+    }
+
+    private static String requireReplace(String source, String target, String replacement) {
+        if (!source.contains(target))
+            throw new IllegalStateException("Base fixture no longer contains expected anchor: " + target);
+        return source.replace(target, replacement);
+    }
+}

--- a/src/test/java/uk/gov/legislation/transform/simple/MetadataVersionsSemanticsTest.java
+++ b/src/test/java/uk/gov/legislation/transform/simple/MetadataVersionsSemanticsTest.java
@@ -1,0 +1,395 @@
+package uk.gov.legislation.transform.simple;
+
+import net.sf.saxon.s9api.SaxonApiException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import tools.jackson.core.JacksonException;
+import uk.gov.legislation.Application;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest(classes = Application.class)
+class MetadataVersionsSemanticsTest {
+
+    private final Simplify simplifier;
+
+    @Autowired
+    MetadataVersionsSemanticsTest(Simplify simplifier) {
+        this.simplifier = simplifier;
+    }
+
+    @Test
+    void versions_finalCurrentOnly_primary_addsEnactedAndProspective() throws SaxonApiException, JacksonException {
+        Metadata metadata = simplifier.extractDocumentMetadata(FINAL_PRIMARY_CURRENT_ONLY);
+        assertEquals("enacted", metadata.version());
+        assertEquals(List.of("enacted", "prospective"), metadata.versions().stream().toList());
+    }
+
+    @Test
+    void versions_finalCurrentOnly_secondary_addsMadeAndProspective() throws SaxonApiException, JacksonException {
+        Metadata metadata = simplifier.extractDocumentMetadata(FINAL_SECONDARY_CURRENT_ONLY);
+        assertEquals("made", metadata.version());
+        assertEquals(List.of("made", "prospective"), metadata.versions().stream().toList());
+    }
+
+    @Test
+    void versions_finalCurrentOnly_ministerialOrder_addsCreatedAndProspective() throws SaxonApiException, JacksonException {
+        Metadata metadata = simplifier.extractDocumentMetadata(FINAL_MINISTERIAL_ORDER_CURRENT_ONLY);
+        assertEquals("created", metadata.version());
+        assertEquals(List.of("created", "prospective"), metadata.versions().stream().toList());
+    }
+
+    @Test
+    void versions_finalCurrentOnly_euDirective_addsAdoptedAndProspective() throws SaxonApiException, JacksonException {
+        Metadata metadata = simplifier.extractDocumentMetadata(FINAL_EU_DIRECTIVE_CURRENT_ONLY);
+        assertEquals("adopted", metadata.version());
+        assertEquals(List.of("adopted", "prospective"), metadata.versions().stream().toList());
+    }
+
+    @Test
+    void versions_finalCurrentAlongsideDate_ignoresCurrentAndDoesNotAddProspective() throws SaxonApiException, JacksonException {
+        Metadata metadata = simplifier.extractDocumentMetadata(FINAL_PRIMARY_CURRENT_AND_DATE);
+        assertEquals("enacted", metadata.version());
+        assertEquals(List.of("enacted", "2024-01-01"), metadata.versions().stream().toList());
+    }
+
+    @Test
+    void versions_finalWithoutHasVersion_addsFirstVersionOnly() throws SaxonApiException, JacksonException {
+        Metadata metadata = simplifier.extractDocumentMetadata(FINAL_PRIMARY_WITHOUT_HAS_VERSION);
+        assertEquals("enacted", metadata.version());
+        assertEquals(List.of("enacted"), metadata.versions().stream().toList());
+    }
+
+    @Test
+    void version_revisedDocumentWhoseTargetIsNotProspective_usesDctValidDate() throws SaxonApiException, JacksonException, IOException {
+        String clml = UnappliedEffectsHelper.read("/asp_2025_11/asp-2025-11-2025-08-07.xml");
+        Metadata metadata = simplifier.extractDocumentMetadata(clml);
+        assertEquals("2025-08-07", metadata.version());
+        assertEquals(List.of("enacted", "2025-08-07"), metadata.versions().stream().toList());
+    }
+
+    @Test
+    void version_revisedFragmentWithProspectiveProvisions_usesProspectiveLabel() throws SaxonApiException, JacksonException, IOException {
+        String clml = UnappliedEffectsHelper.read("/asp_2025_11/asp-2025-11-part-1-crossheading-reviews-2025-08-07.xml");
+        Metadata metadata = simplifier.extractFragmentMetadata(clml);
+        assertEquals("prospective", metadata.version());
+        assertEquals(List.of("enacted", "prospective"), metadata.versions().stream().toList());
+    }
+
+    @Test
+    void versions_unversionedProspectiveRevised_withoutCurrent_addsProspectiveLabel() throws SaxonApiException, JacksonException {
+        Metadata metadata = simplifier.extractDocumentMetadata(UNVERSIONED_PROSPECTIVE_REVISED_WITHOUT_CURRENT);
+        assertEquals("prospective", metadata.version());
+        assertEquals(List.of("enacted", "prospective"), metadata.versions().stream().toList());
+    }
+
+    @Test
+    void versions_revisedWholeDocumentWithCurrent_addsDctValidAsDocumentVersion() {
+        Metadata metadata = new Metadata();
+        metadata.status = Metadata.REVISED;
+        metadata.longType = "UnitedKingdomPublicGeneralAct";
+        metadata.setValid("2024-11-22");
+        metadata.setVersions(List.of(Metadata.HasVersionEntry.of(null, "current")));
+
+        assertEquals("2024-11-22", metadata.version());
+        assertEquals(List.of("2024-11-22"), metadata.versions().stream().toList());
+    }
+
+    @Test
+    void versions_prospectiveRevisedWithCurrentAndEnacted_synthesisesProspectiveNotDctValid() {
+        Metadata metadata = new Metadata();
+        metadata.status = Metadata.REVISED;
+        metadata.longType = "UnitedKingdomPublicGeneralAct";
+        metadata.prospective = true;
+        metadata.setValid("2024-11-22");
+        metadata.setVersions(List.of(
+            Metadata.HasVersionEntry.of(null, "enacted"),
+            Metadata.HasVersionEntry.of(null, "current")));
+
+        assertEquals("prospective", metadata.version());
+        assertEquals(List.of("enacted", "prospective"), metadata.versions().stream().toList());
+    }
+
+    @Test
+    void versions_versionedNonProspectiveFragment_withCurrent_doesNotAddDctValidAsMilestone() throws SaxonApiException, JacksonException {
+        Metadata metadata = simplifier.extractFragmentMetadata(VERSIONED_NON_PROSPECTIVE_FRAGMENT_CURRENT_AND_OLDER_DATE);
+        assertEquals("2024-10-01", metadata.version());
+        assertEquals(List.of("2024-10-01"), metadata.versions().stream().toList());
+    }
+
+    @Test
+    void version_unversionedFragment_usesLastFragmentMilestoneNotPayloadDate() throws SaxonApiException, JacksonException, IOException {
+        String clml = UnappliedEffectsHelper.read("/ukpga_2000_8/ukpga-2000-8-section-91.xml");
+        Metadata metadata = simplifier.extractFragmentMetadata(clml);
+        assertEquals("2024-01-30", metadata.version());
+        assertEquals("2024-01-30", metadata.versions().last());
+    }
+
+    @Test
+    void versions_welshFragment_filtersToWelshHasVersionLinksOnly() throws SaxonApiException, JacksonException, IOException {
+        Metadata metadata = simplifier.extractFragmentMetadata(BilingualFragmentFixtures.welsh());
+        assertEquals("2021-02-27", metadata.version());
+        assertEquals(
+            List.of("made", "2020-12-20", "2020-12-24", "2021-01-09", "2021-01-15", "2021-01-22", "2021-01-29", "2021-02-27"),
+            metadata.versions().stream().toList()
+        );
+    }
+
+    @Test
+    void versionedWelshFragment_pointInTimeAndDctValidDoNotOverrideFragmentMilestone() throws SaxonApiException, JacksonException, IOException {
+        Metadata metadata = simplifier.extractFragmentMetadata(BilingualFragmentFixtures.welshPointInTime());
+        assertEquals(LocalDate.of(2021, 5, 17), metadata.getPointInTime().orElseThrow());
+        assertEquals("2021-02-27", metadata.version());
+        assertEquals(
+            List.of("made", "2020-12-20", "2020-12-24", "2021-01-09", "2021-01-15", "2021-01-22", "2021-01-29", "2021-02-27"),
+            metadata.versions().stream().toList()
+        );
+    }
+
+    @Test
+    void versions_matchingLanguageRetainsUntaggedLinksAndFiltersOtherLanguages() {
+        Metadata metadata = new Metadata();
+        metadata.status = Metadata.REVISED;
+        metadata.longType = "WelshStatutoryInstrument";
+        metadata.lang = "cy";
+        metadata.setVersions(List.of(
+            Metadata.HasVersionEntry.of(null, "made"),
+            Metadata.HasVersionEntry.of("cy", "2021-02-27"),
+            Metadata.HasVersionEntry.of("en", "2022-03-28")));
+
+        assertEquals(List.of("made", "2021-02-27"), metadata.versions().stream().toList());
+    }
+
+    @Test
+    void versions_unknownLanguageRetainsAllLinks() {
+        Metadata metadata = new Metadata();
+        metadata.status = Metadata.REVISED;
+        metadata.longType = "WelshStatutoryInstrument";
+        metadata.setVersions(List.of(
+            Metadata.HasVersionEntry.of(null, "made"),
+            Metadata.HasVersionEntry.of("cy", "2021-02-27"),
+            Metadata.HasVersionEntry.of("en", "2022-03-28")));
+
+        assertEquals(List.of("made", "2021-02-27", "2022-03-28"), metadata.versions().stream().toList());
+    }
+
+    @Test
+    void versions_stripsRepealedSuffixFromLatestLabel() {
+        Metadata metadata = new Metadata();
+        metadata.status = Metadata.REVISED;
+        metadata.longType = "UnitedKingdomPublicGeneralAct";
+        metadata.setVersions(List.of(
+            Metadata.HasVersionEntry.of(null, "enacted"),
+            Metadata.HasVersionEntry.of(null, "2001-01-01"),
+            Metadata.HasVersionEntry.of(null, "2003-01-01 repealed")));
+        assertEquals(List.of("enacted", "2001-01-01", "2003-01-01"), metadata.versions().stream().toList());
+    }
+
+    @Test
+    void version_revisedNoEligibleMilestone_fallsBackToDctValid() {
+        Metadata metadata = new Metadata();
+        metadata.status = Metadata.REVISED;
+        metadata.longType = "UnitedKingdomPublicGeneralAct";
+        metadata.setValid("2024-01-01");
+        metadata.setVersions(List.of(Metadata.HasVersionEntry.of(null, "prospective")));
+
+        assertEquals("2024-01-01", metadata.version());
+        assertEquals(List.of("prospective"), metadata.versions().stream().toList());
+    }
+
+    private static final String FINAL_PRIMARY_CURRENT_ONLY = """
+        <Legislation xmlns="http://www.legislation.gov.uk/namespaces/legislation" DocumentURI="http://www.legislation.gov.uk/nia/2022/21/enacted">
+            <Metadata xmlns="http://www.legislation.gov.uk/namespaces/metadata" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:atom="http://www.w3.org/2005/Atom">
+                <dc:identifier>http://www.legislation.gov.uk/nia/2022/21/enacted</dc:identifier>
+                <dc:title>Test Act</dc:title>
+                <dc:publisher>Statute Law Database</dc:publisher>
+                <dc:modified>2026-01-01</dc:modified>
+                <atom:link rel="http://purl.org/dc/terms/hasVersion" href="http://www.legislation.gov.uk/nia/2022/21" title="current"/>
+                <PrimaryMetadata>
+                    <DocumentClassification>
+                        <DocumentCategory Value="primary" />
+                        <DocumentMainType Value="NorthernIrelandAct" />
+                        <DocumentStatus Value="final" />
+                    </DocumentClassification>
+                    <Year Value="2022" />
+                    <Number Value="21" />
+                    <EnactmentDate Date="2022-01-01" />
+                </PrimaryMetadata>
+            </Metadata>
+        </Legislation>
+        """;
+
+    private static final String FINAL_SECONDARY_CURRENT_ONLY = """
+        <Legislation xmlns="http://www.legislation.gov.uk/namespaces/legislation" DocumentURI="http://www.legislation.gov.uk/uksi/2025/3/made">
+            <Metadata xmlns="http://www.legislation.gov.uk/namespaces/metadata" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:atom="http://www.w3.org/2005/Atom">
+                <dc:identifier>http://www.legislation.gov.uk/uksi/2025/3/made</dc:identifier>
+                <dc:title>Test Regulations</dc:title>
+                <dc:publisher>Statute Law Database</dc:publisher>
+                <dc:modified>2026-01-01</dc:modified>
+                <atom:link rel="http://purl.org/dc/terms/hasVersion" href="http://www.legislation.gov.uk/uksi/2025/3" title="current"/>
+                <SecondaryMetadata>
+                    <DocumentClassification>
+                        <DocumentCategory Value="secondary" />
+                        <DocumentMainType Value="UnitedKingdomStatutoryInstrument" />
+                        <DocumentStatus Value="final" />
+                    </DocumentClassification>
+                    <Year Value="2025" />
+                    <Number Value="3" />
+                    <Made Date="2025-01-01" />
+                </SecondaryMetadata>
+            </Metadata>
+        </Legislation>
+        """;
+
+    private static final String FINAL_PRIMARY_CURRENT_AND_DATE = """
+        <Legislation xmlns="http://www.legislation.gov.uk/namespaces/legislation" DocumentURI="http://www.legislation.gov.uk/ukla/2017/1/enacted">
+            <Metadata xmlns="http://www.legislation.gov.uk/namespaces/metadata" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:atom="http://www.w3.org/2005/Atom">
+                <dc:identifier>http://www.legislation.gov.uk/ukla/2017/1/enacted</dc:identifier>
+                <dc:title>Test Local Act</dc:title>
+                <dc:publisher>Statute Law Database</dc:publisher>
+                <dc:modified>2026-01-01</dc:modified>
+                <atom:link rel="http://purl.org/dc/terms/hasVersion" href="http://www.legislation.gov.uk/ukla/2017/1/2024-01-01" title="2024-01-01"/>
+                <atom:link rel="http://purl.org/dc/terms/hasVersion" href="http://www.legislation.gov.uk/ukla/2017/1" title="current"/>
+                <PrimaryMetadata>
+                    <DocumentClassification>
+                        <DocumentCategory Value="primary" />
+                        <DocumentMainType Value="UnitedKingdomLocalAct" />
+                        <DocumentStatus Value="final" />
+                    </DocumentClassification>
+                    <Year Value="2017" />
+                    <Number Value="1" />
+                    <EnactmentDate Date="2017-01-01" />
+                </PrimaryMetadata>
+            </Metadata>
+        </Legislation>
+        """;
+
+    private static final String FINAL_PRIMARY_WITHOUT_HAS_VERSION = """
+        <Legislation xmlns="http://www.legislation.gov.uk/namespaces/legislation" DocumentURI="http://www.legislation.gov.uk/ukpga/2025/1/enacted">
+            <Metadata xmlns="http://www.legislation.gov.uk/namespaces/metadata" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:atom="http://www.w3.org/2005/Atom">
+                <dc:identifier>http://www.legislation.gov.uk/ukpga/2025/1/enacted</dc:identifier>
+                <dc:title>Test Act Without HasVersion</dc:title>
+                <dc:publisher>Statute Law Database</dc:publisher>
+                <dc:modified>2026-01-01</dc:modified>
+                <PrimaryMetadata>
+                    <DocumentClassification>
+                        <DocumentCategory Value="primary" />
+                        <DocumentMainType Value="UnitedKingdomPublicGeneralAct" />
+                        <DocumentStatus Value="final" />
+                    </DocumentClassification>
+                    <Year Value="2025" />
+                    <Number Value="1" />
+                    <EnactmentDate Date="2025-01-01" />
+                </PrimaryMetadata>
+            </Metadata>
+        </Legislation>
+        """;
+
+    private static final String FINAL_MINISTERIAL_ORDER_CURRENT_ONLY = """
+        <Legislation xmlns="http://www.legislation.gov.uk/namespaces/legislation" DocumentURI="http://www.legislation.gov.uk/ukmo/2024/5/made">
+            <Metadata xmlns="http://www.legislation.gov.uk/namespaces/metadata" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:atom="http://www.w3.org/2005/Atom">
+                <dc:identifier>http://www.legislation.gov.uk/ukmo/2024/5/made</dc:identifier>
+                <dc:title>Test Ministerial Order</dc:title>
+                <dc:publisher>Statute Law Database</dc:publisher>
+                <dc:modified>2026-01-01</dc:modified>
+                <atom:link rel="http://purl.org/dc/terms/hasVersion" href="http://www.legislation.gov.uk/ukmo/2024/5" title="current"/>
+                <SecondaryMetadata>
+                    <DocumentClassification>
+                        <DocumentCategory Value="secondary" />
+                        <DocumentMainType Value="UnitedKingdomMinisterialOrder" />
+                        <DocumentStatus Value="final" />
+                    </DocumentClassification>
+                    <Year Value="2024" />
+                    <Number Value="5" />
+                    <Made Date="2024-01-01" />
+                </SecondaryMetadata>
+            </Metadata>
+        </Legislation>
+        """;
+
+    private static final String FINAL_EU_DIRECTIVE_CURRENT_ONLY = """
+        <Legislation xmlns="http://www.legislation.gov.uk/namespaces/legislation" DocumentURI="http://www.legislation.gov.uk/eudr/2019/7/adopted">
+            <Metadata xmlns="http://www.legislation.gov.uk/namespaces/metadata" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:atom="http://www.w3.org/2005/Atom">
+                <dc:identifier>http://www.legislation.gov.uk/eudr/2019/7/adopted</dc:identifier>
+                <dc:title>Test EU Directive</dc:title>
+                <dc:publisher>King's Printer of Acts of Parliament</dc:publisher>
+                <dc:modified>2026-01-01</dc:modified>
+                <atom:link rel="http://purl.org/dc/terms/hasVersion" href="http://www.legislation.gov.uk/eudr/2019/7" title="current"/>
+                <EUMetadata>
+                    <DocumentClassification>
+                        <DocumentCategory Value="euretained" />
+                        <DocumentMainType Value="EuropeanUnionDirective" />
+                        <DocumentStatus Value="final" />
+                    </DocumentClassification>
+                    <Year Value="2019" />
+                    <Number Value="7" />
+                    <EnactmentDate Date="2019-01-01" />
+                </EUMetadata>
+            </Metadata>
+        </Legislation>
+        """;
+
+    private static final String UNVERSIONED_PROSPECTIVE_REVISED_WITHOUT_CURRENT = """
+        <Legislation xmlns="http://www.legislation.gov.uk/namespaces/legislation" DocumentURI="http://www.legislation.gov.uk/ukpga/2026/8" Status="Prospective">
+            <Metadata xmlns="http://www.legislation.gov.uk/namespaces/metadata" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:atom="http://www.w3.org/2005/Atom">
+                <dc:identifier>http://www.legislation.gov.uk/ukpga/2026/8</dc:identifier>
+                <dc:title>Test Prospective Act</dc:title>
+                <dc:publisher>Statute Law Database</dc:publisher>
+                <dc:modified>2026-02-12</dc:modified>
+                <dct:valid>2026-03-05</dct:valid>
+                <atom:link rel="http://purl.org/dc/terms/hasVersion" href="http://www.legislation.gov.uk/ukpga/2026/8/enacted" title="enacted"/>
+                <PrimaryMetadata>
+                    <DocumentClassification>
+                        <DocumentCategory Value="primary" />
+                        <DocumentMainType Value="UnitedKingdomPublicGeneralAct" />
+                        <DocumentStatus Value="revised" />
+                    </DocumentClassification>
+                    <Year Value="2026" />
+                    <Number Value="8" />
+                    <EnactmentDate Date="2026-02-12" />
+                </PrimaryMetadata>
+            </Metadata>
+        </Legislation>
+        """;
+
+    private static final String VERSIONED_NON_PROSPECTIVE_FRAGMENT_CURRENT_AND_OLDER_DATE = """
+        <Legislation xmlns="http://www.legislation.gov.uk/namespaces/legislation" DocumentURI="http://www.legislation.gov.uk/ukpga/2024/1/2024-11-01">
+            <Metadata xmlns="http://www.legislation.gov.uk/namespaces/metadata" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:atom="http://www.w3.org/2005/Atom">
+                <dc:identifier>http://www.legislation.gov.uk/ukpga/2024/1/section/2/2024-11-01</dc:identifier>
+                <dc:title>Test Revised Section</dc:title>
+                <dc:publisher>Statute Law Database</dc:publisher>
+                <dc:modified>2024-11-02</dc:modified>
+                <dct:valid>2024-11-01</dct:valid>
+                <atom:link rel="http://purl.org/dc/terms/hasVersion" href="http://www.legislation.gov.uk/ukpga/2024/1/section/2/2024-10-01" title="2024-10-01"/>
+                <atom:link rel="http://purl.org/dc/terms/hasVersion" href="http://www.legislation.gov.uk/ukpga/2024/1/section/2" title="current"/>
+                <PrimaryMetadata>
+                    <DocumentClassification>
+                        <DocumentCategory Value="primary" />
+                        <DocumentMainType Value="UnitedKingdomPublicGeneralAct" />
+                        <DocumentStatus Value="revised" />
+                    </DocumentClassification>
+                    <Year Value="2024" />
+                    <Number Value="1" />
+                    <EnactmentDate Date="2024-01-01" />
+                </PrimaryMetadata>
+            </Metadata>
+            <Primary>
+                <Body DocumentURI="http://www.legislation.gov.uk/ukpga/2024/1/body/2024-11-01" IdURI="http://www.legislation.gov.uk/id/ukpga/2024/1/body" RestrictStartDate="2024-11-01">
+                    <P1group RestrictStartDate="2024-10-01">
+                        <P1 DocumentURI="http://www.legislation.gov.uk/ukpga/2024/1/section/2/2024-11-01" IdURI="http://www.legislation.gov.uk/id/ukpga/2024/1/section/2" id="section-2">
+                            <Pnumber>2</Pnumber>
+                            <P1para>
+                                <Text>Test text.</Text>
+                            </P1para>
+                        </P1>
+                    </P1group>
+                </Body>
+            </Primary>
+        </Legislation>
+        """;
+}


### PR DESCRIPTION
This PR tightens up how we derive `version` and `versions` from legislation.gov.uk metadata, especially for fragments.

The main issue is that `dct:valid` is not always the version of the thing being requested. For a whole document, it usually identifies the revised document snapshot. But for a fragment, it can identify the containing document snapshot instead. That matters in cases like `wsi/2020/1609/part/3/chapter/1/welsh`, where the XML is valid from `2021-04-26`, but the Welsh fragment’s own latest milestone is still `2021-02-27`.

The change makes that distinction explicit. Fragment versioning now works from the fragment’s own scoped `hasVersion` links, including language filtering for bilingual XML. Untagged links are kept, same-language links are kept, and other-language links are ignored. That prevents English milestones from leaking into Welsh fragment responses.

It also formalises a few edge cases we had been handling less clearly:

- `current` is treated as an alias, not a version label.
- final/enacted or made XML with only `current` gets a label-only `prospective` entry.
- revised prospective content also gets a label-only `prospective` entry, matching the legacy timeline behaviour.
- `dct:valid` is only recovered into `versions` when stripping `current` would otherwise lose the label for the returned representation.
- scalar `version` is selected as the latest eligible milestone not after `dct:valid`, except for prospective revised content, where it is `prospective`.

I added `docs/versions.md` as the canonical description of these rules, because the behaviour is subtle and I do not want it to live only in code. The tests now cover the main branches directly, including final/current handling, prospective revised content, fragment milestone selection, repealed labels, Welsh/English filtering, and the fetcher guard ordering.