### PR TITLE
Fix /dates/published 500 when nothing published that day

### DIFF
--- a/src/main/java/uk/gov/legislation/endpoints/dates/DatesController.java
+++ b/src/main/java/uk/gov/legislation/endpoints/dates/DatesController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.gov.legislation.api.responses.DateCount;
 import uk.gov.legislation.data.marklogic.search.Parameters;
 import uk.gov.legislation.data.marklogic.search.Search;
+import uk.gov.legislation.data.marklogic.search.SearchResults;
 
 @RestController
 public class DatesController implements DatesApi {
@@ -25,6 +26,13 @@ public class DatesController implements DatesApi {
     public List<DateCount> published() throws IOException, InterruptedException {
         LocalDate date = LocalDate.now(LONDON).minusDays(1);
         Parameters params = Parameters.builder().published(date).build();
-        return search.get(params).facets.facetPublishDates.stream().map(DateCount::new).toList();
+        SearchResults.Facets facets = search.get(params).facets;
+        // MarkLogic omits the <facets>/<facetPublishDates> elements entirely when nothing was
+        // published on the queried day, so Jackson leaves these null (not empty). Guard both
+        // levels and return an empty list rather than throwing.
+        if (facets == null || facets.facetPublishDates == null) {
+            return List.of();
+        }
+        return facets.facetPublishDates.stream().map(DateCount::new).toList();
     }
 }

--- a/src/test/java/uk/gov/legislation/endpoints/dates/DatesControllerTest.java
+++ b/src/test/java/uk/gov/legislation/endpoints/dates/DatesControllerTest.java
@@ -63,6 +63,37 @@ class DatesControllerTest {
     }
 
     @Test
+    void shouldReturnEmptyList_whenFacetPublishDatesAbsent() throws Exception {
+        // MarkLogic omits the <facetPublishDates> element entirely when nothing was published,
+        // so Jackson leaves the list null (not empty) — the real "no publications" shape that the
+        // emptyList() mock above does not exercise. This is what produced the live 500.
+        SearchResults results = new SearchResults();
+        results.facets = new SearchResults.Facets();
+        results.facets.facetPublishDates = null;
+
+        when(search.get(any(Parameters.class))).thenReturn(results);
+
+        mockMvc.perform(get("/dates/published").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(content().json("[]"));
+    }
+
+    @Test
+    void shouldReturnEmptyList_whenFacetsAbsent() throws Exception {
+        // If the <facets> element itself is absent, the whole facets object is null.
+        SearchResults results = new SearchResults();
+        results.facets = null;
+
+        when(search.get(any(Parameters.class))).thenReturn(results);
+
+        mockMvc.perform(get("/dates/published").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(content().json("[]"));
+    }
+
+    @Test
     void shouldReturnSingleDateCount_whenOnePublishDate() throws Exception {
         SearchResults results = new SearchResults();
         results.facets = new SearchResults.Facets();


### PR DESCRIPTION
## Problem
`GET /dates/published` returned **500** whenever the queried day had no publications. `DatesController` did:

```java
return search.get(params).facets.facetPublishDates.stream()...
```

MarkLogic omits the `<facets>` / `<facetPublishDates>` elements entirely when nothing was published on the queried day (yesterday, Europe/London), so Jackson leaves both **null** — and the unguarded dereference threw an NPE. The day this was found, yesterday genuinely had no publications, so the live endpoint 500'd every call.

The existing test only mocked the empty case with `Collections.emptyList()`, a shape MarkLogic never actually returns for no-results — so it stayed green while production failed.

## Fix
- Capture `facets`, guard **both** null levels, and return an empty list when absent (the honest answer for "nothing published that day").
- Add two regression tests for the real shapes (`facetPublishDates == null`; `facets == null`). Both were verified to throw the exact production NPE against the unfixed controller, then pass after the fix.

## Verification
- `./mvnw verify`: **699 tests, 0 failures** (+2 new), `spotless:check` clean, BUILD SUCCESS.
- Confirmed live: the endpoint now returns `200` with `[]` instead of 500.

## Scope note
This stops the crash; it does not change that the endpoint only ever queries *yesterday*, so on any day with no prior-day publications it now legitimately returns `[]`. Whether "recent publication dates" should use a rolling window is a separate product question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
