### PR TITLE
Remove deprecated fragment/prev/next fields from fragment metadata

### DIFF
--- a/src/main/java/uk/gov/legislation/api/responses/FragmentMetadata.java
+++ b/src/main/java/uk/gov/legislation/api/responses/FragmentMetadata.java
@@ -12,15 +12,6 @@ import java.util.List;
  */
 public class FragmentMetadata extends CommonMetadata {
 
-    @Schema(example = "section/2", deprecated = true, description = "use fragmentInfo")
-    public String fragment;
-
-    @Schema(example = "section/1", deprecated = true, description = "use prevInfo")
-    public String prev;
-
-    @Schema(example = "section/3", deprecated = true, description = "use nextInfo")
-    public String next;
-
     @Schema public Level fragmentInfo;
 
     @Schema(description = "Previous fragment with display label (see LabelledLink).")

--- a/src/main/java/uk/gov/legislation/converters/FragmentMetadataConverter.java
+++ b/src/main/java/uk/gov/legislation/converters/FragmentMetadataConverter.java
@@ -27,9 +27,6 @@ public class FragmentMetadataConverter {
     public static FragmentMetadata convert(Metadata simple) {
         FragmentMetadata converted = new FragmentMetadata();
         DocumentMetadataConverter.convertCommon(simple, converted);
-        converted.fragment = simple.fragment();
-        converted.prev = simple.prev();
-        converted.next = simple.next();
         if (simple.prevUri != null) {
             converted.prevInfo = new LabelledLink();
             converted.prevInfo.href = Links.extractFragmentIdentifierFromLink(simple.prevUri);

--- a/src/main/java/uk/gov/legislation/transform/simple/Metadata.java
+++ b/src/main/java/uk/gov/legislation/transform/simple/Metadata.java
@@ -290,11 +290,11 @@ public class Metadata {
     /**
      * True when the payload is a whole-document response rather than a fragment response. {@code
      * simplify/metadata.xsl} only emits the {@code <fragment>} element (from which {@link
-     * #fragment} is populated) when the {@code is-fragment} parameter is true, so a null {@code
-     * fragment} uniquely indicates a whole-document request.
+     * #fragmentUri} is populated) when the {@code is-fragment} parameter is true, so a null {@code
+     * fragmentUri} uniquely indicates a whole-document request.
      */
     private boolean isWholeDocument() {
-        return fragment == null;
+        return fragmentUri == null;
     }
 
     private boolean matchesResponseLanguage(String hreflang) {
@@ -360,33 +360,19 @@ public class Metadata {
     /* fragment info */
 
     public URI fragmentUri;
-    private String fragment;
-
-    @Deprecated(forRemoval = true)
-    public String fragment() {
-        return fragment;
-    }
 
     @JsonSetter("fragment")
     public void setFragment(String value) {
         fragmentUri = URI.create(value);
-        fragment = Links.extractFragmentIdentifierFromLink(value);
     }
 
     /* info for prev and next links */
 
     public URI prevUri;
-    private String prev;
-
-    @Deprecated(forRemoval = true) // use prevUri
-    public String prev() {
-        return prev;
-    }
 
     @JsonSetter("prev")
     public void setPrev(String value) {
         prevUri = URI.create(value);
-        prev = Links.extractFragmentIdentifierFromLink(value);
     }
 
     /**
@@ -397,17 +383,10 @@ public class Metadata {
     @JacksonXmlProperty public String prevTitle;
 
     public URI nextUri;
-    private String next; // to remove
-
-    @Deprecated(forRemoval = true) // use nextUri
-    public String next() {
-        return next;
-    }
 
     @JsonSetter("next")
     public void setNext(String value) {
         nextUri = URI.create(value);
-        next = Links.extractFragmentIdentifierFromLink(value);
     }
 
     /**

--- a/src/test/java/uk/gov/legislation/response/ExpectedWelshResponseDataCy.java
+++ b/src/test/java/uk/gov/legislation/response/ExpectedWelshResponseDataCy.java
@@ -117,9 +117,6 @@ public class ExpectedWelshResponseDataCy {
                               "xml",
                               "pdf"
                           ],
-                          "fragment": "regulation/2",
-                          "prev": "regulation/1",
-                          "next": "regulation/3",
                           "fragmentInfo": {
                               "element": "P1",
                               "id": "regulation-2",

--- a/src/test/resources/aep_Ann_6_11/aep-Ann-6-11-part-1-1991-02-01.json
+++ b/src/test/resources/aep_Ann_6_11/aep-Ann-6-11-part-1-1991-02-01.json
@@ -28,9 +28,6 @@
     "pointInTime" : "1991-02-01",
     "alternatives" : [ ],
     "associated" : [ ],
-    "fragment" : "part/1",
-    "prev" : "introduction",
-    "next" : "part/2",
     "fragmentInfo" : {
       "element" : "Part",
       "id" : "part-1",

--- a/src/test/resources/aip_Geo3_40_38/aip-Geo3-40-38-part-1-1991-02-01.json
+++ b/src/test/resources/aip_Geo3_40_38/aip-Geo3-40-38-part-1-1991-02-01.json
@@ -28,9 +28,6 @@
     "pointInTime" : null,
     "alternatives" : [ ],
     "associated" : [ ],
-    "fragment" : "part/1",
-    "prev" : "section/I.",
-    "next" : "part/2",
     "fragmentInfo" : {
       "element" : "Part",
       "id" : "part-1",

--- a/src/test/resources/anaw_2020_3/anaw-2020-3-section-2-welsh.json
+++ b/src/test/resources/anaw_2020_3/anaw-2020-3-section-2-welsh.json
@@ -60,9 +60,6 @@
       "date" : "2020-03-26",
       "size" : 2499242
     } ],
-    "fragment" : "section/2",
-    "prev" : "section/1",
-    "next" : "section/3",
     "fragmentInfo" : {
       "element" : "P1",
       "id" : "section-2",

--- a/src/test/resources/aosp_1707_8/aosp-1707-8-paragraph-p3-2007-01-01.json
+++ b/src/test/resources/aosp_1707_8/aosp-1707-8-paragraph-p3-2007-01-01.json
@@ -23,9 +23,6 @@
     "pointInTime" : "2007-01-01",
     "alternatives" : [ ],
     "associated" : [ ],
-    "fragment" : "paragraph/p3",
-    "prev" : "introduction",
-    "next" : null,
     "fragmentInfo" : {
       "element" : "P",
       "id" : "paragraph-p3",

--- a/src/test/resources/apgb_Geo3_39-40_14/apgb-Geo3-39-40-14-section-2.json
+++ b/src/test/resources/apgb_Geo3_39-40_14/apgb-Geo3-39-40-14-section-2.json
@@ -28,9 +28,6 @@
     "pointInTime" : null,
     "alternatives" : [ ],
     "associated" : [ ],
-    "fragment" : "section/2",
-    "prev" : "section/1.",
-    "next" : null,
     "fragmentInfo" : {
       "element" : "P1",
       "id" : "section-2",

--- a/src/test/resources/asc_2025_1/asc-2025-1-part-1-chapter-2-2025-03-25.json
+++ b/src/test/resources/asc_2025_1/asc-2025-1-part-1-chapter-2-2025-03-25.json
@@ -61,9 +61,6 @@
       "date" : "2025-04-09",
       "size" : 555756
     } ],
-    "fragment" : "part/1/chapter/2",
-    "prev" : "part/1/chapter/1",
-    "next" : "part/2",
     "fragmentInfo" : {
       "element" : "Chapter",
       "id" : "part-1-chapter-2",

--- a/src/test/resources/asp_2025_11/asp-2025-11-part-1-crossheading-reviews-2025-08-07.json
+++ b/src/test/resources/asp_2025_11/asp-2025-11-part-1-crossheading-reviews-2025-08-07.json
@@ -31,9 +31,6 @@
       "size" : 1631326
     } ],
     "associated" : [ ],
-    "fragment" : "part/1/crossheading/reviews",
-    "prev" : "part/1/crossheading/supporting-provisions",
-    "next" : "part/2/crossheading/establishment",
     "fragmentInfo" : {
       "element" : "Pblock",
       "id" : "part-1-crossheading-reviews",

--- a/src/test/resources/eudr_2020_2089/eudr-2020-2089-article-1-2020-12-11.json
+++ b/src/test/resources/eudr_2020_2089/eudr-2020-2089-article-1-2020-12-11.json
@@ -30,9 +30,6 @@
       "size" : 532550
     } ],
     "associated" : [ ],
-    "fragment" : "article/1",
-    "prev" : "introduction",
-    "next" : "article/2",
     "fragmentInfo" : {
       "element" : "P1",
       "id" : "article-1",

--- a/src/test/resources/mnia_1974_4/mnia-1974-4-section-5-2006-01-01.json
+++ b/src/test/resources/mnia_1974_4/mnia-1974-4-section-5-2006-01-01.json
@@ -24,9 +24,6 @@
     "pointInTime" : "2006-01-01",
     "alternatives" : [ ],
     "associated" : [ ],
-    "fragment" : "section/5",
-    "prev" : "paragraph/p1",
-    "next" : "section/6",
     "fragmentInfo" : {
       "element" : "P1",
       "id" : "section-5",

--- a/src/test/resources/mwa_2011_7/mwa-2011-7-section-1-2012-11-16.json
+++ b/src/test/resources/mwa_2011_7/mwa-2011-7-section-1-2012-11-16.json
@@ -66,9 +66,6 @@
       "date" : "2011-05-12",
       "size" : 63843
     } ],
-    "fragment" : "section/1",
-    "prev" : "introduction",
-    "next" : "section/2",
     "fragmentInfo" : {
       "element" : "P1",
       "id" : "section-1",

--- a/src/test/resources/mwa_2011_7/mwa-2011-7-section-1.json
+++ b/src/test/resources/mwa_2011_7/mwa-2011-7-section-1.json
@@ -66,9 +66,6 @@
       "date" : "2011-05-12",
       "size" : 63843
     } ],
-    "fragment" : "section/1",
-    "prev" : "introduction",
-    "next" : "section/2",
     "fragmentInfo" : {
       "element" : "P1",
       "id" : "section-1",

--- a/src/test/resources/nia_2022_21/nia-2022-21-introduction-enacted.json
+++ b/src/test/resources/nia_2022_21/nia-2022-21-introduction-enacted.json
@@ -30,9 +30,6 @@
       "size" : 352718
     } ],
     "associated" : [ ],
-    "fragment" : "introduction",
-    "prev" : null,
-    "next" : "section/1",
     "fragmentInfo" : {
       "element" : "PrimaryPrelims",
       "id" : "introduction",

--- a/src/test/resources/ssi_2025_281/ssi-2025-281-regulation-1-made.json
+++ b/src/test/resources/ssi_2025_281/ssi-2025-281-regulation-1-made.json
@@ -53,9 +53,6 @@
       "date" : "2025-10-09",
       "size" : 37669
     } ],
-    "fragment" : "regulation/1",
-    "prev" : "introduction",
-    "next" : "regulation/2",
     "fragmentInfo" : {
       "element" : "P1",
       "id" : "regulation-1",

--- a/src/test/resources/ukcm_2025_2/ukcm-2025-2-section-1.json
+++ b/src/test/resources/ukcm_2025_2/ukcm-2025-2-section-1.json
@@ -30,9 +30,6 @@
       "size" : 320616
     } ],
     "associated" : [ ],
-    "fragment" : "section/1",
-    "prev" : "introduction",
-    "next" : "section/2",
     "fragmentInfo" : {
       "element" : "P1",
       "id" : "section-1",

--- a/src/test/resources/ukla_2017_1/ukla-2017-1-part-3-enacted.json
+++ b/src/test/resources/ukla_2017_1/ukla-2017-1-part-3-enacted.json
@@ -31,9 +31,6 @@
       "size" : 440723
     } ],
     "associated" : [ ],
-    "fragment" : "part/3",
-    "prev" : "part/2",
-    "next" : "part/4",
     "fragmentInfo" : {
       "element" : "Part",
       "id" : "part-3",

--- a/src/test/resources/ukpga_2000_8/ukpga-2000-8-section-91.json
+++ b/src/test/resources/ukpga_2000_8/ukpga-2000-8-section-91.json
@@ -31,9 +31,6 @@
       "size" : null
     } ],
     "associated" : [ ],
-    "fragment" : "section/91",
-    "prev" : "section/90B",
-    "next" : "section/92",
     "fragmentInfo" : {
       "element" : "P1",
       "id" : "section-91",

--- a/src/test/resources/ukpga_2000_8_schedule_6_paragraph_4A/meta.json
+++ b/src/test/resources/ukpga_2000_8_schedule_6_paragraph_4A/meta.json
@@ -30,9 +30,6 @@
     "size" : null
   } ],
   "associated" : [ ],
-  "fragment" : "schedule/6/paragraph/4A",
-  "prev" : "schedule/6/paragraph/3E",
-  "next" : "schedule/6/paragraph/4B",
   "fragmentInfo" : {
     "element" : "P1",
     "id" : "schedule-6-paragraph-4A",

--- a/src/test/resources/ukpga_2026_2/ukpga-2026-2-section-22.json
+++ b/src/test/resources/ukpga_2026_2/ukpga-2026-2-section-22.json
@@ -31,9 +31,6 @@
       "size" : 1470529
     } ],
     "associated" : [ ],
-    "fragment" : "section/22",
-    "prev" : "section/21",
-    "next" : "section/23",
     "fragmentInfo" : {
       "element" : "P1",
       "id" : "section-22",

--- a/src/test/resources/ukpga_Geo6_6-7_48/ukpga-Geo6-6-7-48-part-1-1991-02-01.json
+++ b/src/test/resources/ukpga_Geo6_6-7_48/ukpga-Geo6-6-7-48-part-1-1991-02-01.json
@@ -35,9 +35,6 @@
       "size" : 3178982
     } ],
     "associated" : [ ],
-    "fragment" : "part/1",
-    "prev" : "introduction",
-    "next" : "part/III",
     "fragmentInfo" : {
       "element" : "Part",
       "id" : "part-1",

--- a/src/test/resources/uksi_2025_3/uksi-2025-3-regulation-2-made.json
+++ b/src/test/resources/uksi_2025_3/uksi-2025-3-regulation-2-made.json
@@ -39,9 +39,6 @@
       "date" : "2025-01-06",
       "size" : 76463
     } ],
-    "fragment" : "regulation/2",
-    "prev" : "regulation/1",
-    "next" : "regulation/3",
     "fragmentInfo" : {
       "element" : "P1",
       "id" : "regulation-2",


### PR DESCRIPTION
## What

Removes the three deprecated string fields — `fragment`, `prev`, `next` — from the fragment-metadata response (`FragmentMetadata`). They were superseded by the richer `fragmentInfo` / `prevInfo` / `nextInfo`.

**This is a public API contract change.** The Django front end has been investigated and confirmed to no longer read any of the three fields, so removing them is safe for the only known consumer.

## Changes

- `FragmentMetadata`: drop the `fragment` / `prev` / `next` fields.
- `FragmentMetadataConverter`: stop populating them.
- `Metadata` (simple transform): remove the deprecated `fragment()` / `prev()` / `next()` getters and the now-unused `prev` / `next` backing fields; simplify `setPrev` / `setNext` to set only `prevUri` / `nextUri`.
- `isWholeDocument()`: key off `fragmentUri == null` instead of the removed `fragment` field — equivalent for all real inputs, and a more direct test of `<fragment>`-element presence. This also gives the previously write-only `fragmentUri` a real reader.

## Tests

- Updated 20 fragment JSON golden files and the Welsh expected-response constant to match the new output (only the three top-level deprecated keys removed; `unappliedEffects.fragment` effects arrays left intact).
- Full suite green: **696 tests, 0 failures**.

## Sequencing

Sits on top of #185 (already merged); no file overlap with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)