### PR TITLE
Add ukAmended facet field to search results

### DIFF
--- a/src/main/java/uk/gov/legislation/api/responses/PageOfDocuments.java
+++ b/src/main/java/uk/gov/legislation/api/responses/PageOfDocuments.java
@@ -72,6 +72,10 @@ public class PageOfDocuments {
         public String type;
 
         @Schema
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        public Boolean ukAmended;
+
+        @Schema
         public int count;
 
     }

--- a/src/main/java/uk/gov/legislation/converters/Facets.java
+++ b/src/main/java/uk/gov/legislation/converters/Facets.java
@@ -20,8 +20,18 @@ public class Facets {
 
     private static PageOfDocuments.ByType make1(SearchResults.FacetType atom) {
         PageOfDocuments.ByType byType = new PageOfDocuments.ByType();
-        byType.type = atom.type;
         byType.count = atom.value;
+        int pipe = atom.type == null ? -1 : atom.type.indexOf('|');
+        if (pipe < 0) {
+            byType.type = atom.type;
+        } else {
+            byType.type = atom.type.substring(0, pipe);
+            String qualifier = atom.type.substring(pipe + 1);
+            if ("ukamended=true".equals(qualifier))
+                byType.ukAmended = Boolean.TRUE;
+            else if ("ukamended=false".equals(qualifier))
+                byType.ukAmended = Boolean.FALSE;
+        }
         return byType;
     }
 

--- a/src/main/java/uk/gov/legislation/data/marklogic/search/Parameters.java
+++ b/src/main/java/uk/gov/legislation/data/marklogic/search/Parameters.java
@@ -12,6 +12,8 @@ public class Parameters extends AbstractParameters {
 
     public String type;
 
+    public Boolean ukamended;
+
     public Integer year;
 
     public Integer startYear;
@@ -109,6 +111,11 @@ public class Parameters extends AbstractParameters {
             } else {
                 params.type = String.join("+", types);
             }
+            return this;
+        }
+
+        public Builder ukamended(Boolean ukamended) {
+            params.ukamended = ukamended;
             return this;
         }
 

--- a/src/main/java/uk/gov/legislation/endpoints/search/SearchController.java
+++ b/src/main/java/uk/gov/legislation/endpoints/search/SearchController.java
@@ -79,6 +79,7 @@ public class SearchController implements SearchApi {
     private static Parameters convert(SearchParameters params) {
         var builder = Parameters.builder()
             .type(params.getTypes())
+            .ukamended(params.getUkAmended())
             .year(params.getYear())
             .startYear(params.getStartYear())
             .endYear(params.getEndYear())

--- a/src/main/java/uk/gov/legislation/endpoints/search/SearchParameters.java
+++ b/src/main/java/uk/gov/legislation/endpoints/search/SearchParameters.java
@@ -23,6 +23,7 @@ import java.util.Set;
 public class SearchParameters {
 
     private List<String> types;
+    private Boolean ukAmended;
     private Integer year;
     private Integer startYear;
     private Integer endYear;
@@ -49,6 +50,15 @@ public class SearchParameters {
 
     public void setType(List<String> types) {
         this.types = types;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Boolean getUkAmended() {
+        return ukAmended;
+    }
+
+    public void setUkAmended(Boolean ukAmended) {
+        this.ukAmended = ukAmended;
     }
 
     @Year

--- a/src/test/java/uk/gov/legislation/converters/FacetsTest.java
+++ b/src/test/java/uk/gov/legislation/converters/FacetsTest.java
@@ -69,6 +69,43 @@ class FacetsTest {
     }
 
     @Test
+    @DisplayName("Should split ukamended qualifier out of the type string")
+    void testConvertTypeFacets_UkAmendedQualifier_SplitIntoSeparateField() {
+        SearchResults.FacetType plain = new SearchResults.FacetType();
+        plain.type = "EuropeanUnionRegulation";
+        plain.value = 124855;
+
+        SearchResults.FacetType amended = new SearchResults.FacetType();
+        amended.type = "EuropeanUnionRegulation|ukamended=true";
+        amended.value = 3683;
+
+        SearchResults.FacetType notAmended = new SearchResults.FacetType();
+        notAmended.type = "EuropeanUnionRegulation|ukamended=false";
+        notAmended.value = 121172;
+
+        SearchResults.FacetTypes facetTypes = new SearchResults.FacetTypes();
+        facetTypes.entries = List.of(plain, amended, notAmended);
+
+        List<PageOfDocuments.ByType> result = Facets.convertTypeFacets(facetTypes);
+
+        assertAll("ukamended split",
+            () -> assertEquals(3, result.size()),
+
+            () -> assertEquals("EuropeanUnionRegulation", result.get(0).type),
+            () -> assertNull(result.get(0).ukAmended),
+            () -> assertEquals(124855, result.get(0).count),
+
+            () -> assertEquals("EuropeanUnionRegulation", result.get(1).type),
+            () -> assertEquals(Boolean.TRUE, result.get(1).ukAmended),
+            () -> assertEquals(3683, result.get(1).count),
+
+            () -> assertEquals("EuropeanUnionRegulation", result.get(2).type),
+            () -> assertEquals(Boolean.FALSE, result.get(2).ukAmended),
+            () -> assertEquals(121172, result.get(2).count)
+        );
+    }
+
+    @Test
     @DisplayName("Should exclude filtered type 'UnitedKingdomDraftPublicBill'")
     void testConvertTypeFacets_FilteredType_ExcludesFilteredEntries() {
         SearchResults.FacetType entry1 = new SearchResults.FacetType();


### PR DESCRIPTION
## Summary

EU retained law documents in MarkLogic are split into two subsets: those that have been amended by UK legislation since Brexit, and those that have not. MarkLogic surfaces this distinction in its type facets by appending a `|ukamended=true` or `|ukamended=false` qualifier to the type string (e.g. `EuropeanUnionRegulation|ukamended=true`).

This PR exposes that distinction cleanly so the UI can:
- **Show counts** for amended vs. unamended EU document subsets alongside the main type facets
- **Allow selective searching** by passing `ukAmended=true` or `ukAmended=false` as a search parameter to filter to one subset

## Changes

- **`Facets.java`**: Strips the `|ukamended=...` qualifier from the raw type string and maps it to a new `ukAmended` boolean field on the `ByType` response object
- **`PageOfDocuments.ByType`**: Adds the `ukAmended` field (nullable — absent for non-EU types)
- **`SearchParameters` / `Parameters` / `SearchController`**: Wires up `ukAmended` as a new optional search parameter passed through to MarkLogic

## Test plan
- [ ] New `FacetsTest` case verifies that `ukamended=true/false` qualifiers are correctly split into the `ukAmended` field while leaving the base type intact
- [ ] Unamended type strings are unaffected (`ukAmended` is null/absent)