### PR TITLE
Decouple data layer from Spring Environment via plain config records

### DIFF
--- a/src/main/java/uk/gov/legislation/config/DataConfig.java
+++ b/src/main/java/uk/gov/legislation/config/DataConfig.java
@@ -1,0 +1,38 @@
+package uk.gov.legislation.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import uk.gov.legislation.data.marklogic.MarkLogicConfig;
+import uk.gov.legislation.data.virtuoso.VirtuosoConfig;
+import uk.gov.legislation.data.virtuoso.defra.DefraLexConfig;
+
+/**
+ * Binds external properties to the framework-agnostic data-layer config records. All Spring
+ * coupling for data-source configuration lives here, keeping {@code uk.gov.legislation.data} free
+ * of configuration plumbing.
+ */
+@Configuration
+public class DataConfig {
+
+    @Bean
+    MarkLogicConfig markLogicConfig(
+            @Value("${MARKLOGIC_HOST}") String host,
+            @Value("${MARKLOGIC_PORT}") int port,
+            @Value("${MARKLOGIC_USERNAME}") String username,
+            @Value("${MARKLOGIC_PASSWORD}") String password) {
+        return new MarkLogicConfig(host, port, username, password);
+    }
+
+    @Bean
+    VirtuosoConfig virtuosoConfig(
+            @Value("${VIRTUOSO_HOST}") String host, @Value("${VIRTUOSO_PORT}") int port) {
+        return new VirtuosoConfig(host, port);
+    }
+
+    @Bean
+    DefraLexConfig defraLexConfig(
+            @Value("${VIRTUOSO_HOST}") String host, @Value("${DEFRALEX_PORT}") int port) {
+        return new DefraLexConfig(host, port);
+    }
+}

--- a/src/main/java/uk/gov/legislation/data/marklogic/MarkLogic.java
+++ b/src/main/java/uk/gov/legislation/data/marklogic/MarkLogic.java
@@ -10,28 +10,20 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Base64;
-import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 import uk.gov.legislation.exceptions.MarkLogicRequestException;
 
 @Component
 public class MarkLogic {
 
-    private final HttpClient httpClient;
+    private final HttpClient httpClient = HttpClient.newHttpClient();
     private final String baseUri;
     private final String authHeader;
 
     /** Using constructor-based injection for better testability and immutability. */
-    public MarkLogic(Environment env) {
-        this.httpClient = HttpClient.newHttpClient();
-
-        String host = env.getProperty("MARKLOGIC_HOST");
-        String port = env.getProperty("MARKLOGIC_PORT");
-        String username = env.getProperty("MARKLOGIC_USERNAME");
-        String password = env.getProperty("MARKLOGIC_PASSWORD");
-
-        this.baseUri = String.format("http://%s:%s/queries/", host, port);
-        this.authHeader = createAuthHeader(username, password);
+    public MarkLogic(MarkLogicConfig config) {
+        this.baseUri = String.format("http://%s:%d/queries/", config.host(), config.port());
+        this.authHeader = createAuthHeader(config.username(), config.password());
     }
 
     private String createAuthHeader(String username, String password) {

--- a/src/main/java/uk/gov/legislation/data/marklogic/MarkLogicConfig.java
+++ b/src/main/java/uk/gov/legislation/data/marklogic/MarkLogicConfig.java
@@ -1,0 +1,4 @@
+package uk.gov.legislation.data.marklogic;
+
+/** MarkLogic connection settings. Plain record — no framework dependency. */
+public record MarkLogicConfig(String host, int port, String username, String password) {}

--- a/src/main/java/uk/gov/legislation/data/virtuoso/Virtuoso.java
+++ b/src/main/java/uk/gov/legislation/data/virtuoso/Virtuoso.java
@@ -9,22 +9,16 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Set;
-import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public class Virtuoso {
 
     private final String endpoint;
+    private final HttpClient httpClient = HttpClient.newHttpClient();
 
-    public Virtuoso(Environment env) {
-        String host = env.getProperty("VIRTUOSO_HOST");
-        String port = env.getProperty("VIRTUOSO_PORT");
-
-        if (host == null || port == null) {
-            throw new IllegalArgumentException("VIRTUOSO_HOST or VIRTUOSO_PORT cannot be null");
-        }
-        endpoint = "http://" + host + ":" + port + "/sparql";
+    public Virtuoso(VirtuosoConfig config) {
+        endpoint = "http://" + config.host() + ":" + config.port() + "/sparql";
     }
 
     public static final Set<String> Formats =
@@ -44,10 +38,8 @@ public class Virtuoso {
                 URI.create(endpoint + "?query=" + URLEncoder.encode(query, StandardCharsets.UTF_8));
         HttpRequest request =
                 HttpRequest.newBuilder().GET().uri(uri).header("Accept", format).build();
-        HttpResponse<String> response;
-        try (HttpClient client = HttpClient.newHttpClient()) {
-            response = client.send(request, HttpResponse.BodyHandlers.ofString());
-        }
+        HttpResponse<String> response =
+                httpClient.send(request, HttpResponse.BodyHandlers.ofString());
         return response.body();
     }
 

--- a/src/main/java/uk/gov/legislation/data/virtuoso/VirtuosoConfig.java
+++ b/src/main/java/uk/gov/legislation/data/virtuoso/VirtuosoConfig.java
@@ -1,0 +1,11 @@
+package uk.gov.legislation.data.virtuoso;
+
+import java.util.Objects;
+
+/** Virtuoso connection settings. Plain record — no framework dependency. */
+public record VirtuosoConfig(String host, int port) {
+    public VirtuosoConfig {
+        // Preserves Virtuoso's old fail-fast, framework-agnostic so it also holds outside Spring.
+        Objects.requireNonNull(host, "VIRTUOSO_HOST must not be null");
+    }
+}

--- a/src/main/java/uk/gov/legislation/data/virtuoso/defra/DefraLex.java
+++ b/src/main/java/uk/gov/legislation/data/virtuoso/defra/DefraLex.java
@@ -11,7 +11,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
-import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Repository;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
@@ -26,10 +25,8 @@ public class DefraLex {
 
     static final ObjectMapper mapper = JsonResults.MAPPER;
 
-    public DefraLex(Environment env) {
-        String host = env.getProperty("VIRTUOSO_HOST");
-        String port = env.getProperty("DEFRALEX_PORT");
-        this.endpoint = "http://" + host + ":" + port + "/sparql";
+    public DefraLex(DefraLexConfig config) {
+        this.endpoint = "http://" + config.host() + ":" + config.port() + "/sparql";
     }
 
     private static final String RESULTS_QUERY =

--- a/src/main/java/uk/gov/legislation/data/virtuoso/defra/DefraLexConfig.java
+++ b/src/main/java/uk/gov/legislation/data/virtuoso/defra/DefraLexConfig.java
@@ -1,0 +1,4 @@
+package uk.gov.legislation.data.virtuoso.defra;
+
+/** DefraLex connection settings. Plain record — no framework dependency. */
+public record DefraLexConfig(String host, int port) {}

--- a/src/test/java/uk/gov/legislation/data/marklogic/TestMarkLogic.java
+++ b/src/test/java/uk/gov/legislation/data/marklogic/TestMarkLogic.java
@@ -4,22 +4,16 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.PushbackInputStream;
 import java.nio.charset.StandardCharsets;
-import org.springframework.mock.env.MockEnvironment;
 
 /**
- * Base MarkLogic stub for tests. Supplies the minimal property set the real MarkLogic constructor
- * reads. Subclasses override {@link #get} or {@link #getStream} as needed; both throw by default so
- * tests fail loudly if they hit an unmocked path.
+ * Base MarkLogic stub for tests. Supplies the minimal config the real MarkLogic constructor needs.
+ * Subclasses override {@link #get} or {@link #getStream} as needed; both throw by default so tests
+ * fail loudly if they hit an unmocked path.
  */
 public class TestMarkLogic extends MarkLogic {
 
     public TestMarkLogic() {
-        super(
-                new MockEnvironment()
-                        .withProperty("MARKLOGIC_HOST", "localhost")
-                        .withProperty("MARKLOGIC_PORT", "8080")
-                        .withProperty("MARKLOGIC_USERNAME", "user")
-                        .withProperty("MARKLOGIC_PASSWORD", "password"));
+        super(new MarkLogicConfig("localhost", 8080, "user", "password"));
     }
 
     @Override


### PR DESCRIPTION
Decouples `uk.gov.legislation.data` from Spring's `Environment` so the package is
portable (framework-agnostic apart from `@Component`/`@Repository`).

**What changed**
- `MarkLogic`, `Virtuoso`, `DefraLex` no longer inject `Environment`. Each takes a
  plain config record — `MarkLogicConfig`, `VirtuosoConfig`, `DefraLexConfig`.
- A single `DataConfig` `@Configuration` binds the external properties and constructs
  the records. All Spring config plumbing for data sources now lives in that one file.
- `Virtuoso` reuses one `HttpClient` instead of creating one per request (matching
  `MarkLogic` and `DefraLex`).

**What did NOT change**
- Property keys (`MARKLOGIC_HOST`, `VIRTUOSO_PORT`, `DEFRALEX_PORT`, …) and their
  sources (`application-secrets.properties` / AWS Parameter Store / test props) are
  identical. Values are simply read in `DataConfig` now instead of in three constructors.
- No behavior change beyond ports now being read as typed `int` (fail-fast if missing
  or non-numeric).

**Testing**
- Full unit/integration suite: 696 tests, green.
- Live e2e (dev profile): MarkLogic, Virtuoso, and DefraLex all return live data
  through the new `DataConfig`.

8 files changed (+72 / −40): 4 new (`DataConfig`, `MarkLogicConfig`, `VirtuosoConfig`,
`DefraLexConfig`), 4 modified (`MarkLogic`, `Virtuoso`, `DefraLex`, `TestMarkLogic`).
