### PR TITLE
Mock LegislationById in FragmentVersioningTest

### DIFF
--- a/src/test/java/uk/gov/legislation/endpoints/fragment/FragmentVersioningTest.java
+++ b/src/test/java/uk/gov/legislation/endpoints/fragment/FragmentVersioningTest.java
@@ -9,6 +9,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.legislation.converters.UnappliedEffectsFetcher;
 import uk.gov.legislation.data.marklogic.legislation.Legislation;
+import uk.gov.legislation.data.marklogic.legislationbyid.LegislationById;
 import uk.gov.legislation.transform.Akn2Html;
 import uk.gov.legislation.transform.Clml2Akn;
 import uk.gov.legislation.transform.Clml2Pdf;
@@ -39,6 +40,9 @@ class FragmentVersioningTest {
 
     @MockitoBean
     private Legislation marklogic;
+
+    @MockitoBean
+    private LegislationById legislationById;
 
     @MockitoBean
     private Clml2Docx clml2Docx;


### PR DESCRIPTION
## Summary
- PR #174 added `LegislationById` as a constructor dependency to `FragmentController` for the HEAD fragment existence endpoint
- `FragmentVersioningTest` was not updated to provide a mock, causing all 4 tests to fail with an `ApplicationContext` load error
- Adds the missing `@MockitoBean` for `LegislationById`

## Test plan
- [ ] Run `FragmentVersioningTest` — all 4 tests pass