### PR TITLE
Dependency updates: Spring Boot 4.1.0, Spotless 3.6.0, and patch/minor bumps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
 		<dependency>
 			<groupId>io.awspring.cloud</groupId>
 			<artifactId>spring-cloud-aws-starter-parameter-store</artifactId>
-			<version>4.0.0</version>
+			<version>4.0.2</version>
 			<exclusions>
 				<exclusion>
 					<groupId>commons-logging</groupId>
@@ -80,7 +80,7 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
-			<version>3.0.1</version>
+			<version>3.0.3</version>
 		</dependency>
 		<!-- Spring Boot AOP -->
 		<dependency>
@@ -175,7 +175,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.14</version>
+				<version>0.8.15</version>
 				<executions>
 					<execution>
 						<goals>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.1</version>
+		<version>4.1.0</version>
 		<relativePath/>
 		<!-- lookup parent from repository -->
 	</parent>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 	<properties>
 		<java.version>21</java.version>
 		<errorprone.version>2.39.0</errorprone.version>
-		<spotless.plugin.version>2.44.5</spotless.plugin.version>
+		<spotless.plugin.version>3.6.0</spotless.plugin.version>
 		<google.format.version>1.27.0</google.format.version>
 	</properties>
 	<dependencies>


### PR DESCRIPTION
## Summary

Routine dependency maintenance. Three commits, each independently verified with `./mvnw clean verify` — 696 tests, Spotless check, and jacoco all green at every step.

## Changes

- `spring-cloud-aws-starter-parameter-store` 4.0.0 -> 4.0.2
- `springdoc-openapi-starter-webmvc-api` 3.0.1 -> 3.0.3
- `jacoco-maven-plugin` 0.8.14 -> 0.8.15
- Spring Boot parent 4.0.1 -> 4.1.0 — carries `mockito-core` 5.20.0 -> 5.23.0 and the Jackson 3 family -> 3.1.4 forward coherently via the BOM, with no per-artifact overrides
- Spotless plugin 2.44.5 -> 3.6.0 — google-java-format stays pinned at 1.27.0, so the formatter is unchanged and no reformat is triggered (357 files already clean)

## Deliberately excluded

- **Saxon-HE 12.9 -> 13.0** — compiles clean, but Saxon 13 changes its internal `generate-id()` node numbering, which fails the golden-output transform tests. The drift is non-functional (outputs are byte-identical apart from the opaque `d1eNNN` ids, and `id`/`href` pairs move in lockstep so links still resolve). It will come as its own PR with regenerated golden files plus a live e2e rendering sweep.
- **jackson-dataformat-xml 3.1.4 -> 3.2.0** — left for a future Spring Boot BOM bump; overriding it alone would desync it from the rest of the Jackson 3 family (still 3.1.4).
